### PR TITLE
feat: redesign Help tab as evidence-based 4-stage urge response (#34)

### DIFF
--- a/.claude/plans/issue-34-help-tab-redesign.md
+++ b/.claude/plans/issue-34-help-tab-redesign.md
@@ -1,0 +1,113 @@
+# Help Tab Redesign — Implementation Plan
+
+**Issue:** [#34](https://github.com/johnbukhin/ai-dopamine-cursor/issues/34)
+**Overall Progress:** `100%` (9/9 steps) · TypeScript clean · `vite build` passes
+
+## TLDR
+
+Rebuild [webapp/components/UrgeHelp.tsx](../../webapp/components/UrgeHelp.tsx) as a 4-stage evidence-based urge-response journey (Pause → Locate → Act → Reflect). Replace the 60s timer with a 3-min one, expand to 10 actions each with its own interactive mini-screen, add an always-accessible AI Coach modal, log every completed urge to `localStorage`, and surface an "Urges Surfed" tile on the Dashboard. Visual language harmonizes with Plan tab.
+
+## Critical Decisions
+
+- **Future-Self Letter** = action contains its own editor (first-time guided write, then read; editable from Settings). No onboarding to read from.
+- **Persistence** = `localStorage` only (key `mc.urge_log.v1`). Supabase deferred to a follow-up issue.
+- **AI Coach mid-flow** = slide-up modal *over* Help (not nav). Receives `currentUrgeContext` props. UrgeHelp state stays local.
+- **Phone Away** = soft timer + back button (browser cannot enforce hard lock).
+- **All 10 actions** get full mini-screens — no static cards.
+- **Intensity slider** = visible in Stage 2, skippable.
+- **Auto-log** triggers only on Reflect-stage feedback click.
+- **Urges Surfed tile** ships in this issue (3rd Dashboard tile).
+- **Visual style** = rose palette retained for emergency context, but spacing/radii/typography aligned with Plan (`rounded-2xl`, soft shadow, stagger-fade entrance).
+
+## Tasks
+
+- [x] 🟩 **Step 1: Types & data foundation**
+  - [x] 🟩 Add `Feeling`, `UrgeAction`, `UrgeActionId`, `UrgeLogEntry`, `UrgeContextSeed` to [webapp/types.ts](../../webapp/types.ts)
+  - [x] 🟩 Define feeling list (7 entries) with `{ id, label, context }`
+  - [x] 🟩 Define action registry (10 entries) in [webapp/data/urgeData.ts](../../webapp/data/urgeData.ts) with `{ id, title, category, whyItWorks, recommendedFor: feelingId[] }` + category meta
+  - [x] 🟩 Add localStorage helpers in [webapp/src/lib/urgeLog.ts](../../webapp/src/lib/urgeLog.ts) (`readLog`, `appendEntry`, `count`)
+  - [x] 🟩 Add localStorage helper for Future-Self Letter in same file (`readLetter`, `writeLetter`)
+
+- [x] 🟩 **Step 2: Stage shell & Pause (3-min timer)**
+  - [x] 🟩 Refactor [UrgeHelp.tsx](../../webapp/components/UrgeHelp.tsx) into stage orchestrator (state machine + stub stages for incremental fill-in)
+  - [x] 🟩 Build [PauseStage.tsx](../../webapp/components/urgeHelp/PauseStage.tsx): 3-min countdown, animated ring, reframe copy, Skip button
+  - [x] 🟩 Build [StageProgress.tsx](../../webapp/components/urgeHelp/StageProgress.tsx) wizard indicator (4 dots) pinned to top of every stage
+  - [x] 🟩 [CoachPill.tsx](../../webapp/components/urgeHelp/CoachPill.tsx) floating bottom-right with mobile offset `bottom-[5.5rem]`, desktop `bottom-6`
+
+- [ ] 🟥 **Step 3: Locate stage (feelings + intensity)**
+  - [ ] 🟥 Render feelings as 2-col tiles with one-line context per feeling (mobile-first)
+  - [ ] 🟥 After feeling selection, slide-in optional intensity slider (1–10) with skippable Continue CTA
+  - [ ] 🟥 Persist selection in component state for downstream stages + Coach context
+
+- [x] 🟩 **Step 4: Act stage (10 action grid)**
+  - [x] 🟩 Category-grouped sections (Reset / Ground / Protect / Reframe), 2 cards/row, subtle category tints via `URGE_CATEGORY_META`
+  - [x] 🟩 Stagger-fade entrance (50ms apart, capped at 400ms total)
+  - [x] 🟩 Recommended-for-feeling "Best fit" badge on top 2 matches via `recommendedFor`
+  - [x] 🟩 Card layout: icon-first, title, why-it-works always visible (small text); "tried" dot on prior actions
+
+- [x] 🟩 **Step 5: 10 mini-screen components**
+  - [x] 🟩 [urgeActions/](../../webapp/components/urgeActions/) directory + [index.ts](../../webapp/components/urgeActions/index.ts) registry barrel
+  - [x] 🟩 [ActionScreenShell](../../webapp/components/urgeActions/ActionScreenShell.tsx) — shared wrapper with header (title + why) + content slot + Done/Back CTAs
+  - [x] 🟩 [BoxBreathingScreen](../../webapp/components/urgeActions/BoxBreathingScreen.tsx) — animated breathing circle, 4-4-4-4 × 5 cycles
+  - [x] 🟩 [ColdWaterScreen](../../webapp/components/urgeActions/ColdWaterScreen.tsx) — 3-step instructional checklist
+  - [x] 🟩 [PhysicalBurstScreen](../../webapp/components/urgeActions/PhysicalBurstScreen.tsx) — tap-counter to 20 with milestone copy
+  - [x] 🟩 [Grounding54321Screen](../../webapp/components/urgeActions/Grounding54321Screen.tsx) — interactive sensory checkboxes, auto-advance per sense
+  - [x] 🟩 [HALTCheckScreen](../../webapp/components/urgeActions/HALTCheckScreen.tsx) — 4 toggles → 1 merged recommendation (priority Hungry > Tired > Angry > Lonely)
+  - [x] 🟩 [LeaveRoomScreen](../../webapp/components/urgeActions/LeaveRoomScreen.tsx) — 60s reorient with pulsing dot + breath prompt
+  - [x] 🟩 [PhoneAwayScreen](../../webapp/components/urgeActions/PhoneAwayScreen.tsx) — soft 15-min countdown, back always available
+  - [x] 🟩 [UrgeJournalScreen](../../webapp/components/urgeActions/UrgeJournalScreen.tsx) — Trigger chips + intensity slider + note
+  - [x] 🟩 [FutureSelfLetterScreen](../../webapp/components/urgeActions/FutureSelfLetterScreen.tsx) — guided write OR display saved letter; uses shared [LetterEditor](../../webapp/components/urgeActions/LetterEditor.tsx)
+  - [x] 🟩 [PlayTheTapeScreen](../../webapp/components/urgeActions/PlayTheTapeScreen.tsx) — 30s auto-advancing 5-scene visualization
+
+- [x] 🟩 **Step 6: Reflect stage + Urge Log**
+  - [x] 🟩 [ReflectStage.tsx](../../webapp/components/urgeHelp/ReflectStage.tsx) — three feedback options with descriptive subtitles
+  - [x] 🟩 On click, orchestrator writes `UrgeLogEntry` via `urgeLog.appendEntry` (timestamp, feeling, intensity, actionsTried[], outcome)
+  - [x] 🟩 "Yes, it passed" → [SurfCelebration.tsx](../../webapp/components/urgeHelp/SurfCelebration.tsx) sparkle overlay → reset to Pause
+  - [x] 🟩 "Still here" → return to Act stage with prior actions still marked
+  - [x] 🟩 "I want to talk it through" → opens Coach modal pre-seeded
+
+- [x] 🟩 **Step 7: AI Coach modal integration**
+  - [x] 🟩 Extended `AICoachProps` with `currentUrgeContext?: UrgeContextSeed | null` and `compact?: boolean`
+  - [x] 🟩 `formatUrgeContext()` in AICoach prepends an "ACTIVE URGE SESSION" block to the existing context string when seed present (no system-prompt rewrite needed)
+  - [x] 🟩 [CoachModal.tsx](../../webapp/components/urgeHelp/CoachModal.tsx) — slide-up sheet on mobile, centered on desktop, dismissible, renders AICoach in compact mode
+  - [x] 🟩 Wired from CoachPill: `useMemo` snapshots seed at modal-open time so context doesn't drift while modal is open
+  - [x] 🟩 App.tsx now passes `chatHistory` + `setChatHistory` + `checkIns` into UrgeHelp; Coach view continues to mount full-page version unchanged
+
+- [x] 🟩 **Step 8: Future-Self Letter editor — Help tab only** _(Settings entry removed per user feedback)_
+  - [x] 🟩 Editor lives inside the [FutureSelfLetterScreen](../../webapp/components/urgeActions/FutureSelfLetterScreen.tsx) action mini-screen only — no Settings tab
+  - [x] 🟩 First-time users land in guided write flow (auto-detected via `readLetter() === null`)
+  - [x] 🟩 Subsequent visits show formatted letter with Edit button
+  - [x] 🟩 Reads/writes through `urgeLog.readLetter` / `writeLetter` — single source of truth
+  - [x] 🟩 [LetterEditor](../../webapp/components/urgeActions/LetterEditor.tsx) extracted as reusable component (kept for potential future re-introduction)
+
+- [x] 🟩 **Step 9: Dashboard — Urges Surfed tile**
+  - [x] 🟩 3rd tile added matching Streak structure (rose-100 bg, decorative wave SVG, min-h, rounded-2xl)
+  - [x] 🟩 Grid reflowed to `grid-cols-2 md:grid-cols-3`; tile spans `col-span-2 md:col-span-1` so mobile stays clean (Streak + Check-in row + Urges Surfed full-width row)
+  - [x] 🟩 Data: `urgeLog.count()` read once via `useMemo` on mount
+  - [x] 🟩 Rose-100/rose-700 accents — kindred to Help context, doesn't overpower purple-dominant Dashboard
+
+## Out of scope (explicit)
+
+- Supabase persistence for urge log (separate follow-up)
+- Audio/voice meditation guidance
+- Push notifications
+- Social/accountability contact integration
+- Onboarding to capture future-self letter pre-emptively
+- Any change to Sidebar labels or icons
+- Routing/URL changes
+
+## Post-build adjustments (per user feedback after initial /execute)
+
+These deviated from the original plan based on real UX testing of the built feature:
+
+- **CoachPill removed entirely.** Originally a persistent floating pill on every stage. User found it visually distracting and overlapping the action footer. Coach is now only accessible from the Reflect-stage "I want to talk it through" option.
+- **Settings "Letter" tab removed.** Originally a parallel surface in Settings for editing the Future-Self Letter. User decided the in-Help editor (which already auto-opens for first-time users and has an Edit button afterward) is sufficient.
+- **LocateStage redesigned as a bottom sheet.** Originally inline intensity-slider + Continue. Reworked to slide up as a sheet (matching LessonBottomSheet pattern) — pulls the eye to the next decision without crowding the grid.
+- **Dashboard "Urges Surfed" tile compressed to a single horizontal row** with full purple styling (matches Streak structure exactly). Originally a vertical tile mirroring Streak/Check-in dimensions.
+- **Grounding 5-4-3-2-1**: tap-anywhere-on-card pattern, completion banner with auto-advance, scrollIntoView. Originally just the dot checkboxes.
+- **PlayTheTape**: per-scene durations (8/8/7/9/6 instead of uniform 6s) plus tap-to-skip with discoverability hint. Originally fixed auto-advance only.
+- **Urge log policy**: only `passed` and `escalated` outcomes are logged. `still_here` is now treated as mid-session feedback (no log entry) so the Dashboard counter reflects resolved urge sessions, not attempt counts.
+
+## Acceptance criteria mirror
+
+Maps to Acceptance Criteria from issue #34 exploration comment — all 10 items must be true before review.

--- a/webapp/App.tsx
+++ b/webapp/App.tsx
@@ -321,7 +321,11 @@ export default function App() {
         )}
 
         {currentView === View.URGE_HELP && (
-          <UrgeHelp onChangeView={setCurrentView} />
+          <UrgeHelp
+            checkInHistory={checkIns}
+            chatHistory={chatHistory}
+            setChatHistory={setChatHistory}
+          />
         )}
 
         {currentView === View.PLAN_21 && (

--- a/webapp/components/AICoach.tsx
+++ b/webapp/components/AICoach.tsx
@@ -1,16 +1,42 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Brain, Send, User as UserIcon, Loader2 } from 'lucide-react';
 import { getCoachResponse } from '../services/claudeService';
-import { CheckIn, ChatMessage } from '../types';
+import { CheckIn, ChatMessage, UrgeContextSeed } from '../types';
+import { URGE_ACTION_BY_ID } from '../data/urgeData';
 import { supabase } from '../src/lib/supabase';
 
 interface AICoachProps {
     checkInHistory: CheckIn[];
     messages: ChatMessage[];
     setMessages: React.Dispatch<React.SetStateAction<ChatMessage[]>>;
+    /** When present, the Coach is being invoked from inside the Help flow.
+     *  We augment the system context with the live urge state so Claude's
+     *  first response is targeted instead of generic. */
+    currentUrgeContext?: UrgeContextSeed | null;
+    /** When true, render in compact "embedded" mode (no edge-to-edge header
+     *  image, less vertical chrome). Used by the Help-tab CoachModal. */
+    compact?: boolean;
 }
 
-export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setMessages }) => {
+/** Format the urge context seed into a compact block the Claude system
+ *  prompt can read. Returns an empty string when there's nothing to add,
+ *  so the existing recentHistory flow is unaffected for non-urge sessions. */
+function formatUrgeContext(seed: UrgeContextSeed | null | undefined): string {
+    if (!seed) return '';
+    const action = seed.actionAttempted ? URGE_ACTION_BY_ID[seed.actionAttempted]?.title : null;
+    const lines = [
+        'ACTIVE URGE SESSION (user opened the Help tab and is currently mid-flow):',
+        `- Stage: ${seed.stage}`,
+        seed.feeling ? `- Named feeling: ${seed.feeling}` : '- Named feeling: (none yet)',
+        seed.intensity != null ? `- Self-reported intensity: ${seed.intensity}/10` : null,
+        action ? `- Most recent action they tried: ${action}` : null,
+        `- Time on Help tab so far: ${seed.elapsedSec}s`,
+        'Respond using the Urge structure from the system prompt. Reference what they\'ve already done — do not suggest the same action again.',
+    ].filter(Boolean);
+    return lines.join('\n');
+}
+
+export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setMessages, currentUrgeContext, compact = false }) => {
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -32,10 +58,16 @@ export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setM
     setIsLoading(true);
 
     // Build context summary from check-in history (last 5 entries) — passed as
-    // system-prompt context, separate from chat history.
-    const recentHistory = checkInHistory.slice(-5).map(c =>
+    // system-prompt context, separate from chat history. When the Coach is
+    // invoked from a live urge session, prepend the urge seed so Claude's
+    // first reply is grounded in the actual moment.
+    const checkInBlock = checkInHistory.slice(-5).map(c =>
         `Date: ${c.date.toDateString()}, Status: ${c.status}, Emotions: ${c.emotions.join(',')}`
     ).join('; ');
+    const urgeBlock = formatUrgeContext(currentUrgeContext);
+    const recentHistory = urgeBlock
+        ? `${urgeBlock}\n\nRECENT CHECK-INS:\n${checkInBlock}`
+        : checkInBlock;
 
     // Pass the last 10 chat messages so Claude has multi-turn memory.
     // Drop index 0 (hardcoded welcome message — never sent to the model).
@@ -86,17 +118,20 @@ export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setM
 
   return (
     <div className="flex flex-col h-full bg-purple-50">
-      <div className="flex-1 overflow-y-auto pb-28 md:pb-4" ref={scrollRef}>
-        {/* Edge-to-Edge Header Image */}
-        <div className="w-full h-48 md:h-56 relative mb-6 overflow-hidden">
-          <img src="/illustrations/coach.png" alt="AI Coach" className="w-full h-full object-cover scale-[1.4] origin-center" />
-          <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-purple-50" />
-          <div className="absolute bottom-10 md:bottom-12 left-4 md:left-8 right-4 md:right-8">
-            <h2 className="text-2xl md:text-3xl font-extrabold text-purple-900 mt-1">Your AI Coach</h2>
+      <div className={`flex-1 overflow-y-auto ${compact ? 'pb-4' : 'pb-28 md:pb-4'}`} ref={scrollRef}>
+        {/* Edge-to-Edge Header Image — hidden in compact (modal) mode where
+            the host already provides its own chrome. */}
+        {!compact && (
+          <div className="w-full h-48 md:h-56 relative mb-6 overflow-hidden">
+            <img src="/illustrations/coach.png" alt="AI Coach" className="w-full h-full object-cover scale-[1.4] origin-center" />
+            <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-purple-50" />
+            <div className="absolute bottom-10 md:bottom-12 left-4 md:left-8 right-4 md:right-8">
+              <h2 className="text-2xl md:text-3xl font-extrabold text-purple-900 mt-1">Your AI Coach</h2>
+            </div>
           </div>
-        </div>
-        
-        <div className="px-4 space-y-4 max-w-4xl mx-auto">
+        )}
+
+        <div className={`px-4 space-y-4 max-w-4xl mx-auto ${compact ? 'pt-2' : ''}`}>
           {messages.map((m, i) => (
           <div key={i} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
             <div className={`flex gap-3 max-w-[85%] md:max-w-[75%] ${m.role === 'user' ? 'flex-row-reverse' : 'flex-row'}`}>

--- a/webapp/components/Dashboard.tsx
+++ b/webapp/components/Dashboard.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useMemo, useEffect, useRef } from 'react';
 import { CheckIn, CheckInStatus, View } from '../types';
-import { ChevronLeft, ChevronRight, X, Trophy, CircleCheck, Anchor, CalendarDays } from 'lucide-react';
+import { ChevronLeft, ChevronRight, X, Trophy, CircleCheck, Anchor, CalendarDays, Waves } from 'lucide-react';
 import { format, isSameDay, startOfMonth, endOfMonth, eachDayOfInterval, getDay, addMonths, subMonths, isFuture } from 'date-fns';
+import { count as readUrgeCount } from '../src/lib/urgeLog';
 
 interface DashboardProps {
   checkIns: CheckIn[];
@@ -115,6 +116,12 @@ export const Dashboard: React.FC<DashboardProps> = ({ checkIns, streak, hasCheck
   // from firing twice (e.g. if Dashboard rerenders while signal is still set).
   const lastSignalTsRef = useRef(0);
 
+  // Urges Surfed tile data (Issue #34). Read once on mount — the urge log is
+  // local-only for v1 and only changes inside the Help tab, so by the time
+  // the user is back on the Dashboard the latest count is what we want to
+  // show. No live subscription needed.
+  const urgesSurfed = useMemo(() => readUrgeCount(), []);
+
   useEffect(() => {
     if (hasCheckedInToday) return;
 
@@ -209,7 +216,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ checkIns, streak, hasCheck
       
       {/* Top Section: Streak + Check-in (top row), Urge Help (utility row below) */}
       <div className="max-w-4xl mx-auto w-full px-4 md:px-8 relative z-10 -mt-8 mb-8 flex flex-col gap-3 md:gap-4">
-         <div className="grid grid-cols-2 gap-3 md:gap-4">
+         <div className="grid grid-cols-2 md:grid-cols-3 gap-3 md:gap-4">
             {/* Streak — light purple sibling of Check-in; same internal structure */}
             <div className="relative overflow-hidden bg-purple-100 p-5 md:p-6 rounded-2xl border border-purple-200 flex flex-col justify-between min-h-[126px] md:min-h-[144px]">
                 {/* Decorative upward line-chart silhouette (📈), bottom-right, low contrast */}
@@ -277,15 +284,50 @@ export const Dashboard: React.FC<DashboardProps> = ({ checkIns, streak, hasCheck
                    <span className="text-sm">Read Only Mode</span>
                </div>
             )}
+
+            {/* Urges Surfed (Issue #34). Single-row compact layout: icon +
+                label on the left, count + unit on the right. Visually
+                styled as a sibling of the Streak tile (purple palette,
+                same icon-badge tint, same stroke weight) so the row reads
+                as one cohesive trio. */}
+            <div className="col-span-2 md:col-span-1 md:self-center relative overflow-hidden bg-purple-100 px-4 py-3 md:py-4 rounded-2xl border border-purple-200 flex items-center justify-between gap-3">
+                {/* Decorative wave silhouette — "urges rise and fall like
+                    waves" reframe. Stroke weight matches the Streak chart
+                    and Check-in plus for visual consistency across the row. */}
+                <svg
+                   aria-hidden="true"
+                   viewBox="0 0 60 60"
+                   fill="none"
+                   stroke="currentColor"
+                   strokeWidth="6"
+                   strokeLinecap="round"
+                   strokeLinejoin="round"
+                   className="absolute -bottom-2 -right-3 w-16 h-16 text-purple-600/20 pointer-events-none"
+                >
+                   <path d="M2 36 Q12 22 22 36 T42 36 T62 36" />
+                   <path d="M2 46 Q12 32 22 46 T42 46 T62 46" />
+                </svg>
+                <div className="flex items-center gap-2 relative">
+                   <div className="bg-purple-300/60 p-1.5 rounded-lg">
+                      <Waves size={16} className="text-purple-700" />
+                   </div>
+                   <span className="text-[10px] font-semibold uppercase tracking-wider text-purple-700">Urges Surfed</span>
+                </div>
+                <div className="flex items-baseline gap-1.5 relative">
+                   <span className="text-[23px] md:text-[27px] font-semibold text-purple-900 leading-tight">{urgesSurfed}</span>
+                   <span className="text-xl md:text-2xl font-semibold text-purple-700 leading-tight">{urgesSurfed === 1 ? 'surf' : 'surfs'}</span>
+                </div>
+            </div>
          </div>
 
-         {/* Urge Help — utility row; icon framed to match the cards above */}
+         {/* Urge Help — utility row; rose accent to telegraph "this is the
+             panic button" without drowning the dashboard's purple palette. */}
          <button
             onClick={() => onChangeView(View.URGE_HELP)}
-            className="bg-purple-50 hover:bg-purple-100 border border-purple-200 rounded-xl px-4 py-2.5 flex items-center justify-center gap-2 text-purple-800 text-sm font-medium transition-colors"
+            className="bg-rose-50 hover:bg-rose-100 border border-rose-200 rounded-xl px-4 py-2.5 flex items-center justify-center gap-2 text-rose-800 text-sm font-medium transition-colors"
          >
-             <div className="bg-purple-200/70 p-1 rounded-md">
-                <Anchor size={14} className="text-purple-700" />
+             <div className="bg-rose-200/70 p-1 rounded-md">
+                <Anchor size={14} className="text-rose-700" />
              </div>
              <span>I'm having an urge — help me</span>
          </button>

--- a/webapp/components/UrgeHelp.tsx
+++ b/webapp/components/UrgeHelp.tsx
@@ -1,280 +1,249 @@
-import React, { useState, useEffect } from 'react';
-import { View } from '../types';
-import { Wind, Footprints, PenTool, PhoneOff, ArrowRight } from 'lucide-react';
-import { Button } from './Button';
+import React, { useCallback, useRef, useState } from 'react';
+import { FeelingId, UrgeActionId, UrgeContextSeed, UrgeOutcome, CheckIn, ChatMessage } from '../types';
+import { StageProgress, type Stage } from './urgeHelp/StageProgress';
+import { PauseStage } from './urgeHelp/PauseStage';
+import { LocateStage } from './urgeHelp/LocateStage';
+import { ActStage } from './urgeHelp/ActStage';
+import { ReflectStage } from './urgeHelp/ReflectStage';
+import { SurfCelebration } from './urgeHelp/SurfCelebration';
+import { CoachModal } from './urgeHelp/CoachModal';
+import { URGE_ACTION_SCREENS } from './urgeActions';
+import { appendEntry, count as readUrgeCount } from '../src/lib/urgeLog';
 
 interface UrgeHelpProps {
-  onChangeView?: (view: View) => void;
+  // Coach state lifted from App so the modal session stays continuous with
+  // the dedicated Coach view — same conversation, same persistence.
+  checkInHistory: CheckIn[];
+  chatHistory: ChatMessage[];
+  setChatHistory: React.Dispatch<React.SetStateAction<ChatMessage[]>>;
 }
 
-export const UrgeHelp: React.FC<UrgeHelpProps> = ({ onChangeView }) => {
-  const [step, setStep] = useState(1);
-  const [selectedFeeling, setSelectedFeeling] = useState<string | null>(null);
-  const [activeTechnique, setActiveTechnique] = useState<number | null>(null);
+/**
+ * Help tab orchestrator (Issue #34).
+ *
+ * Owns the 4-stage state machine — Pause → Locate → Act → Reflect — plus
+ * the active mini-screen (when the user is inside one of the 10 actions),
+ * the AI Coach modal (slide-up over the current stage), and the urge log
+ * write that fires on Reflect-stage feedback.
+ *
+ * State is intentionally local to this component: the user starts a fresh
+ * session every time they open the Help tab. That matches the existing
+ * pattern (the legacy UrgeHelp also reset on remount) and matches user
+ * expectation — an urge is a discrete moment, not a resumable workflow.
+ */
+export const UrgeHelp: React.FC<UrgeHelpProps> = ({
+  checkInHistory,
+  chatHistory,
+  setChatHistory,
+}) => {
+  // ── Session state ─────────────────────────────────────────────────────────
+  const [stage, setStage] = useState<Stage>('pause');
+  const [feeling, setFeeling] = useState<FeelingId | null>(null);
+  const [intensity, setIntensity] = useState<number | null>(null);
+  const [actionsTried, setActionsTried] = useState<UrgeActionId[]>([]);
+  const [activeActionId, setActiveActionId] = useState<UrgeActionId | null>(null);
+  const [coachOpen, setCoachOpen] = useState(false);
+  /** Snapshot of the urge state at the moment the Coach modal opens.
+   *  Captured imperatively (not derived) so the modal sees a stable
+   *  context for its full lifetime, regardless of any background state
+   *  changes in the orchestrator. */
+  const [coachSeed, setCoachSeed] = useState<UrgeContextSeed | null>(null);
+  /** Number of completed surfs in the log. Read once per session reset so
+   *  the Reflect copy ("Surf #N on your record") is accurate without
+   *  re-reading localStorage on every keystroke. */
+  const [priorSurfCount, setPriorSurfCount] = useState<number>(() => readUrgeCount());
+  /** When non-null, we're showing the post-"passed" celebration overlay.
+   *  Carries the freshly-incremented total so the overlay renders without
+   *  a second storage read. */
+  const [celebrationCount, setCelebrationCount] = useState<number | null>(null);
 
-  // --- Step 1: Timer Logic ---
-  const [timeLeft, setTimeLeft] = useState(60);
-  const duration = 60;
-  
-  useEffect(() => {
-    let interval: any;
-    if (step === 1 && timeLeft > 0) {
-      interval = setInterval(() => {
-        setTimeLeft((prev) => prev - 1);
-      }, 1000);
-    } else if (step === 1 && timeLeft === 0) {
-      // Auto advance when timer hits 0
-      setStep(2);
-    }
-    return () => clearInterval(interval);
-  }, [step, timeLeft]);
+  /** Wall-clock start of this session — captured once per mount. Used to
+   *  compute `elapsedSec` for the Coach context seed. A ref (not state) so
+   *  re-renders don't reset it and we never re-render just because time
+   *  passed. */
+  const openedAtRef = useRef<number>(Date.now());
 
-  // Calculate SVG Circle props
-  // Using a fixed viewBox size for consistent calculation
-  const size = 280;
-  const strokeWidth = 20; // Thicker for better aesthetics
-  const radius = (size - strokeWidth) / 2;
-  const circumference = 2 * Math.PI * radius;
-  const strokeDashoffset = circumference - ((duration - timeLeft) / duration) * circumference;
+  // ── Stage transitions ─────────────────────────────────────────────────────
 
-  // --- Lists ---
-  const feelings = [
-    "Boredom", "Anxiety", "Loneliness", "Stress", 
-    "Frustration", "Tiredness", "Sexual Tension"
-  ];
+  const goToLocate = useCallback(() => setStage('locate'), []);
 
-  const techniques = [
-    {
-      id: 1,
-      icon: Wind,
-      title: "Box Breathing",
-      desc: "Inhale 4s, Hold 4s, Exhale 4s, Hold 4s.",
-      action: () => setActiveTechnique(1)
+  /** Locate → Act. Captures the named feeling and (optional) intensity into
+   *  session state so downstream stages and the Coach seed can read them. */
+  const handleLocateComplete = useCallback(
+    (chosenFeeling: FeelingId, chosenIntensity: number | null) => {
+      setFeeling(chosenFeeling);
+      setIntensity(chosenIntensity);
+      setStage('act');
     },
-    {
-      id: 2,
-      icon: Footprints,
-      title: "Leave the Room",
-      desc: "Change your physical environment immediately.",
-      action: () => setActiveTechnique(2)
+    [],
+  );
+
+  /** Open a specific action mini-screen and record it in actionsTried.
+   *  Dedupes so reopening the same action mid-session doesn't inflate the log. */
+  const openAction = useCallback((id: UrgeActionId) => {
+    setActiveActionId(id);
+    setActionsTried((prev) => (prev.includes(id) ? prev : [...prev, id]));
+  }, []);
+
+  /** Close the current action mini-screen and either return to the Act grid
+   *  ("back") or advance to Reflect ("done"). Keeps the orchestrator the
+   *  single source of truth for stage progression. */
+  const closeAction = useCallback((next: 'back' | 'done') => {
+    setActiveActionId(null);
+    if (next === 'done') setStage('reflect');
+  }, []);
+
+  // Stable callbacks for the active action screen. These end up in the
+  // dependency arrays of effects inside individual action components
+  // (notably Grounding's auto-advance) — fresh inline arrows would force
+  // those effects to re-fire on every parent re-render and reset their
+  // timers. Memoized once for the lifetime of the orchestrator.
+  const handleActionDone = useCallback(() => closeAction('done'), [closeAction]);
+  const handleActionBack = useCallback(() => closeAction('back'), [closeAction]);
+
+  /** Reset all session state to a fresh Pause. Called after the celebration
+   *  overlay or whenever the user explicitly restarts. */
+  const resetSession = useCallback(() => {
+    setStage('pause');
+    setFeeling(null);
+    setIntensity(null);
+    setActionsTried([]);
+    setActiveActionId(null);
+    openedAtRef.current = Date.now();
+  }, []);
+
+  // ── Coach modal open/close ────────────────────────────────────────────────
+  // Declared above handleReflect because the 'escalated' branch calls it.
+
+  /** Open the Coach modal with a fresh snapshot of the current urge state.
+   *  Captured imperatively at this single point so the modal's seed never
+   *  drifts while it's open, and we don't have to ignore exhaustive-deps. */
+  const openCoach = useCallback(() => {
+    setCoachSeed({
+      stage,
+      feeling,
+      intensity,
+      actionAttempted: actionsTried[actionsTried.length - 1] ?? null,
+      elapsedSec: Math.floor((Date.now() - openedAtRef.current) / 1000),
+    });
+    setCoachOpen(true);
+  }, [stage, feeling, intensity, actionsTried]);
+
+  const closeCoach = useCallback(() => {
+    setCoachOpen(false);
+    setCoachSeed(null);
+  }, []);
+
+  /** Reflect-stage handler. Logs only on terminal outcomes (`passed` /
+   *  `escalated`) — `still_here` is mid-session feedback ("let me try
+   *  another action"), not the end of an urge surf. Logging it would
+   *  inflate the Dashboard tile with one entry per attempt instead of
+   *  one entry per resolved session.
+   */
+  const handleReflect = useCallback(
+    (outcome: UrgeOutcome) => {
+      switch (outcome) {
+        case 'passed': {
+          const now = Date.now();
+          appendEntry({
+            id: now,
+            endedAt: new Date(now).toISOString(),
+            feeling,
+            intensity,
+            actionsTried,
+            outcome,
+          });
+          const newTotal = priorSurfCount + 1;
+          setPriorSurfCount(newTotal);
+          // Surface the celebration; resetSession runs after it auto-dismisses.
+          setCelebrationCount(newTotal);
+          break;
+        }
+        case 'escalated': {
+          const now = Date.now();
+          appendEntry({
+            id: now,
+            endedAt: new Date(now).toISOString(),
+            feeling,
+            intensity,
+            actionsTried,
+            outcome,
+          });
+          setPriorSurfCount((c) => c + 1);
+          // Open Coach modal pre-seeded. Stay on Reflect so the user has
+          // somewhere to land when they close the modal.
+          openCoach();
+          break;
+        }
+        case 'still_here':
+          // Mid-session feedback only — no log entry. Send the user back
+          // to the Act grid with prior actions still marked so they can
+          // pick a fresh technique.
+          setStage('act');
+          break;
+      }
     },
-    {
-      id: 3,
-      icon: PenTool,
-      title: "Write it Down",
-      desc: "Write what you feel. Don't judge it, just capture it.",
-      action: () => setActiveTechnique(3)
-    },
-    {
-      id: 4,
-      icon: PhoneOff,
-      title: "Put Phone Away",
-      desc: "Place your device in another room for 15 minutes.",
-      action: () => setActiveTechnique(4)
-    }
-  ];
+    [feeling, intensity, actionsTried, priorSurfCount, openCoach],
+  );
 
-  // --- Handlers ---
-  const handleFeelingSelect = (feeling: string) => {
-    setSelectedFeeling(feeling);
-    setStep(3);
-  };
 
-  const handleFeedback = (type: 'passed' | 'still_there' | 'need_help') => {
-    if (type === 'passed') {
-      // Reset
-      setStep(1);
-      setTimeLeft(60);
-      setSelectedFeeling(null);
-      setActiveTechnique(null);
-    } else if (type === 'still_there') {
-      setStep(3); // Go back to tools
-      setActiveTechnique(null);
-    } else if (type === 'need_help') {
-      if (onChangeView) onChangeView(View.AI_COACH);
-    }
-  };
+  // ── Render ────────────────────────────────────────────────────────────────
 
-  // --- Renders ---
+  // The CoachPill is rendered globally over all stages and mini-screens.
+  // Background tint stays rose throughout — the emergency context is the
+  // single visual constant binding the four stages together.
+  return (
+    <div className="flex-1 flex flex-col bg-rose-50 relative overflow-hidden">
+      <StageProgress current={stage} />
 
-  // Screen 1: Timer
-  if (step === 1) {
-    return (
-      <div className="flex-1 flex flex-col items-center justify-center p-6 bg-rose-50 animate-in fade-in duration-500 relative overflow-hidden">
-        <div className="absolute top-0 left-0 right-0 h-64 md:h-80 z-0 overflow-hidden">
-          <img src="/illustrations/urge.png" alt="Calm" className="w-full h-full object-cover mix-blend-multiply opacity-40 scale-[1.4] origin-center" />
-          <div className="absolute inset-0 bg-gradient-to-b from-transparent via-rose-50/60 to-rose-50" />
-        </div>
-        
-        <h2 className="text-xl md:text-2xl font-medium text-rose-900 mb-10 text-center max-w-md leading-relaxed relative z-10 mt-12">
-          You don't need to decide right now.
-        </h2>
+      <div className="flex-1 flex flex-col min-h-0">
+        {stage === 'pause' && <PauseStage onComplete={goToLocate} />}
 
-        <div className="relative w-72 h-72 mb-10 z-10">
-          <svg className="w-full h-full transform -rotate-90" viewBox={`0 0 ${size} ${size}`}>
-            {/* Background Ring */}
-            <circle
-              cx={size / 2}
-              cy={size / 2}
-              r={radius}
-              stroke="currentColor"
-              strokeWidth={strokeWidth}
-              fill="transparent"
-              className="text-rose-200"
-            />
-            {/* Progress Ring */}
-            <circle
-              cx={size / 2}
-              cy={size / 2}
-              r={radius}
-              stroke="currentColor"
-              strokeWidth={strokeWidth}
-              fill="transparent"
-              strokeDasharray={circumference}
-              strokeDashoffset={strokeDashoffset}
-              strokeLinecap="round"
-              className="text-rose-800 transition-all duration-1000 ease-linear"
-            />
-          </svg>
-          
-          <div className="absolute inset-0 flex flex-col items-center justify-center select-none">
-            <span className="text-7xl font-light text-rose-900 tracking-tighter tabular-nums">
-              {timeLeft}
-            </span>
-             <span className="text-xs font-bold text-rose-800/40 uppercase tracking-widest mt-2">
-              Seconds
-            </span>
-          </div>
-        </div>
+        {stage === 'locate' && (
+          <LocateStage initialFeeling={feeling} onComplete={handleLocateComplete} />
+        )}
 
-        <p className="text-stone-500 mb-10 font-medium">Urges rise and fall like waves.</p>
+        {stage === 'act' && activeActionId === null && (
+          <ActStage
+            feeling={feeling}
+            triedActionIds={actionsTried}
+            onPickAction={openAction}
+          />
+        )}
+        {stage === 'act' && activeActionId !== null && (() => {
+          // Resolve the screen component from the registry. Wrapped in an
+          // IIFE so we can keep the lookup tight to the render branch.
+          const ActionScreen = URGE_ACTION_SCREENS[activeActionId];
+          return <ActionScreen onDone={handleActionDone} onBack={handleActionBack} />;
+        })()}
 
-        <button 
-            onClick={() => setStep(2)}
-            className="px-8 py-4 bg-stone-200 text-stone-600 rounded-xl hover:bg-stone-300 transition-colors font-semibold text-sm tracking-wide"
-        >
-            Skip Timer (I'm grounded)
-        </button>
+        {stage === 'reflect' && (
+          <ReflectStage
+            totalSurfsAfterThisOne={priorSurfCount + 1}
+            onChoose={handleReflect}
+          />
+        )}
       </div>
-    );
-  }
 
-  // Screen 2: Feelings
-  if (step === 2) {
-    return (
-      <div className="flex-1 flex flex-col items-center justify-center p-4 bg-rose-50 animate-in slide-in-from-right-8 duration-300">
-        <h2 className="text-2xl md:text-3xl font-bold text-rose-900 mb-8 text-center">
-          What are you feeling?
-        </h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 w-full max-w-2xl">
-          {feelings.map((feeling) => (
-            <button
-              key={feeling}
-              onClick={() => handleFeelingSelect(feeling)}
-              className="p-6 bg-white border border-rose-200 rounded-xl text-lg font-medium text-rose-900 hover:border-rose-400 hover:shadow-md transition-all text-center"
-            >
-              {feeling}
-            </button>
-          ))}
-        </div>
-      </div>
-    );
-  }
+      {celebrationCount !== null && (
+        <SurfCelebration
+          total={celebrationCount}
+          onDone={() => {
+            setCelebrationCount(null);
+            resetSession();
+          }}
+        />
+      )}
 
-  // Screen 3: Urge Emergency Actions
-  if (step === 3) {
-    return (
-      <div className="flex-1 p-4 md:p-8 overflow-y-auto bg-rose-50 flex flex-col items-center justify-center animate-in slide-in-from-right-8 duration-300">
-        <div className="max-w-2xl w-full space-y-6">
-            <div className="text-center space-y-2">
-                <h2 className="text-2xl md:text-3xl font-bold text-rose-900">Urge Emergency</h2>
-                <p className="text-rose-800/70">Don't fight the urge. Just delay the reaction. Pick one action now.</p>
-            </div>
-
-            <div className="grid grid-cols-1 gap-4">
-                {techniques.map((t) => (
-                    <button
-                        key={t.id}
-                        onClick={t.action}
-                        className={`p-6 rounded-2xl border-2 text-left transition-all group relative overflow-hidden ${
-                            activeTechnique === t.id 
-                            ? 'bg-rose-100 border-rose-500 shadow-md ring-1 ring-rose-500' 
-                            : 'bg-white border-rose-200 hover:border-rose-400'
-                        }`}
-                    >
-                        <div className="flex items-center gap-4 mb-2 relative z-10">
-                            <div className={`p-3 rounded-full ${activeTechnique === t.id ? 'bg-rose-600 text-white' : 'bg-white text-rose-800'}`}>
-                                <t.icon size={24} />
-                            </div>
-                            <span className="font-bold text-rose-900 text-lg">{t.title}</span>
-                        </div>
-                        <p className="text-stone-600 pl-[3.25rem] relative z-10">{t.desc}</p>
-                    </button>
-                ))}
-            </div>
-
-            {/* Animation Area for specific techniques */}
-            {activeTechnique === 1 && (
-                <div className="bg-rose-700 text-stone-100 p-8 rounded-2xl text-center animate-in zoom-in duration-300">
-                    <p className="text-xl font-light mb-4">Breathe In...</p>
-                    <div className="w-full h-2 bg-emerald-800 rounded-full overflow-hidden">
-                        <div className="h-full bg-emerald-400 animate-[pulse_4s_infinite]"></div>
-                    </div>
-                </div>
-            )}
-
-            {/* Next Button - Appears if a technique is selected */}
-            {activeTechnique !== null && (
-                <div className="pt-4 flex justify-end animate-in fade-in slide-in-from-bottom-4">
-                     <button 
-                        onClick={() => setStep(4)}
-                        className="flex items-center gap-2 px-6 py-3 bg-emerald-800 text-white rounded-xl hover:bg-rose-700 transition-colors shadow-lg"
-                     >
-                        <span>I did this</span>
-                        <ArrowRight size={20} />
-                     </button>
-                </div>
-            )}
-        </div>
-      </div>
-    );
-  }
-
-  // Screen 4: Feedback
-  if (step === 4) {
-    return (
-      <div className="flex-1 flex flex-col items-center justify-center p-4 bg-rose-50 animate-in slide-in-from-right-8 duration-300">
-         <h2 className="text-2xl md:text-3xl font-bold text-rose-900 mb-8 text-center">
-            Did the urge decrease?
-         </h2>
-         
-         <div className="w-full max-w-md space-y-4">
-            <button 
-                onClick={() => handleFeedback('passed')}
-                className="w-full p-4 bg-rose-700 text-white rounded-xl font-medium hover:bg-rose-800 transition-colors shadow-md"
-            >
-                Yes, it passed
-            </button>
-            
-            <button 
-                onClick={() => handleFeedback('still_there')}
-                className="w-full p-4 bg-white border-2 border-rose-700 text-rose-900 rounded-xl font-medium hover:bg-rose-50 transition-colors"
-            >
-                It's still there (Try another)
-            </button>
-            
-            <button 
-                onClick={() => handleFeedback('need_help')}
-                className="w-full p-4 bg-stone-300 text-stone-800 rounded-xl font-medium hover:bg-stone-400 transition-colors"
-            >
-                I need more help (Return to Coach)
-            </button>
-         </div>
-
-         <p className="mt-8 text-stone-500 text-sm">You slowed the pattern. That matters.</p>
-      </div>
-    );
-  }
-
-  return null;
+      <CoachModal
+        open={coachOpen}
+        onClose={closeCoach}
+        seed={coachSeed}
+        checkInHistory={checkInHistory}
+        messages={chatHistory}
+        setMessages={setChatHistory}
+      />
+    </div>
+  );
 };
+

--- a/webapp/components/urgeActions/ActionScreenShell.tsx
+++ b/webapp/components/urgeActions/ActionScreenShell.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { ArrowLeft, Check } from 'lucide-react';
+import type { UrgeAction } from '../../types';
+import { URGE_CATEGORY_META } from '../../data/urgeData';
+
+interface ActionScreenShellProps {
+  action: UrgeAction;
+  /** Visual icon for the header — passed in by the registry so it stays in
+   *  sync with the Act-stage card icons. */
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  /** Tap target for "I did this" — closes the screen and advances to Reflect. */
+  onDone: () => void;
+  /** Tap target for "Back" — returns to the Act grid without advancing. */
+  onBack: () => void;
+  /** When true, the "Done" CTA is shown but disabled. Used by screens that
+   *  complete passively (e.g. timer screens where the timer must finish). */
+  doneDisabled?: boolean;
+  /** Override the default "I did this" copy when a more natural verb fits
+   *  (e.g. "I'm done writing" on the journal screen). */
+  doneLabel?: string;
+  /** When true, hide the Done CTA entirely. Useful for screens that handle
+   *  their own completion via a custom button (e.g. the journal Save). */
+  hideDone?: boolean;
+  children: React.ReactNode;
+}
+
+/**
+ * Shared wrapper for every action mini-screen.
+ *
+ * Provides one consistent visual + interaction shell so the user learns the
+ * pattern once and never has to re-orient: header up top with icon + title +
+ * "why it works", interactive content in the middle, "Back" + "I did this"
+ * footer pinned to the bottom of the viewport on mobile.
+ *
+ * The category tint colours the icon badge so screens within the same
+ * category (Reset / Ground / Protect / Reframe) feel like siblings.
+ */
+export const ActionScreenShell: React.FC<ActionScreenShellProps> = ({
+  action,
+  icon: Icon,
+  onDone,
+  onBack,
+  doneDisabled,
+  doneLabel = 'I did this',
+  hideDone,
+  children,
+}) => {
+  const meta = URGE_CATEGORY_META[action.category];
+
+  return (
+    // Animation keeps the entrance direction consistent across all 10
+    // screens so the user perceives "going deeper" into a single flow,
+    // not jumping into separate features.
+    <div className="flex-1 flex flex-col bg-rose-50 animate-in fade-in slide-in-from-right-4 duration-300">
+      {/* Header */}
+      <header className="px-4 md:px-6 pt-4 md:pt-6 pb-2">
+        <button
+          onClick={onBack}
+          className="inline-flex items-center gap-1 text-rose-700/70 hover:text-rose-900 text-sm font-medium mb-4 transition-colors"
+          aria-label="Back to actions"
+        >
+          <ArrowLeft size={16} />
+          <span>Back</span>
+        </button>
+
+        <div className="flex items-start gap-3 mb-1">
+          <div
+            className={`flex-shrink-0 inline-flex items-center justify-center w-12 h-12 rounded-xl
+                        ${meta.tint} ${meta.accent}`}
+          >
+            <Icon size={22} />
+          </div>
+          <div className="flex-1 min-w-0 pt-1">
+            <h2 className="text-xl md:text-2xl font-bold text-rose-900 leading-tight">
+              {action.title}
+            </h2>
+            <p className="text-xs md:text-sm text-rose-700/70 mt-0.5">{action.whyItWorks}</p>
+          </div>
+        </div>
+      </header>
+
+      {/* Interactive area — scrolls if a screen needs it (e.g. letter editor) */}
+      <div className="flex-1 overflow-y-auto px-4 md:px-6 py-4">{children}</div>
+
+      {/* Footer CTA — pinned, with safe spacing for the mobile nav */}
+      {!hideDone && (
+        <footer className="px-4 md:px-6 py-3 pb-[5.5rem] md:pb-4 bg-rose-50 border-t border-rose-100">
+          <button
+            onClick={onDone}
+            disabled={doneDisabled}
+            className={`w-full inline-flex items-center justify-center gap-2 px-6 py-3 rounded-xl
+                        font-semibold text-sm shadow-md transition-all
+                        ${
+                          doneDisabled
+                            ? 'bg-rose-200 text-rose-400 cursor-not-allowed'
+                            : 'bg-rose-700 text-white hover:bg-rose-800 active:scale-[0.99]'
+                        }`}
+          >
+            <Check size={18} />
+            <span>{doneLabel}</span>
+          </button>
+        </footer>
+      )}
+    </div>
+  );
+};

--- a/webapp/components/urgeActions/BoxBreathingScreen.tsx
+++ b/webapp/components/urgeActions/BoxBreathingScreen.tsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useState } from 'react';
+import { Wind } from 'lucide-react';
+import { ActionScreenShell } from './ActionScreenShell';
+import { URGE_ACTION_BY_ID } from '../../data/urgeData';
+
+interface ScreenProps {
+  onDone: () => void;
+  onBack: () => void;
+}
+
+const PHASES = [
+  { name: 'Inhale', seconds: 4 },
+  { name: 'Hold', seconds: 4 },
+  { name: 'Exhale', seconds: 4 },
+  { name: 'Hold', seconds: 4 },
+] as const;
+
+const TOTAL_CYCLES = 5;
+
+/**
+ * Box breathing — 4-4-4-4 inhale/hold/exhale/hold for 5 cycles.
+ *
+ * Animated breathing circle drives the pace: it expands during Inhale,
+ * stays large during the first Hold, contracts during Exhale, stays small
+ * during the second Hold. The user follows the circle with their breath
+ * — no counting required, no app-juggling.
+ */
+export const BoxBreathingScreen: React.FC<ScreenProps> = ({ onDone, onBack }) => {
+  const [cycle, setCycle] = useState(1);
+  const [phaseIdx, setPhaseIdx] = useState(0);
+  const [secondsLeft, setSecondsLeft] = useState<number>(PHASES[0].seconds);
+  const [completed, setCompleted] = useState(false);
+
+  // Tick down the seconds counter every 1s. Pure: only mutates secondsLeft.
+  useEffect(() => {
+    if (completed) return;
+    const id = window.setInterval(() => {
+      setSecondsLeft((s) => Math.max(0, s - 1));
+    }, 1000);
+    return () => window.clearInterval(id);
+  }, [completed]);
+
+  // Watch for phase completion (secondsLeft reaching 0) and advance phase
+  // and cycle from there. Splitting this off the tick effect avoids the
+  // setState-inside-setState anti-pattern that misbehaves under React 18
+  // StrictMode (updaters double-invoked surface side effects twice).
+  useEffect(() => {
+    if (completed || secondsLeft > 0) return;
+    const nextPhase = (phaseIdx + 1) % PHASES.length;
+    if (nextPhase === 0) {
+      // Just wrapped a full cycle — either advance the cycle counter or
+      // finish if we've hit the cap.
+      if (cycle >= TOTAL_CYCLES) {
+        setCompleted(true);
+        return;
+      }
+      setCycle((c) => c + 1);
+    }
+    setPhaseIdx(nextPhase);
+    setSecondsLeft(PHASES[nextPhase].seconds);
+  }, [secondsLeft, phaseIdx, cycle, completed]);
+
+  // Map phase to circle scale: large for Inhale and the hold after it; small
+  // for Exhale and the hold after it. Tailwind doesn't do dynamic transform
+  // values cleanly, so we drive the scale via inline style.
+  const phaseName = PHASES[phaseIdx].name;
+  const scale = phaseIdx === 0 || phaseIdx === 1 ? 1 : 0.55;
+  const transitionDuration = phaseName === 'Hold' ? '0ms' : '4000ms';
+
+  return (
+    <ActionScreenShell
+      action={URGE_ACTION_BY_ID.box_breathing}
+      icon={Wind}
+      onDone={onDone}
+      onBack={onBack}
+      doneDisabled={!completed}
+      doneLabel={completed ? "I'm calmer" : `Cycle ${cycle} of ${TOTAL_CYCLES}`}
+    >
+      <div className="flex flex-col items-center justify-center min-h-[55vh]">
+        {/* Breathing circle — purely visual; the colour shifts with each
+            phase to give an extra sensory cue beyond size alone. */}
+        <div className="relative w-64 h-64 flex items-center justify-center">
+          <div
+            aria-hidden="true"
+            className="rounded-full bg-rose-300/40 ring-8 ring-rose-200/40"
+            style={{
+              width: '256px',
+              height: '256px',
+              transform: `scale(${scale})`,
+              transition: `transform ${transitionDuration} ease-in-out`,
+            }}
+          />
+          <div className="absolute inset-0 flex flex-col items-center justify-center select-none">
+            <span className="text-3xl md:text-4xl font-light text-rose-900 tracking-tight">
+              {phaseName}
+            </span>
+            <span className="text-5xl md:text-6xl font-light text-rose-900 tabular-nums mt-2">
+              {secondsLeft}
+            </span>
+          </div>
+        </div>
+
+        <p className="mt-8 text-sm text-rose-700/70 text-center max-w-xs">
+          {completed
+            ? 'Five cycles done. Notice how your shoulders feel.'
+            : 'Match your breath to the circle.'}
+        </p>
+      </div>
+    </ActionScreenShell>
+  );
+};

--- a/webapp/components/urgeActions/ColdWaterScreen.tsx
+++ b/webapp/components/urgeActions/ColdWaterScreen.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import { Droplets, Check } from 'lucide-react';
+import { ActionScreenShell } from './ActionScreenShell';
+import { URGE_ACTION_BY_ID } from '../../data/urgeData';
+
+interface ScreenProps {
+  onDone: () => void;
+  onBack: () => void;
+}
+
+const STEPS = [
+  { title: 'Walk to the sink', body: 'Stand up. Move now — momentum is most of the work.' },
+  {
+    title: '30 seconds of cold water on your face',
+    body: 'Aim for the area around your eyes. The colder the better.',
+  },
+  {
+    title: 'Notice the reset',
+    body: "You'll feel your heart rate drop within seconds. That's the diving reflex — the fastest reset your body has.",
+  },
+] as const;
+
+/**
+ * Cold water — guided 3-step instructional screen.
+ *
+ * We can't enforce that the user actually walks to the sink, but we can
+ * make the path frictionless: one tap per step, encouraging copy, and a
+ * final "How do you feel?" check that converts the experience into a
+ * tangible result. Each tap produces a small dopamine hit that competes
+ * with the urge.
+ */
+export const ColdWaterScreen: React.FC<ScreenProps> = ({ onDone, onBack }) => {
+  const [stepIdx, setStepIdx] = useState(0);
+  const isLast = stepIdx === STEPS.length - 1;
+
+  return (
+    <ActionScreenShell
+      action={URGE_ACTION_BY_ID.cold_water}
+      icon={Droplets}
+      onDone={onDone}
+      onBack={onBack}
+      doneDisabled={!isLast}
+    >
+      <ol className="space-y-3 max-w-md mx-auto" aria-label="Cold water reset steps">
+        {STEPS.map((s, i) => {
+          const done = i < stepIdx;
+          const current = i === stepIdx;
+          return (
+            <li
+              key={i}
+              className={`p-4 rounded-2xl border-2 transition-all
+                          ${
+                            current
+                              ? 'bg-white border-rose-500 shadow-md'
+                              : done
+                                ? 'bg-rose-50 border-rose-200 opacity-70'
+                                : 'bg-white border-rose-100 opacity-50'
+                          }`}
+            >
+              <div className="flex items-start gap-3">
+                <div
+                  className={`flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold
+                              ${
+                                done
+                                  ? 'bg-rose-700 text-white'
+                                  : current
+                                    ? 'bg-rose-700 text-white'
+                                    : 'bg-rose-100 text-rose-400'
+                              }`}
+                >
+                  {done ? <Check size={14} /> : i + 1}
+                </div>
+                <div className="flex-1">
+                  <h4 className="font-semibold text-rose-900 text-sm md:text-base">{s.title}</h4>
+                  <p className="text-xs md:text-sm text-rose-700/70 mt-1">{s.body}</p>
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+
+      {!isLast && (
+        <div className="mt-6 flex justify-center">
+          <button
+            onClick={() => setStepIdx((i) => Math.min(i + 1, STEPS.length - 1))}
+            className="px-6 py-2.5 bg-white border border-rose-300 text-rose-800 rounded-xl
+                       text-sm font-semibold hover:bg-rose-50 transition-colors"
+          >
+            Next step
+          </button>
+        </div>
+      )}
+    </ActionScreenShell>
+  );
+};

--- a/webapp/components/urgeActions/FutureSelfLetterScreen.tsx
+++ b/webapp/components/urgeActions/FutureSelfLetterScreen.tsx
@@ -1,0 +1,100 @@
+import React, { useState } from 'react';
+import { Mail, Pencil } from 'lucide-react';
+import { ActionScreenShell } from './ActionScreenShell';
+import { LetterEditor } from './LetterEditor';
+import { URGE_ACTION_BY_ID } from '../../data/urgeData';
+import { readLetter, writeLetter, type FutureSelfLetter } from '../../src/lib/urgeLog';
+
+interface ScreenProps {
+  onDone: () => void;
+  onBack: () => void;
+}
+
+/**
+ * Future-Self Letter.
+ *
+ * Two modes:
+ *   1. First-time use → guided editor (3 fields). The act of writing it is
+ *      already valuable — even if the user doesn't reach Reflect, they've
+ *      done the introspective work.
+ *   2. Letter exists → display in calm prose with an Edit affordance, plus
+ *      the standard "I read it" Done CTA from the shell.
+ *
+ * Persistence is local-only via `urgeLog.ts`. The Settings tab also exposes
+ * the same editor so users don't have to re-trigger the action to edit.
+ */
+export const FutureSelfLetterScreen: React.FC<ScreenProps> = ({ onDone, onBack }) => {
+  const [letter, setLetter] = useState<FutureSelfLetter | null>(() => readLetter());
+  const [editing, setEditing] = useState<boolean>(() => readLetter() === null);
+
+  const handleSave = (next: Pick<FutureSelfLetter, 'values' | 'identity' | 'message'>) => {
+    writeLetter(next);
+    setLetter({ ...next, updatedAt: new Date().toISOString() });
+    setEditing(false);
+  };
+
+  const isShowingLetter = !editing && letter !== null;
+
+  return (
+    <ActionScreenShell
+      action={URGE_ACTION_BY_ID.future_self_letter}
+      icon={Mail}
+      onDone={onDone}
+      onBack={onBack}
+      doneDisabled={!isShowingLetter}
+      doneLabel={isShowingLetter ? "I heard myself" : 'Save your letter first'}
+      hideDone={editing}
+    >
+      {editing ? (
+        <div className="max-w-md mx-auto space-y-4">
+          <p className="text-sm text-rose-800">
+            Write this once. Future-you will read it the next time the urge shows up.
+          </p>
+          <LetterEditor
+            initial={letter ?? { values: '', identity: '', message: '' }}
+            onSave={handleSave}
+          />
+        </div>
+      ) : letter ? (
+        <article className="max-w-md mx-auto space-y-5 text-rose-900">
+          <header className="text-center">
+            <p className="text-xs font-semibold uppercase tracking-widest text-rose-700/60">
+              From past-you to right-now-you
+            </p>
+          </header>
+
+          <div className="bg-white border border-rose-100 rounded-2xl p-5 space-y-4 shadow-sm">
+            <section>
+              <p className="text-[11px] font-bold uppercase tracking-wider text-rose-700/60 mb-1">
+                What matters
+              </p>
+              <p className="text-base leading-relaxed">{letter.values}</p>
+            </section>
+
+            <section>
+              <p className="text-[11px] font-bold uppercase tracking-wider text-rose-700/60 mb-1">
+                Who you're becoming
+              </p>
+              <p className="text-base leading-relaxed">{letter.identity}</p>
+            </section>
+
+            <section>
+              <p className="text-[11px] font-bold uppercase tracking-wider text-rose-700/60 mb-1">
+                Your message
+              </p>
+              <p className="text-base leading-relaxed whitespace-pre-wrap">{letter.message}</p>
+            </section>
+          </div>
+
+          <button
+            onClick={() => setEditing(true)}
+            className="inline-flex items-center gap-1 text-sm text-rose-700/70 hover:text-rose-900 transition-colors mx-auto"
+          >
+            <Pencil size={12} />
+            Edit letter
+          </button>
+        </article>
+      ) : null}
+    </ActionScreenShell>
+  );
+};

--- a/webapp/components/urgeActions/Grounding54321Screen.tsx
+++ b/webapp/components/urgeActions/Grounding54321Screen.tsx
@@ -1,0 +1,211 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Eye, Hand, Ear, Wind, Coffee, Check, Sparkles } from 'lucide-react';
+import { ActionScreenShell } from './ActionScreenShell';
+import { URGE_ACTION_BY_ID } from '../../data/urgeData';
+
+interface ScreenProps {
+  onDone: () => void;
+  onBack: () => void;
+}
+
+/** Auto-advance delay once all 15 dots are checked. Long enough that the
+ *  user can register the completion banner; short enough that they don't
+ *  feel stranded. */
+const AUTO_ADVANCE_MS = 1400;
+
+const SENSES = [
+  { count: 5, sense: 'see', icon: Eye, prompt: 'Name 5 things you can see.' },
+  { count: 4, sense: 'feel', icon: Hand, prompt: 'Name 4 things you can feel.' },
+  { count: 3, sense: 'hear', icon: Ear, prompt: 'Name 3 things you can hear.' },
+  { count: 2, sense: 'smell', icon: Wind, prompt: 'Name 2 things you can smell.' },
+  { count: 1, sense: 'taste', icon: Coffee, prompt: 'Name 1 thing you can taste.' },
+] as const;
+
+/**
+ * 5-4-3-2-1 sensory grounding.
+ *
+ * Walks the user through the five senses in descending count. Each sense
+ * is its own card; tapping the card reveals checkboxes equal to the
+ * required count, and the user marks each thing they notice. The next
+ * sense unlocks once all checkboxes for the current sense are filled.
+ *
+ * We don't ask for text input — checkboxes are enough and don't make the
+ * user fight a keyboard during a crisis. The act of looking around and
+ * mentally naming each item is what does the work.
+ */
+export const Grounding54321Screen: React.FC<ScreenProps> = ({ onDone, onBack }) => {
+  // checks[i] is the number of items the user has marked for sense i.
+  const [checks, setChecks] = useState<number[]>(SENSES.map(() => 0));
+  const [activeIdx, setActiveIdx] = useState(0);
+
+  // Holds the auto-advance timeout so we can cancel it if the user
+  // unmounts the screen mid-pause (e.g. taps Back during the 250ms window).
+  const advanceTimerRef = useRef<number | null>(null);
+  useEffect(() => {
+    return () => {
+      if (advanceTimerRef.current !== null) {
+        window.clearTimeout(advanceTimerRef.current);
+      }
+    };
+  }, []);
+
+  const allDone = SENSES.every((s, i) => checks[i] >= s.count);
+
+  // Ref on the completion banner so we can scrollIntoView once it mounts —
+  // the senses list is tall enough that the footer Done button can land
+  // off-screen, leaving the user stuck staring at the last filled card.
+  const doneBannerRef = useRef<HTMLDivElement | null>(null);
+  // Holds the auto-advance-to-Reflect timeout so the user gets a brief
+  // moment to register completion before the screen exits on its own.
+  const autoDoneTimerRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!allDone) return;
+    // Bring the celebration into view first…
+    doneBannerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    // …then auto-fire onDone, mirroring the auto-completion behaviour of
+    // the other timed/visual action screens (BoxBreathing, PhysicalBurst).
+    autoDoneTimerRef.current = window.setTimeout(() => {
+      autoDoneTimerRef.current = null;
+      onDone();
+    }, AUTO_ADVANCE_MS);
+    return () => {
+      if (autoDoneTimerRef.current !== null) {
+        window.clearTimeout(autoDoneTimerRef.current);
+        autoDoneTimerRef.current = null;
+      }
+    };
+  }, [allDone, onDone]);
+
+  return (
+    <ActionScreenShell
+      action={URGE_ACTION_BY_ID.grounding_54321}
+      icon={Eye}
+      onDone={onDone}
+      onBack={onBack}
+      doneDisabled={!allDone}
+      doneLabel={allDone ? "I'm back here" : `${SENSES.reduce((sum, s, i) => sum + Math.min(checks[i], s.count), 0)} / 15`}
+    >
+      <div className="max-w-md mx-auto">
+      <ol className="space-y-3" aria-label="Grounding senses">
+        {SENSES.map((s, i) => {
+          const Icon = s.icon;
+          const count = checks[i];
+          const isActive = i === activeIdx;
+          const isComplete = count >= s.count;
+          // Whole-card tap is enabled only on the active, not-yet-complete
+          // card. Once complete (or for inactive cards), taps are inert so
+          // the user can't keep firing increments while waiting for the
+          // 250ms auto-advance to next sense.
+          const cardTappable = isActive && !isComplete;
+
+          /** Bump the count for this sense by 1, wired to both the card-
+           *  level tap and the legacy keyboard-Enter path. */
+          const bump = () => {
+            if (!cardTappable) return;
+            const next = [...checks];
+            next[i] = Math.min(next[i] + 1, s.count);
+            setChecks(next);
+            if (next[i] >= s.count && i < SENSES.length - 1) {
+              if (advanceTimerRef.current !== null) {
+                window.clearTimeout(advanceTimerRef.current);
+              }
+              advanceTimerRef.current = window.setTimeout(() => {
+                advanceTimerRef.current = null;
+                setActiveIdx(i + 1);
+              }, 250);
+            }
+          };
+
+          return (
+            <li key={s.sense}>
+              <div
+                role={cardTappable ? 'button' : undefined}
+                tabIndex={cardTappable ? 0 : undefined}
+                onClick={bump}
+                onKeyDown={(e) => {
+                  if (!cardTappable) return;
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    bump();
+                  }
+                }}
+                aria-label={cardTappable ? `${s.prompt} Tap to count one.` : undefined}
+                className={`p-4 rounded-2xl border-2 transition-all select-none
+                            ${
+                              isActive
+                                ? 'bg-white border-rose-500 shadow-md'
+                                : isComplete
+                                  ? 'bg-rose-50 border-rose-200'
+                                  : 'bg-white border-rose-100 opacity-50'
+                            }
+                            ${cardTappable ? 'cursor-pointer active:scale-[0.99] active:bg-rose-50' : ''}`}
+              >
+                <div className="flex items-center gap-3 mb-3">
+                  <div
+                    className={`w-9 h-9 rounded-xl flex items-center justify-center
+                                ${isComplete ? 'bg-rose-700 text-white' : 'bg-rose-100 text-rose-700'}`}
+                  >
+                    {isComplete ? <Check size={16} /> : <Icon size={16} />}
+                  </div>
+                  <div className="flex-1">
+                    <p className="text-sm font-semibold text-rose-900">{s.prompt}</p>
+                    {cardTappable && (
+                      <p className="text-[11px] text-rose-700/60 mt-0.5">
+                        Tap anywhere on this card to count one.
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                {/* Visual count indicator — pure indicator, NOT interactive
+                    (taps go through the wrapping card). Avoids nested
+                    interactive elements and keeps the tap target huge. */}
+                <div className="flex gap-2 pl-12" aria-hidden="true">
+                  {Array.from({ length: s.count }).map((_, j) => {
+                    const filled = j < count;
+                    return (
+                      <span
+                        key={j}
+                        className={`w-6 h-6 rounded-full border-2 transition-all
+                                    ${
+                                      filled
+                                        ? 'bg-rose-700 border-rose-700'
+                                        : isActive
+                                          ? 'bg-white border-rose-400'
+                                          : 'bg-stone-100 border-stone-200'
+                                    }`}
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+
+      {/* Completion banner — appears once all 15 dots are filled, auto-
+          scrolls into view, and the screen auto-exits to Reflect a beat
+          later so the user never has to hunt for a Done button at the
+          bottom of a long list. */}
+      {allDone && (
+        <div
+          ref={doneBannerRef}
+          role="status"
+          aria-live="polite"
+          className="mt-4 p-5 rounded-2xl bg-rose-700 text-white text-center
+                     shadow-md animate-in fade-in zoom-in-95 duration-300"
+        >
+          <div className="flex items-center justify-center gap-2 mb-1">
+            <Sparkles size={18} />
+            <p className="font-bold text-base md:text-lg">You're back in the room.</p>
+          </div>
+          <p className="text-xs text-rose-100">
+            Nice grounding. Wrapping up…
+          </p>
+        </div>
+      )}
+      </div>
+    </ActionScreenShell>
+  );
+};

--- a/webapp/components/urgeActions/HALTCheckScreen.tsx
+++ b/webapp/components/urgeActions/HALTCheckScreen.tsx
@@ -1,0 +1,125 @@
+import React, { useState } from 'react';
+import { Activity } from 'lucide-react';
+import { ActionScreenShell } from './ActionScreenShell';
+import { URGE_ACTION_BY_ID } from '../../data/urgeData';
+
+interface ScreenProps {
+  onDone: () => void;
+  onBack: () => void;
+}
+
+type HaltKey = 'hungry' | 'angry' | 'lonely' | 'tired';
+
+const OPTIONS: { key: HaltKey; label: string; emoji: string }[] = [
+  { key: 'hungry', label: 'Hungry', emoji: '🍎' },
+  { key: 'angry', label: 'Angry', emoji: '😤' },
+  { key: 'lonely', label: 'Lonely', emoji: '🫥' },
+  { key: 'tired', label: 'Tired', emoji: '😴' },
+];
+
+/**
+ * Recommendation per HALT axis. We surface ONE merged recommendation rather
+ * than four independent ones — in a crisis, one clear next action is more
+ * useful than a list. Priority order (Hungry > Tired > Angry > Lonely) is
+ * based on which need most reliably amplifies cravings when unmet.
+ */
+const RECS: Record<HaltKey, { headline: string; body: string }> = {
+  hungry: {
+    headline: 'Eat something first.',
+    body: 'Hunger amplifies cravings 2–3×. Even a small snack flips this. Then come back.',
+  },
+  tired: {
+    headline: 'Your willpower is empty.',
+    body: 'Sleep debt destroys impulse control. A 20-min nap or a real bedtime is the move — not gritting through.',
+  },
+  angry: {
+    headline: 'The anger needs an exit.',
+    body: 'Walk fast for 10 minutes, hit a pillow, or write what you wish you could say. Discharge first.',
+  },
+  lonely: {
+    headline: 'You need a person, not a pixel.',
+    body: 'Text one human you trust right now — even a quick "thinking of you". Connection is the actual fix.',
+  },
+};
+
+const PRIORITY: HaltKey[] = ['hungry', 'tired', 'angry', 'lonely'];
+
+/**
+ * HALT check — Hungry / Angry / Lonely / Tired.
+ *
+ * Classic addiction-recovery primer that surfaces the unmet need driving
+ * the urge. Often the urge isn't really about the urge — it's a hunger or
+ * exhaustion signal that's been mis-routed. Naming the actual need takes
+ * the edge off and points at a real fix.
+ */
+export const HALTCheckScreen: React.FC<ScreenProps> = ({ onDone, onBack }) => {
+  const [picked, setPicked] = useState<Set<HaltKey>>(new Set());
+
+  const toggle = (key: HaltKey) => {
+    setPicked((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  // Decide which recommendation to show. Highest-priority picked option
+  // wins. If nothing is picked yet, no recommendation is shown.
+  const topPick = PRIORITY.find((k) => picked.has(k));
+  const rec = topPick ? RECS[topPick] : null;
+
+  return (
+    <ActionScreenShell
+      action={URGE_ACTION_BY_ID.halt_check}
+      icon={Activity}
+      onDone={onDone}
+      onBack={onBack}
+      doneDisabled={picked.size === 0}
+      doneLabel={picked.size === 0 ? 'Tick at least one' : 'I see what this is'}
+    >
+      <div className="max-w-md mx-auto">
+        <p className="text-sm text-rose-800 mb-4 text-center">
+          Tick anything you are right now. Be honest.
+        </p>
+
+        <div className="grid grid-cols-2 gap-3 mb-6">
+          {OPTIONS.map((o) => {
+            const isOn = picked.has(o.key);
+            return (
+              <button
+                key={o.key}
+                onClick={() => toggle(o.key)}
+                aria-pressed={isOn}
+                className={`p-4 rounded-2xl border-2 transition-all flex flex-col items-center gap-2
+                            ${
+                              isOn
+                                ? 'bg-rose-100 border-rose-500 shadow-md'
+                                : 'bg-white border-rose-100 hover:border-rose-300'
+                            }`}
+              >
+                <span className="text-3xl" aria-hidden="true">
+                  {o.emoji}
+                </span>
+                <span className="font-semibold text-rose-900">{o.label}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        {rec && (
+          <div className="bg-rose-700 text-white p-5 rounded-2xl shadow-md animate-in fade-in slide-in-from-bottom-2 duration-300">
+            <p className="font-bold text-lg mb-1">{rec.headline}</p>
+            <p className="text-sm text-rose-100 leading-relaxed">{rec.body}</p>
+            {picked.size > 1 && (
+              <p className="text-xs text-rose-200 mt-3 italic">
+                More than one ticked? Start with this — the rest will get easier once it's
+                handled.
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    </ActionScreenShell>
+  );
+};

--- a/webapp/components/urgeActions/LeaveRoomScreen.tsx
+++ b/webapp/components/urgeActions/LeaveRoomScreen.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react';
+import { Footprints } from 'lucide-react';
+import { ActionScreenShell } from './ActionScreenShell';
+import { URGE_ACTION_BY_ID } from '../../data/urgeData';
+
+interface ScreenProps {
+  onDone: () => void;
+  onBack: () => void;
+}
+
+/** A single 60-second reorientation window. Long enough to actually walk
+ *  to another room and breathe; short enough that the user doesn't feel
+ *  trapped on the screen. */
+const TOTAL_SECONDS = 60;
+
+/**
+ * Leave the Room — 60-second reorient.
+ *
+ * Just enough structure to get the user up and moving. The screen shows a
+ * calm gradient, a slow countdown, and a single line of breath guidance.
+ * The point isn't the timer — the point is that the user is no longer in
+ * the trigger room. The timer just gives them permission to do nothing
+ * for a minute while their nervous system catches up.
+ */
+export const LeaveRoomScreen: React.FC<ScreenProps> = ({ onDone, onBack }) => {
+  const [secondsLeft, setSecondsLeft] = useState(TOTAL_SECONDS);
+  const done = secondsLeft <= 0;
+
+  useEffect(() => {
+    if (done) return;
+    const id = window.setInterval(() => setSecondsLeft((s) => s - 1), 1000);
+    return () => window.clearInterval(id);
+  }, [done]);
+
+  return (
+    <ActionScreenShell
+      action={URGE_ACTION_BY_ID.leave_room}
+      icon={Footprints}
+      onDone={onDone}
+      onBack={onBack}
+      doneDisabled={!done}
+      doneLabel={done ? "I'm in a new space" : `${secondsLeft}s — keep walking`}
+    >
+      <div className="flex flex-col items-center justify-center min-h-[50vh] gap-8">
+        <p className="text-base md:text-lg text-rose-900 font-medium text-center max-w-sm">
+          Stand up and walk to a different room. Any room. Bathroom, kitchen, balcony.
+        </p>
+
+        {/* Calm pulsing dot — visual cue to slow breath while walking. */}
+        <div className="relative w-40 h-40 flex items-center justify-center">
+          <span
+            aria-hidden="true"
+            className="absolute inset-0 rounded-full bg-rose-300/40 animate-ping"
+          />
+          <span
+            aria-hidden="true"
+            className="absolute inset-2 rounded-full bg-rose-200/60"
+          />
+          <span className="relative text-5xl font-light text-rose-900 tabular-nums">
+            {secondsLeft > 0 ? secondsLeft : '✓'}
+          </span>
+        </div>
+
+        <p className="text-sm text-rose-700/70 text-center max-w-xs">
+          {done
+            ? 'You changed your environment. The pattern just broke.'
+            : 'Slow breath in. Slow breath out. Keep moving.'}
+        </p>
+      </div>
+    </ActionScreenShell>
+  );
+};

--- a/webapp/components/urgeActions/LetterEditor.tsx
+++ b/webapp/components/urgeActions/LetterEditor.tsx
@@ -1,0 +1,122 @@
+import React, { useId, useState } from 'react';
+import { Check } from 'lucide-react';
+import type { FutureSelfLetter } from '../../src/lib/urgeLog';
+
+type LetterDraft = Pick<FutureSelfLetter, 'values' | 'identity' | 'message'>;
+
+interface LetterEditorProps {
+  initial: LetterDraft;
+  onSave: (letter: LetterDraft) => void;
+  /** Override the default save-button copy ("Save letter") when a more
+   *  specific verb fits the host context. */
+  saveLabel?: string;
+  /** Called after a successful save AND optional close — used by Settings to
+   *  show a momentary success state. */
+  onSaveSuccess?: () => void;
+}
+
+/**
+ * Three-field editor for the Future-Self Letter.
+ *
+ * Lifted out of FutureSelfLetterScreen so the same component can be reused
+ * by the Settings "Your Future-Self Letter" section. Single source of truth
+ * for the field shape, validation, and copy.
+ */
+export const LetterEditor: React.FC<LetterEditorProps> = ({
+  initial,
+  onSave,
+  saveLabel = 'Save letter',
+  onSaveSuccess,
+}) => {
+  const [values, setValues] = useState(initial.values);
+  const [identity, setIdentity] = useState(initial.identity);
+  const [message, setMessage] = useState(initial.message);
+
+  // Per-instance ID prefix so two LetterEditors mounted simultaneously
+  // (e.g. Settings panel + an action screen modal in some future flow)
+  // don't collide on `for`/`id` pairs.
+  const baseId = useId();
+  const valuesId = `${baseId}-values`;
+  const identityId = `${baseId}-identity`;
+  const messageId = `${baseId}-message`;
+
+  const isValid =
+    values.trim().length > 0 && identity.trim().length > 0 && message.trim().length > 0;
+
+  const handleSave = () => {
+    if (!isValid) return;
+    onSave({ values, identity, message });
+    onSaveSuccess?.();
+  };
+
+  return (
+    <div className="space-y-4">
+      <section>
+        <label
+          htmlFor={valuesId}
+          className="block text-xs font-bold uppercase tracking-wider text-rose-700/70 mb-1"
+        >
+          Three things that matter most to you
+        </label>
+        <input
+          id={valuesId}
+          value={values}
+          onChange={(e) => setValues(e.target.value)}
+          placeholder="e.g. my health, my partner, my work"
+          className="w-full p-3 bg-white border border-rose-200 rounded-xl text-sm text-rose-900
+                     placeholder-rose-400/60 focus:outline-none focus:ring-2 focus:ring-rose-300"
+        />
+      </section>
+
+      <section>
+        <label
+          htmlFor={identityId}
+          className="block text-xs font-bold uppercase tracking-wider text-rose-700/70 mb-1"
+        >
+          Who you are becoming
+        </label>
+        <input
+          id={identityId}
+          value={identity}
+          onChange={(e) => setIdentity(e.target.value)}
+          placeholder="e.g. someone who keeps promises to themselves"
+          className="w-full p-3 bg-white border border-rose-200 rounded-xl text-sm text-rose-900
+                     placeholder-rose-400/60 focus:outline-none focus:ring-2 focus:ring-rose-300"
+        />
+      </section>
+
+      <section>
+        <label
+          htmlFor={messageId}
+          className="block text-xs font-bold uppercase tracking-wider text-rose-700/70 mb-1"
+        >
+          A message to yourself, in this exact moment
+        </label>
+        <textarea
+          id={messageId}
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          rows={5}
+          placeholder="Write what you need to hear right now."
+          className="w-full p-3 bg-white border border-rose-200 rounded-xl text-sm text-rose-900
+                     placeholder-rose-400/60 focus:outline-none focus:ring-2 focus:ring-rose-300"
+        />
+      </section>
+
+      <button
+        onClick={handleSave}
+        disabled={!isValid}
+        className={`w-full inline-flex items-center justify-center gap-2 px-6 py-3 rounded-xl
+                    font-semibold text-sm transition-all
+                    ${
+                      isValid
+                        ? 'bg-rose-700 text-white shadow-md hover:bg-rose-800'
+                        : 'bg-rose-200 text-rose-400 cursor-not-allowed'
+                    }`}
+      >
+        <Check size={16} />
+        {saveLabel}
+      </button>
+    </div>
+  );
+};

--- a/webapp/components/urgeActions/PhoneAwayScreen.tsx
+++ b/webapp/components/urgeActions/PhoneAwayScreen.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useState } from 'react';
+import { PhoneOff } from 'lucide-react';
+import { ActionScreenShell } from './ActionScreenShell';
+import { URGE_ACTION_BY_ID } from '../../data/urgeData';
+
+interface ScreenProps {
+  onDone: () => void;
+  onBack: () => void;
+}
+
+const TOTAL_SECONDS = 15 * 60;
+
+/**
+ * Phone Away — 15-minute soft timer.
+ *
+ * Browser apps cannot enforce a real lock, so this screen is built on
+ * trust: it explains *why* distance from the device matters, sets a clear
+ * 15-minute target, and gets out of the user's way. The Back button is
+ * always available — we never trap users — but the copy reframes early
+ * exit as costing them the whole point of the exercise.
+ */
+export const PhoneAwayScreen: React.FC<ScreenProps> = ({ onDone, onBack }) => {
+  const [secondsLeft, setSecondsLeft] = useState(TOTAL_SECONDS);
+  const done = secondsLeft <= 0;
+
+  useEffect(() => {
+    if (done) return;
+    const id = window.setInterval(() => setSecondsLeft((s) => s - 1), 1000);
+    return () => window.clearInterval(id);
+  }, [done]);
+
+  const minutes = Math.floor(secondsLeft / 60);
+  const seconds = secondsLeft % 60;
+  const display = `${minutes}:${seconds.toString().padStart(2, '0')}`;
+
+  return (
+    <ActionScreenShell
+      action={URGE_ACTION_BY_ID.phone_away}
+      icon={PhoneOff}
+      onDone={onDone}
+      onBack={onBack}
+      doneDisabled={!done}
+      doneLabel={done ? 'I made it the full 15' : 'Put the phone down'}
+    >
+      <div className="flex flex-col items-center justify-center min-h-[55vh] gap-6">
+        <p className="text-base md:text-lg text-rose-900 font-medium text-center max-w-sm">
+          Place this phone screen-down in a different room. Set it on a shelf, a fridge,
+          anywhere out of arm's reach.
+        </p>
+
+        <div className="text-7xl md:text-8xl font-light text-rose-900 tabular-nums tracking-tight">
+          {display}
+        </div>
+
+        <div className="text-center max-w-xs space-y-2">
+          <p className="text-sm text-rose-700/80">
+            {done
+              ? "You made it the full 15. The urge has almost certainly passed by now."
+              : 'Distance from the trigger device drops urge intensity faster than anything else on this list.'}
+          </p>
+          <p className="text-[11px] text-rose-700/50 italic">
+            Back button is here if you really need it — but every minute counts.
+          </p>
+        </div>
+      </div>
+    </ActionScreenShell>
+  );
+};

--- a/webapp/components/urgeActions/PhysicalBurstScreen.tsx
+++ b/webapp/components/urgeActions/PhysicalBurstScreen.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+import { Dumbbell, Plus, RotateCcw } from 'lucide-react';
+import { ActionScreenShell } from './ActionScreenShell';
+import { URGE_ACTION_BY_ID } from '../../data/urgeData';
+
+interface ScreenProps {
+  onDone: () => void;
+  onBack: () => void;
+}
+
+const TARGET = 20;
+
+/** Encouragement messages keyed by count threshold. The thresholds are
+ *  spaced so the user gets a fresh reinforcement every five reps without
+ *  becoming noisy. */
+const MILESTONES: { at: number; copy: string }[] = [
+  { at: 5, copy: 'Your heart rate is climbing. Keep going.' },
+  { at: 10, copy: 'Halfway there. The urge is burning off.' },
+  { at: 15, copy: "Almost done. You're stronger than this." },
+  { at: 20, copy: 'Done. Your body just used the urge instead of you.' },
+];
+
+/**
+ * Physical burst — tap-to-count to 20 push-ups (or any equivalent burst).
+ *
+ * The tap-counter is the entire point: each tap is a deliberate beat the
+ * user controls, which competes with the autopilot of the urge. We don't
+ * bother with motion sensors — taps are accessible and unambiguous.
+ *
+ * The "Reset" button is intentional in case the user loses count or wants
+ * a second round.
+ */
+export const PhysicalBurstScreen: React.FC<ScreenProps> = ({ onDone, onBack }) => {
+  const [count, setCount] = useState(0);
+  const reached = count >= TARGET;
+
+  // Find the highest milestone at or below the current count for the
+  // encouragement text. Default to the start prompt before any reps.
+  const milestone =
+    [...MILESTONES].reverse().find((m) => count >= m.at)?.copy ??
+    'Tap each rep. Stand up first if you need to.';
+
+  return (
+    <ActionScreenShell
+      action={URGE_ACTION_BY_ID.physical_burst}
+      icon={Dumbbell}
+      onDone={onDone}
+      onBack={onBack}
+      doneDisabled={!reached}
+      doneLabel={reached ? 'I burned it off' : `${count} / ${TARGET}`}
+    >
+      <div className="flex flex-col items-center justify-center min-h-[50vh]">
+        {/* Big tappable counter — the primary interaction. Sized so the
+            user can tap it without looking after the first few reps. */}
+        <button
+          onClick={() => setCount((c) => Math.min(c + 1, TARGET))}
+          disabled={reached}
+          aria-label="Add one rep"
+          className={`relative w-56 h-56 rounded-full flex flex-col items-center justify-center
+                      shadow-xl transition-all active:scale-95
+                      ${
+                        reached
+                          ? 'bg-emerald-600 text-white'
+                          : 'bg-rose-700 text-white hover:bg-rose-800'
+                      }`}
+        >
+          <span className="text-7xl font-light tabular-nums leading-none">{count}</span>
+          <span className="text-xs font-semibold uppercase tracking-widest mt-2 opacity-80">
+            of {TARGET}
+          </span>
+          {!reached && (
+            <span className="absolute bottom-6 inline-flex items-center gap-1 text-[11px] font-semibold opacity-80">
+              <Plus size={12} />
+              Tap to count
+            </span>
+          )}
+        </button>
+
+        <p className="mt-6 text-sm md:text-base text-rose-800 text-center max-w-xs font-medium">
+          {milestone}
+        </p>
+
+        {count > 0 && (
+          <button
+            onClick={() => setCount(0)}
+            className="mt-4 inline-flex items-center gap-1 text-xs text-rose-700/70 hover:text-rose-900 transition-colors"
+          >
+            <RotateCcw size={12} />
+            Reset
+          </button>
+        )}
+      </div>
+    </ActionScreenShell>
+  );
+};

--- a/webapp/components/urgeActions/PlayTheTapeScreen.tsx
+++ b/webapp/components/urgeActions/PlayTheTapeScreen.tsx
@@ -1,0 +1,158 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Film } from 'lucide-react';
+import { ActionScreenShell } from './ActionScreenShell';
+import { URGE_ACTION_BY_ID } from '../../data/urgeData';
+
+interface ScreenProps {
+  onDone: () => void;
+  onBack: () => void;
+}
+
+/**
+ * Five scenes, each with its own auto-advance window.
+ *
+ * Per-scene timing because the cognitive load varies: visualization-heavy
+ * scenes (1, 2) and the deepest reflective question (4) need more breathing
+ * room; the closing identity statement (5) lands fast. Total ~38s if the
+ * user lets it run, but they can tap to skip ahead at any moment.
+ */
+const SCENES: { text: string; ms: number }[] = [
+  { text: 'Imagine the morning after.', ms: 8000 },
+  { text: 'How does your body feel? What do you see in the mirror?', ms: 8000 },
+  { text: 'What did you trade away for those few minutes?', ms: 7000 },
+  { text: 'What did you actually want underneath the urge?', ms: 9000 },
+  { text: "This is who you're becoming, with every choice like this one.", ms: 6000 },
+];
+
+/** Delay before the "Tap when ready" hint appears on each scene. We don't
+ *  want the hint to crowd the moment a scene first lands. */
+const HINT_DELAY_MS = 3000;
+
+/**
+ * Play the Tape Forward — guided visualization with hybrid pacing.
+ *
+ * The exercise is a classic relapse-prevention technique: instead of
+ * fighting the impulse head-on, you walk forward through the consequences
+ * and notice the gap between the imagined dopamine and the real aftermath.
+ *
+ * Pacing is hybrid by design:
+ *   - **Auto-advance** handles the default case — the user can just sit
+ *     and let each scene wash over them. Per-scene durations give heavier
+ *     scenes more room to land.
+ *   - **Tap-to-skip** lets the engaged user move on the moment a scene
+ *     lands. A subtle "Tap when ready" hint appears mid-scene so the
+ *     option is discoverable without being loud.
+ *
+ * No back, no pause — every extra control is friction in a crisis.
+ */
+export const PlayTheTapeScreen: React.FC<ScreenProps> = ({ onDone, onBack }) => {
+  const [sceneIdx, setSceneIdx] = useState(0);
+  /** Hint visibility per scene — flipped true after HINT_DELAY_MS so the
+   *  cue doesn't appear at the same moment the scene does. */
+  const [showHint, setShowHint] = useState(false);
+
+  const isLast = sceneIdx === SCENES.length - 1;
+  const advanceTimerRef = useRef<number | null>(null);
+  const hintTimerRef = useRef<number | null>(null);
+
+  /** Move to the next scene (auto or via tap). On the last scene this is a
+   *  no-op — the user must use the shell's Done CTA to finish, which gives
+   *  the closing identity line a clear "this is the wrap" feel. */
+  const advance = () => {
+    if (isLast) return;
+    setSceneIdx((i) => i + 1);
+  };
+
+  useEffect(() => {
+    // Reset the hint each time we land on a new scene, then schedule both
+    // the hint and the auto-advance from this same effect so they stay in
+    // sync (and a single cleanup tears both down on unmount or skip).
+    setShowHint(false);
+
+    hintTimerRef.current = window.setTimeout(() => {
+      hintTimerRef.current = null;
+      setShowHint(true);
+    }, HINT_DELAY_MS);
+
+    if (!isLast) {
+      advanceTimerRef.current = window.setTimeout(() => {
+        advanceTimerRef.current = null;
+        setSceneIdx((i) => i + 1);
+      }, SCENES[sceneIdx].ms);
+    }
+
+    return () => {
+      if (advanceTimerRef.current !== null) {
+        window.clearTimeout(advanceTimerRef.current);
+        advanceTimerRef.current = null;
+      }
+      if (hintTimerRef.current !== null) {
+        window.clearTimeout(hintTimerRef.current);
+        hintTimerRef.current = null;
+      }
+    };
+  }, [sceneIdx, isLast]);
+
+  // Footer copy hierarchy: closing scene copy > scene-mid hint > opening
+  // settle prompt. Hoisted out of JSX so the conditional reads top-to-bottom.
+  const footerCopy = isLast
+    ? "Last one. Take it in, then tap Done below."
+    : showHint
+      ? "Tap the card when you're ready to move on."
+      : 'Let each line land before the next one comes.';
+
+  return (
+    <ActionScreenShell
+      action={URGE_ACTION_BY_ID.play_the_tape}
+      icon={Film}
+      onDone={onDone}
+      onBack={onBack}
+      doneDisabled={!isLast}
+      doneLabel={isLast ? 'I saw it' : `${sceneIdx + 1} / ${SCENES.length}`}
+    >
+      <div className="flex flex-col items-center justify-center min-h-[55vh] px-2">
+        {/* Scene card — tapping anywhere on it skips ahead. Kept as a
+            button (vs role+tabindex on a div) for native keyboard support
+            and the right cursor on hover. Disabled on the last scene so
+            an accidental tap doesn't feel broken — the user uses Done. */}
+        <button
+          key={sceneIdx}
+          onClick={advance}
+          disabled={isLast}
+          aria-label={isLast ? SCENES[sceneIdx].text : `${SCENES[sceneIdx].text} Tap to continue.`}
+          className="bg-white border border-rose-100 rounded-2xl p-8 md:p-10 shadow-md max-w-md w-full
+                     animate-in fade-in zoom-in-95 duration-700 text-left
+                     enabled:cursor-pointer enabled:active:scale-[0.99] enabled:hover:border-rose-300
+                     transition-all"
+        >
+          <p className="text-lg md:text-xl text-rose-900 font-medium leading-relaxed text-center">
+            {SCENES[sceneIdx].text}
+          </p>
+        </button>
+
+        {/* Slow progress dots so the user knows the rhythm. */}
+        <div className="mt-8 flex items-center gap-1.5" role="presentation">
+          {SCENES.map((_, i) => (
+            <span
+              key={i}
+              className={`w-1.5 h-1.5 rounded-full transition-colors ${
+                i <= sceneIdx ? 'bg-rose-700' : 'bg-rose-200'
+              }`}
+            />
+          ))}
+        </div>
+
+        {/* Footer copy — swaps from the meditative "let it land" prompt
+            to the discoverability hint after HINT_DELAY_MS. The hint is
+            intentionally low-contrast italic so it never overshadows the
+            scene itself. */}
+        <p
+          className={`mt-6 text-xs italic text-center max-w-xs transition-colors duration-500
+                      ${showHint && !isLast ? 'text-rose-700/80' : 'text-rose-700/60'}`}
+        >
+          {footerCopy}
+        </p>
+      </div>
+    </ActionScreenShell>
+  );
+};

--- a/webapp/components/urgeActions/UrgeJournalScreen.tsx
+++ b/webapp/components/urgeActions/UrgeJournalScreen.tsx
@@ -1,0 +1,135 @@
+import React, { useState } from 'react';
+import { PenTool, Check } from 'lucide-react';
+import { ActionScreenShell } from './ActionScreenShell';
+import { URGE_ACTION_BY_ID } from '../../data/urgeData';
+import { appendJournal } from '../../src/lib/urgeLog';
+
+interface ScreenProps {
+  onDone: () => void;
+  onBack: () => void;
+}
+
+const TRIGGER_CHIPS = [
+  'Phone',
+  'Boredom',
+  'Late night',
+  'Stress',
+  'Loneliness',
+  'Conflict',
+  'Specific memory',
+  'Other',
+];
+
+/**
+ * Urge Journal — 3 quick fields.
+ *
+ * The act of putting words to the urge weakens it (affect labeling). We
+ * keep the form micro-light: chip-based trigger picker, an optional 1-10
+ * intensity slider, and a single short note field. No required fields,
+ * because in a crisis the user shouldn't have to fight a form.
+ *
+ * Note: the journal output is currently visualized only via Done. Future-
+ * iteration: surface in Dashboard or Coach context. Out-of-scope for #34.
+ */
+export const UrgeJournalScreen: React.FC<ScreenProps> = ({ onDone, onBack }) => {
+  const [trigger, setTrigger] = useState<string | null>(null);
+  const [intensity, setIntensity] = useState<number>(5);
+  const [note, setNote] = useState('');
+
+  // No hard requirement — but Done is dimmed until at least one field has
+  // signal so the user knows something's expected.
+  const hasContent = trigger !== null || note.trim().length > 0;
+
+  /** Persist the journal entry to localStorage before the orchestrator
+   *  closes the screen. Wrapping `onDone` so the caller stays unchanged. */
+  const handleDone = () => {
+    if (!hasContent) return;
+    const now = Date.now();
+    appendJournal({
+      id: now,
+      savedAt: new Date(now).toISOString(),
+      trigger,
+      intensity,
+      note: note.trim(),
+    });
+    onDone();
+  };
+
+  return (
+    <ActionScreenShell
+      action={URGE_ACTION_BY_ID.urge_journal}
+      icon={PenTool}
+      onDone={handleDone}
+      onBack={onBack}
+      doneDisabled={!hasContent}
+      doneLabel={hasContent ? "I named it" : 'Add a trigger or note'}
+    >
+      <div className="max-w-md mx-auto space-y-5">
+        {/* Trigger chips */}
+        <section>
+          <label className="block text-xs font-bold uppercase tracking-wider text-rose-700/70 mb-2">
+            What triggered it?
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {TRIGGER_CHIPS.map((chip) => {
+              const isOn = trigger === chip;
+              return (
+                <button
+                  key={chip}
+                  onClick={() => setTrigger(isOn ? null : chip)}
+                  aria-pressed={isOn}
+                  className={`px-3 py-1.5 rounded-full text-sm font-medium transition-all
+                              ${
+                                isOn
+                                  ? 'bg-rose-700 text-white shadow-sm'
+                                  : 'bg-white text-rose-800 border border-rose-200 hover:bg-rose-50'
+                              }`}
+                >
+                  {isOn && <Check size={12} className="inline mr-1" />}
+                  {chip}
+                </button>
+              );
+            })}
+          </div>
+        </section>
+
+        {/* Intensity */}
+        <section className="bg-white border border-rose-100 rounded-2xl p-4">
+          <div className="flex items-baseline justify-between mb-2">
+            <label className="text-xs font-bold uppercase tracking-wider text-rose-700/70">
+              Intensity
+            </label>
+            <span className="text-sm font-bold text-rose-900 tabular-nums">{intensity}</span>
+          </div>
+          <input
+            type="range"
+            min={1}
+            max={10}
+            value={intensity}
+            onChange={(e) => setIntensity(parseInt(e.target.value, 10))}
+            className="w-full accent-rose-700"
+          />
+        </section>
+
+        {/* Note */}
+        <section>
+          <label
+            htmlFor="urge-journal-note"
+            className="block text-xs font-bold uppercase tracking-wider text-rose-700/70 mb-2"
+          >
+            One sentence (optional)
+          </label>
+          <textarea
+            id="urge-journal-note"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="What were you doing? What were you avoiding?"
+            rows={3}
+            className="w-full p-3 bg-white border border-rose-200 rounded-xl text-sm text-rose-900
+                       placeholder-rose-400/60 focus:outline-none focus:ring-2 focus:ring-rose-300"
+          />
+        </section>
+      </div>
+    </ActionScreenShell>
+  );
+};

--- a/webapp/components/urgeActions/index.ts
+++ b/webapp/components/urgeActions/index.ts
@@ -1,0 +1,43 @@
+// Registry of action mini-screens consumed by the UrgeHelp orchestrator.
+//
+// Map structure: action ID → component. The orchestrator looks up the
+// active action by id and renders the matching screen with `onDone` and
+// `onBack` callbacks. Keeping the registry here (separate from urgeData.ts)
+// preserves urgeData.ts as a JSX-free pure data module.
+
+import type { UrgeActionId } from '../../types';
+import { BoxBreathingScreen } from './BoxBreathingScreen';
+import { ColdWaterScreen } from './ColdWaterScreen';
+import { PhysicalBurstScreen } from './PhysicalBurstScreen';
+import { Grounding54321Screen } from './Grounding54321Screen';
+import { HALTCheckScreen } from './HALTCheckScreen';
+import { LeaveRoomScreen } from './LeaveRoomScreen';
+import { PhoneAwayScreen } from './PhoneAwayScreen';
+import { UrgeJournalScreen } from './UrgeJournalScreen';
+import { FutureSelfLetterScreen } from './FutureSelfLetterScreen';
+import { PlayTheTapeScreen } from './PlayTheTapeScreen';
+
+export interface UrgeActionScreenProps {
+  onDone: () => void;
+  onBack: () => void;
+}
+
+export const URGE_ACTION_SCREENS: Record<
+  UrgeActionId,
+  React.ComponentType<UrgeActionScreenProps>
+> = {
+  box_breathing: BoxBreathingScreen,
+  cold_water: ColdWaterScreen,
+  physical_burst: PhysicalBurstScreen,
+  grounding_54321: Grounding54321Screen,
+  halt_check: HALTCheckScreen,
+  leave_room: LeaveRoomScreen,
+  phone_away: PhoneAwayScreen,
+  urge_journal: UrgeJournalScreen,
+  future_self_letter: FutureSelfLetterScreen,
+  play_the_tape: PlayTheTapeScreen,
+};
+
+// Re-export the shell so external consumers (Settings letter editor, future
+// onboarding) can reuse it without reaching into the action sub-tree.
+export { ActionScreenShell } from './ActionScreenShell';

--- a/webapp/components/urgeHelp/ActStage.tsx
+++ b/webapp/components/urgeHelp/ActStage.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import {
+  Wind,
+  Droplets,
+  Dumbbell,
+  Eye,
+  Activity,
+  Footprints,
+  PhoneOff,
+  PenTool,
+  Mail,
+  Film,
+  Sparkles,
+} from 'lucide-react';
+import type { FeelingId, UrgeAction, UrgeActionId } from '../../types';
+import { URGE_ACTIONS, URGE_CATEGORY_META } from '../../data/urgeData';
+
+interface ActStageProps {
+  feeling: FeelingId | null;
+  /** Action IDs the user already opened this session — shown with a quiet
+   *  "tried" mark so they know what they've explored without losing access. */
+  triedActionIds: UrgeActionId[];
+  onPickAction: (id: UrgeActionId) => void;
+}
+
+/** Visual mapping action-id → icon. Kept here (not in urgeData.ts) so the
+ *  data file stays free of React/JSX imports — pure data is easier to test
+ *  and serialize. */
+const ACTION_ICONS: Record<UrgeActionId, React.ComponentType<{ size?: number; className?: string }>> = {
+  box_breathing: Wind,
+  cold_water: Droplets,
+  physical_burst: Dumbbell,
+  grounding_54321: Eye,
+  halt_check: Activity,
+  leave_room: Footprints,
+  phone_away: PhoneOff,
+  urge_journal: PenTool,
+  future_self_letter: Mail,
+  play_the_tape: Film,
+};
+
+/**
+ * Stage 3 — Act.
+ *
+ * Surfaces all 10 evidence-based actions, grouped by category (Reset,
+ * Ground, Protect, Reframe). The grid is intentionally NOT a flat list:
+ * categories give the user a mental model of the kinds of help available,
+ * so picking feels like choosing a tool from a labelled toolbox rather
+ * than scrolling through tips.
+ *
+ * Two UX-friendly touches make the grid scannable in a moment of crisis:
+ *   1. **Recommended badges** — 1–2 cards per session get a "best fit"
+ *      sparkle accent based on the feeling picked in Stage 2 (driven by
+ *      `URGE_ACTIONS[i].recommendedFor`). This handles the analysis paralysis
+ *      that a 10-card grid would otherwise cause.
+ *   2. **Stagger-fade entrance** — cards fade in 50ms apart, capped, so the
+ *      grid feels alive instead of slamming in all at once.
+ */
+export const ActStage: React.FC<ActStageProps> = ({ feeling, triedActionIds, onPickAction }) => {
+  // Compute the recommended set once. We always show at most 2 highlights so
+  // the badge stays meaningful — recommending half the grid is recommending
+  // nothing. Falls back to an empty set when the user skipped feeling
+  // selection (shouldn't happen via normal flow, but is safe).
+  const recommendedIds = React.useMemo<Set<UrgeActionId>>(() => {
+    if (!feeling) return new Set();
+    const matches = URGE_ACTIONS.filter((a) => a.recommendedFor.includes(feeling));
+    return new Set(matches.slice(0, 2).map((a) => a.id));
+  }, [feeling]);
+
+  // Bucket actions by category so each section can render its own header.
+  // Order matches the order in URGE_ACTIONS so the user sees the strongest
+  // physiological resets first.
+  const grouped = React.useMemo(() => {
+    const buckets: Record<string, UrgeAction[]> = { reset: [], ground: [], protect: [], reframe: [] };
+    for (const a of URGE_ACTIONS) buckets[a.category].push(a);
+    return buckets;
+  }, []);
+
+  // Index used to drive the stagger-fade animation across category boundaries.
+  let cardIndex = 0;
+
+  return (
+    <div className="flex-1 overflow-y-auto pb-28 md:pb-8 animate-in fade-in duration-300">
+      <div className="px-4 md:px-6 max-w-3xl mx-auto">
+        <header className="text-center mt-6 md:mt-8 mb-6 md:mb-8">
+          <p className="text-[10px] font-semibold text-rose-700/60 uppercase tracking-widest mb-2">
+            Stage 3 of 4
+          </p>
+          <h2 className="text-2xl md:text-3xl font-bold text-rose-900 mb-2">
+            Pick one action.
+          </h2>
+          <p className="text-sm md:text-base text-rose-700/80 max-w-md mx-auto">
+            Don't fight the urge. Replace the next 5 minutes.
+          </p>
+        </header>
+
+        <div className="space-y-6">
+          {(['reset', 'ground', 'protect', 'reframe'] as const).map((cat) => {
+            const meta = URGE_CATEGORY_META[cat];
+            const items = grouped[cat];
+            return (
+              <section key={cat} aria-label={meta.label}>
+                {/* Quiet category header — informational, not loud. The
+                    subtitle is the one-liner that tells the user what this
+                    bucket does for them. */}
+                <div className="mb-3 px-1">
+                  <h3 className={`text-xs font-bold uppercase tracking-wider ${meta.accent}`}>
+                    {meta.label}
+                  </h3>
+                  <p className="text-xs text-rose-700/60">{meta.subtitle}</p>
+                </div>
+
+                <div className="grid grid-cols-2 gap-3">
+                  {items.map((action) => {
+                    const Icon = ACTION_ICONS[action.id];
+                    const isRecommended = recommendedIds.has(action.id);
+                    const isTried = triedActionIds.includes(action.id);
+                    const i = cardIndex++;
+
+                    return (
+                      <button
+                        key={action.id}
+                        onClick={() => onPickAction(action.id)}
+                        className={`relative text-left p-4 rounded-2xl border bg-white transition-all
+                                    hover:-translate-y-0.5 hover:shadow-md active:scale-[0.98]
+                                    animate-in fade-in slide-in-from-bottom-2 duration-300
+                                    ${
+                                      isRecommended
+                                        ? 'border-rose-500 ring-2 ring-rose-200 shadow-md'
+                                        : 'border-rose-100 hover:border-rose-300'
+                                    }`}
+                        // Cap the stagger at 400ms so even the last card
+                        // appears within ~half a second — the grid should
+                        // feel alive, not slow.
+                        style={{
+                          animationDelay: `${Math.min(i * 50, 400)}ms`,
+                          animationFillMode: 'backwards',
+                        }}
+                      >
+                        {/* Recommended badge — top-right corner, soft */}
+                        {isRecommended && (
+                          <span
+                            aria-label="Recommended for what you're feeling"
+                            className="absolute top-2 right-2 inline-flex items-center gap-1
+                                       px-1.5 py-0.5 rounded-full bg-rose-700 text-white
+                                       text-[9px] font-bold uppercase tracking-wider"
+                          >
+                            <Sparkles size={9} />
+                            <span>Best fit</span>
+                          </span>
+                        )}
+
+                        {/* Already tried indicator — quiet checkmark dot,
+                            doesn't disable the card so users can re-open. */}
+                        {isTried && !isRecommended && (
+                          <span
+                            aria-label="You opened this earlier"
+                            className="absolute top-2 right-2 w-2 h-2 rounded-full bg-rose-400"
+                          />
+                        )}
+
+                        <div
+                          className={`mb-2 inline-flex items-center justify-center w-10 h-10 rounded-xl
+                                       ${meta.tint} ${meta.accent}`}
+                        >
+                          <Icon size={20} />
+                        </div>
+
+                        <div className="font-semibold text-rose-900 text-sm leading-tight mb-1">
+                          {action.title}
+                        </div>
+                        <p className="text-[11px] md:text-xs text-rose-700/70 leading-snug">
+                          {action.whyItWorks}
+                        </p>
+                      </button>
+                    );
+                  })}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/webapp/components/urgeHelp/CoachModal.tsx
+++ b/webapp/components/urgeHelp/CoachModal.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { X, Brain } from 'lucide-react';
+import type { CheckIn, ChatMessage, UrgeContextSeed } from '../../types';
+import { AICoach } from '../AICoach';
+
+interface CoachModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** Live urge state passed through to AICoach so the system prompt is
+   *  seeded with feeling/intensity/action/elapsed. */
+  seed: UrgeContextSeed | null;
+  // Same coach state the App owns — keeps the modal session continuous
+  // with the dedicated Coach view (no parallel conversations).
+  checkInHistory: CheckIn[];
+  messages: ChatMessage[];
+  setMessages: React.Dispatch<React.SetStateAction<ChatMessage[]>>;
+}
+
+/**
+ * Slide-up sheet wrapping the existing AICoach component.
+ *
+ * Designed so the user never leaves the Help flow when they need backup —
+ * the urge-session state stays intact behind the modal, and dismissing
+ * returns them to whatever stage they were on.
+ *
+ * Mobile: full-width sheet that fills the bottom 90% of the screen.
+ * Desktop: centered card with a max-width.
+ */
+export const CoachModal: React.FC<CoachModalProps> = ({
+  open,
+  onClose,
+  seed,
+  checkInHistory,
+  messages,
+  setMessages,
+}) => {
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="AI Coach"
+      className="fixed inset-0 z-50 flex items-end md:items-center justify-center
+                 bg-stone-900/40 backdrop-blur-sm animate-in fade-in duration-200"
+      onClick={onClose}
+    >
+      <div
+        // Stop click propagation so taps inside the sheet don't dismiss it.
+        onClick={(e) => e.stopPropagation()}
+        className="bg-purple-50 w-full md:max-w-2xl md:rounded-2xl rounded-t-3xl
+                   max-h-[90vh] md:max-h-[85vh] flex flex-col overflow-hidden shadow-2xl
+                   animate-in slide-in-from-bottom-8 md:zoom-in-95 duration-300"
+      >
+        {/* Compact header — matches the AICoach palette so it doesn't feel
+            like a different surface. */}
+        <header className="flex-shrink-0 flex items-center justify-between px-4 py-3 bg-purple-100 border-b border-purple-200">
+          <div className="flex items-center gap-2">
+            <div className="bg-purple-700 text-white p-1.5 rounded-lg">
+              <Brain size={16} />
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-purple-900 leading-tight">Coach</p>
+              <p className="text-[10px] text-purple-700/70 leading-tight">
+                {seed ? "Has your urge context · keeps your Help flow open" : 'Always here'}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close coach"
+            className="p-1.5 rounded-lg text-purple-700 hover:bg-purple-200 transition-colors"
+          >
+            <X size={20} />
+          </button>
+        </header>
+
+        <div className="flex-1 min-h-0 overflow-hidden">
+          <AICoach
+            checkInHistory={checkInHistory}
+            messages={messages}
+            setMessages={setMessages}
+            currentUrgeContext={seed}
+            compact
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/webapp/components/urgeHelp/LocateStage.tsx
+++ b/webapp/components/urgeHelp/LocateStage.tsx
@@ -1,0 +1,255 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { ArrowRight, X } from 'lucide-react';
+import type { FeelingId } from '../../types';
+import { FEELINGS } from '../../data/urgeData';
+
+interface LocateStageProps {
+  /** Pre-fills the picker if the user came back from a later stage. */
+  initialFeeling?: FeelingId | null;
+  /** Receives the selected feeling and (optionally) an intensity 1–10. */
+  onComplete: (feeling: FeelingId, intensity: number | null) => void;
+}
+
+/** Exit animation duration — must match `.animate-sheet-down` in index.css. */
+const SHEET_EXIT_MS = 240;
+
+/**
+ * Stage 2 — Locate.
+ *
+ * The Pause bought time; Locate gives the urge a name. Naming the emotion
+ * underneath the impulse activates the prefrontal cortex and weakens the
+ * amygdala response (Lieberman 2007 — "affect labeling"). That's why this
+ * stage is more than a picker: every feeling carries a one-line context
+ * line so the user *understands* what they're feeling, not just labels it.
+ *
+ * The intensity slider rises as a bottom sheet (matching the lesson sheet
+ * pattern from PlanLessonContent) the moment a feeling is picked. This
+ * pulls the user's eye down to the next decision without crowding the
+ * grid above. The sheet has a Close affordance so users can deselect and
+ * pick a different feeling.
+ */
+export const LocateStage: React.FC<LocateStageProps> = ({ initialFeeling, onComplete }) => {
+  const [selected, setSelected] = useState<FeelingId | null>(initialFeeling ?? null);
+  const [intensity, setIntensity] = useState<number | null>(null);
+
+  // Sheet animation lifecycle. `sheetVisible` is true whenever a feeling is
+  // selected; `sheetClosing` flips during the slide-down exit anim so we can
+  // unmount only after it finishes (mirrors LessonBottomSheet timing).
+  const sheetVisible = selected !== null;
+  const [sheetClosing, setSheetClosing] = useState(false);
+  const exitTimerRef = useRef<number | null>(null);
+
+  // Live measurement of the sheet's rendered height. Drives the grid's
+  // bottom padding so the last row of cards is always reachable above the
+  // sheet — no magic numbers, no clipping when localized copy is longer.
+  const sheetRef = useRef<HTMLDivElement | null>(null);
+  const [sheetHeight, setSheetHeight] = useState(0);
+
+  useEffect(() => {
+    if (!sheetVisible || !sheetRef.current) {
+      setSheetHeight(0);
+      return;
+    }
+    const node = sheetRef.current;
+    // Read initial size synchronously, then re-read on any resize
+    // (orientation change, on-screen keyboard, dynamic content).
+    setSheetHeight(node.offsetHeight);
+    const obs = new ResizeObserver((entries) => {
+      const h = entries[0]?.contentRect?.height ?? node.offsetHeight;
+      setSheetHeight(h);
+    });
+    obs.observe(node);
+    return () => obs.disconnect();
+  }, [sheetVisible]);
+
+  useEffect(() => {
+    return () => {
+      if (exitTimerRef.current !== null) window.clearTimeout(exitTimerRef.current);
+    };
+  }, []);
+
+  /** Deselect with a slide-down — used by the close affordance and by
+   *  tapping the same feeling twice. Holds the closing state for one
+   *  animation tick before clearing the selection. */
+  const deselect = () => {
+    if (sheetClosing) return;
+    setSheetClosing(true);
+    exitTimerRef.current = window.setTimeout(() => {
+      setSheetClosing(false);
+      setSelected(null);
+      setIntensity(null);
+      exitTimerRef.current = null;
+    }, SHEET_EXIT_MS);
+  };
+
+  const handleFeelingClick = (id: FeelingId) => {
+    if (id === selected) {
+      deselect();
+      return;
+    }
+    // Cancel any in-flight close animation. Without this, an exit timer
+    // scheduled by a previous deselect would fire after we set the new
+    // selection and clobber it back to null mid-animation.
+    if (exitTimerRef.current !== null) {
+      window.clearTimeout(exitTimerRef.current);
+      exitTimerRef.current = null;
+      setSheetClosing(false);
+    }
+    setSelected(id);
+  };
+
+  const handleContinue = () => {
+    if (!selected) return;
+    onComplete(selected, intensity);
+  };
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0 relative animate-in fade-in duration-300">
+      {/* Scrollable feelings grid. Bottom padding tracks the live sheet
+          height so the last row of cards is always reachable, regardless
+          of localized copy or device chrome. Animation duration matches
+          the sheet slide-up keyframe in index.css for synced motion. */}
+      <div
+        className="flex-1 overflow-y-auto transition-[padding] duration-[320ms]"
+        style={{
+          // +24px breathing room above the sheet edge; +32px when no sheet
+          // for normal scroll bottom space.
+          paddingBottom: sheetVisible ? sheetHeight + 24 : 32,
+        }}
+      >
+        <div className="px-4 md:px-6 max-w-2xl mx-auto">
+          <header className="text-center mt-6 md:mt-8 mb-6 md:mb-8">
+            <p className="text-[10px] font-semibold text-rose-700/60 uppercase tracking-widest mb-2">
+              Stage 2 of 4
+            </p>
+            <h2 className="text-2xl md:text-3xl font-bold text-rose-900 mb-2">
+              What are you feeling?
+            </h2>
+            <p className="text-sm md:text-base text-rose-700/80 max-w-md mx-auto">
+              Naming the feeling underneath the urge is half the work.
+            </p>
+          </header>
+
+          {/* Two-column tile grid on mobile and desktop. Tiles are tall enough
+              to fit the title + a two-line context without truncation, and each
+              tile is a generous tap target (≥ 88px tall). */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-8">
+            {FEELINGS.map((f, i) => {
+              const isSelected = selected === f.id;
+              return (
+                <button
+                  key={f.id}
+                  onClick={() => handleFeelingClick(f.id)}
+                  className={`text-left p-4 rounded-2xl border-2 transition-all
+                              animate-in fade-in slide-in-from-bottom-2 duration-300
+                              ${
+                                isSelected
+                                  ? 'bg-rose-100 border-rose-500 shadow-md'
+                                  : 'bg-white border-rose-100 hover:border-rose-300 hover:shadow-sm'
+                              }`}
+                  style={{ animationDelay: `${i * 40}ms`, animationFillMode: 'backwards' }}
+                  aria-pressed={isSelected}
+                >
+                  <div className="font-semibold text-rose-900 mb-1">{f.label}</div>
+                  <p className="text-xs md:text-sm text-rose-700/70 leading-snug">{f.context}</p>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Bottom sheet — slides up from the bottom of the stage container.
+          Anchored absolutely so it floats above the scrollable grid; mobile
+          bottom-nav offset clears the fixed nav (h-4.5rem). */}
+      {sheetVisible && (
+        <div
+          ref={sheetRef}
+          className={`absolute inset-x-0 bottom-0 mx-auto max-w-2xl pointer-events-auto
+                      ${sheetClosing ? 'animate-sheet-down' : 'animate-sheet-up'}`}
+        >
+          <div
+            className="bg-white border-t border-rose-200 rounded-t-3xl shadow-2xl
+                       px-4 md:px-6 pt-3"
+            style={{
+              paddingBottom: 'calc(env(safe-area-inset-bottom) + 1rem)',
+            }}
+          >
+            {/* Drag-handle visual cue (non-functional — just signals "sheet"). */}
+            <div className="flex justify-center mb-2" aria-hidden="true">
+              <div className="w-10 h-1.5 rounded-full bg-rose-200" />
+            </div>
+
+            {/* Header row with selected feeling + close-to-deselect button. */}
+            <div className="flex items-center justify-between mb-3">
+              <div>
+                <p className="text-[10px] font-bold uppercase tracking-wider text-rose-700/60">
+                  You picked
+                </p>
+                <p className="text-base font-semibold text-rose-900">
+                  {FEELINGS.find((f) => f.id === selected)?.label}
+                </p>
+              </div>
+              <button
+                onClick={deselect}
+                aria-label="Choose a different feeling"
+                className="p-2 rounded-full text-rose-700/70 hover:bg-rose-100 hover:text-rose-900 transition-colors"
+              >
+                <X size={18} />
+              </button>
+            </div>
+
+            {/* Intensity slider — the optional input that gives the log
+                richer signal without blocking progress. */}
+            <section
+              aria-label="How intense is this urge"
+              className="bg-rose-50 border border-rose-100 rounded-2xl p-4 mb-4"
+            >
+              <div className="flex items-baseline justify-between mb-2">
+                <h3 className="text-sm font-semibold text-rose-900">How strong is it?</h3>
+                <span className="text-xs text-rose-700/60">Optional · 1–10</span>
+              </div>
+
+              <input
+                type="range"
+                min={1}
+                max={10}
+                step={1}
+                value={intensity ?? 5}
+                onChange={(e) => setIntensity(parseInt(e.target.value, 10))}
+                className="w-full accent-rose-700"
+                aria-label="Urge intensity from 1 to 10"
+              />
+
+              <div className="flex justify-between text-[10px] font-semibold uppercase tracking-wider text-rose-700/50 mt-1">
+                <span>Mild</span>
+                <span
+                  className={
+                    intensity !== null
+                      ? 'text-rose-800 text-base font-bold normal-case tracking-normal'
+                      : ''
+                  }
+                >
+                  {intensity !== null ? intensity : '·'}
+                </span>
+                <span>Crushing</span>
+              </div>
+            </section>
+
+            {/* Full-width primary CTA — sits flush with the sheet to feel
+                like the natural next step. */}
+            <button
+              onClick={handleContinue}
+              className="w-full inline-flex items-center justify-center gap-2 px-6 py-3
+                         bg-rose-700 text-white rounded-xl font-semibold text-sm shadow-md
+                         hover:bg-rose-800 active:scale-[0.99] transition-all"
+            >
+              <span>Continue</span>
+              <ArrowRight size={18} />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/webapp/components/urgeHelp/PauseStage.tsx
+++ b/webapp/components/urgeHelp/PauseStage.tsx
@@ -1,0 +1,131 @@
+import React, { useEffect, useState } from 'react';
+
+interface PauseStageProps {
+  /** Called when the timer hits zero OR the user taps the skip button. */
+  onComplete: () => void;
+}
+
+/** Total Pause duration: 3 minutes per evidence-based "urge surfing" (Marlatt).
+ *  Enough to weaken peak craving, short enough that the on-screen countdown
+ *  never feels intimidating. */
+const TOTAL_SECONDS = 180;
+
+/** Geometry for the progress ring. Kept large on mobile (`w-72 h-72`) so the
+ *  countdown reads from arm's length while the user is mid-crisis. */
+const SIZE = 280;
+const STROKE_WIDTH = 20;
+const RADIUS = (SIZE - STROKE_WIDTH) / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+/**
+ * Stage 1 — the Pause.
+ *
+ * The user lands here the moment they open the Help tab. The single goal is
+ * to insert a 3-minute delay between impulse and action. The reframe copy
+ * ("3 minutes is all your brain needs to weaken the urge") sells this as a
+ * winnable amount of time, not a sentence.
+ *
+ * Auto-advances to Locate when the timer reaches zero. The user can also
+ * tap "I'm grounded — skip" if they're already past the peak; it's a quiet
+ * secondary button so it doesn't compete with the timer's calming presence.
+ */
+export const PauseStage: React.FC<PauseStageProps> = ({ onComplete }) => {
+  const [timeLeft, setTimeLeft] = useState(TOTAL_SECONDS);
+
+  useEffect(() => {
+    if (timeLeft <= 0) {
+      onComplete();
+      return;
+    }
+    const id = window.setInterval(() => {
+      setTimeLeft((prev) => prev - 1);
+    }, 1000);
+    return () => window.clearInterval(id);
+  }, [timeLeft, onComplete]);
+
+  // Draw the progress ring as a fraction of completed time. `transition-all`
+  // on the stroke gives the slow, calming sweep that mirrors a meditation
+  // timer rather than a stopwatch.
+  const strokeDashoffset =
+    CIRCUMFERENCE - ((TOTAL_SECONDS - timeLeft) / TOTAL_SECONDS) * CIRCUMFERENCE;
+
+  // Format mm:ss; we want the user to read "2:43" not "163". The countdown
+  // is the visual anchor of the screen so it has to be dead-simple to parse.
+  const minutes = Math.floor(timeLeft / 60);
+  const seconds = timeLeft % 60;
+  const display = `${minutes}:${seconds.toString().padStart(2, '0')}`;
+
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center px-4 pb-8 animate-in fade-in duration-500 relative">
+      {/* Soft background illustration anchored at the top — same image as the
+          legacy stage, kept because it matches the rose palette and reads as
+          "calm" rather than "alarm". */}
+      <div className="absolute top-0 left-0 right-0 h-64 md:h-80 z-0 overflow-hidden">
+        <img
+          src="/illustrations/urge.png"
+          alt=""
+          aria-hidden="true"
+          className="w-full h-full object-cover mix-blend-multiply opacity-40 scale-[1.4] origin-center"
+        />
+        <div className="absolute inset-0 bg-gradient-to-b from-transparent via-rose-50/60 to-rose-50" />
+      </div>
+
+      <h2 className="text-xl md:text-2xl font-medium text-rose-900 mb-2 text-center max-w-md leading-relaxed relative z-10 mt-8">
+        You don't need to decide right now.
+      </h2>
+      <p className="text-sm md:text-base text-rose-700/80 mb-8 md:mb-10 text-center max-w-md relative z-10">
+        3 minutes is all your brain needs to weaken the urge.
+      </p>
+
+      <div className="relative w-72 h-72 mb-10 z-10">
+        <svg
+          className="w-full h-full -rotate-90"
+          viewBox={`0 0 ${SIZE} ${SIZE}`}
+          aria-hidden="true"
+        >
+          <circle
+            cx={SIZE / 2}
+            cy={SIZE / 2}
+            r={RADIUS}
+            stroke="currentColor"
+            strokeWidth={STROKE_WIDTH}
+            fill="transparent"
+            className="text-rose-200"
+          />
+          <circle
+            cx={SIZE / 2}
+            cy={SIZE / 2}
+            r={RADIUS}
+            stroke="currentColor"
+            strokeWidth={STROKE_WIDTH}
+            fill="transparent"
+            strokeDasharray={CIRCUMFERENCE}
+            strokeDashoffset={strokeDashoffset}
+            strokeLinecap="round"
+            className="text-rose-800 transition-all duration-1000 ease-linear"
+          />
+        </svg>
+
+        <div className="absolute inset-0 flex flex-col items-center justify-center select-none">
+          <span className="text-6xl md:text-7xl font-light text-rose-900 tracking-tight tabular-nums">
+            {display}
+          </span>
+          <span className="text-[10px] font-bold text-rose-800/40 uppercase tracking-widest mt-2">
+            Breathe
+          </span>
+        </div>
+      </div>
+
+      <p className="text-stone-500 mb-8 font-medium text-sm md:text-base text-center max-w-xs">
+        Urges rise and fall like waves. This one will too.
+      </p>
+
+      <button
+        onClick={onComplete}
+        className="px-6 py-3 bg-white border border-rose-200 text-rose-800 rounded-xl hover:bg-rose-50 transition-colors font-semibold text-sm tracking-wide shadow-sm"
+      >
+        I'm grounded — skip ahead
+      </button>
+    </div>
+  );
+};

--- a/webapp/components/urgeHelp/ReflectStage.tsx
+++ b/webapp/components/urgeHelp/ReflectStage.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import { Sparkles, RotateCcw, MessageCircle } from 'lucide-react';
+import type { UrgeOutcome } from '../../types';
+
+interface ReflectStageProps {
+  /** Total count of completed surfs INCLUDING this one. Drives the
+   *  celebration copy ("Surf #N done") so the user feels the streak. */
+  totalSurfsAfterThisOne: number;
+  onChoose: (outcome: UrgeOutcome) => void;
+}
+
+/**
+ * Stage 4 — Reflect.
+ *
+ * Three options, deliberately phrased as outcomes the user *experienced*
+ * rather than buttons they're judging themselves with:
+ *   • "Yes, it passed"   — fires the micro-celebration and returns to Pause
+ *   • "Still here"       — back to the action grid with prior actions
+ *                          marked, so the user knows what they've already
+ *                          tried this session
+ *   • "I want to talk"   — opens the AI Coach modal pre-seeded with context
+ *
+ * The micro-celebration that follows "passed" lives in the orchestrator
+ * (single source of truth), but this screen owns the moment of choice and
+ * the gentle wrap-up copy.
+ */
+export const ReflectStage: React.FC<ReflectStageProps> = ({ totalSurfsAfterThisOne, onChoose }) => {
+  // Local lock so a fast double-tap doesn't fire two log writes.
+  const [submitted, setSubmitted] = useState(false);
+  const handle = (outcome: UrgeOutcome) => {
+    if (submitted) return;
+    setSubmitted(true);
+    onChoose(outcome);
+  };
+
+  return (
+    <div className="flex-1 overflow-y-auto pb-28 md:pb-8 animate-in fade-in duration-300">
+      <div className="px-4 md:px-6 max-w-md mx-auto">
+        <header className="text-center mt-6 md:mt-8 mb-6 md:mb-8">
+          <p className="text-[10px] font-semibold text-rose-700/60 uppercase tracking-widest mb-2">
+            Stage 4 of 4
+          </p>
+          <h2 className="text-2xl md:text-3xl font-bold text-rose-900 mb-2">
+            How are you now?
+          </h2>
+          <p className="text-sm md:text-base text-rose-700/80">
+            Whatever you say, this counts. Showing up for the urge is the work.
+          </p>
+        </header>
+
+        <div className="space-y-3">
+          <button
+            onClick={() => handle('passed')}
+            disabled={submitted}
+            className="w-full p-5 rounded-2xl bg-rose-700 text-white shadow-md hover:bg-rose-800
+                       transition-all active:scale-[0.99] disabled:opacity-60 text-left flex items-center gap-3"
+          >
+            <Sparkles size={24} className="flex-shrink-0" />
+            <div>
+              <div className="font-bold text-base md:text-lg">Yes, it passed</div>
+              <div className="text-xs text-rose-100">
+                You'll be Surf #{totalSurfsAfterThisOne} on your record.
+              </div>
+            </div>
+          </button>
+
+          <button
+            onClick={() => handle('still_here')}
+            disabled={submitted}
+            className="w-full p-5 rounded-2xl bg-white border-2 border-rose-300 text-rose-900
+                       hover:bg-rose-50 transition-all active:scale-[0.99] disabled:opacity-60 text-left flex items-center gap-3"
+          >
+            <RotateCcw size={24} className="flex-shrink-0 text-rose-700" />
+            <div>
+              <div className="font-bold text-base md:text-lg">Still here</div>
+              <div className="text-xs text-rose-700/70">Try another action — no shame, this is normal.</div>
+            </div>
+          </button>
+
+          <button
+            onClick={() => handle('escalated')}
+            disabled={submitted}
+            className="w-full p-5 rounded-2xl bg-purple-50 border-2 border-purple-200 text-purple-900
+                       hover:bg-purple-100 transition-all active:scale-[0.99] disabled:opacity-60 text-left flex items-center gap-3"
+          >
+            <MessageCircle size={24} className="flex-shrink-0 text-purple-700" />
+            <div>
+              <div className="font-bold text-base md:text-lg">I want to talk it through</div>
+              <div className="text-xs text-purple-700/70">Open the Coach with your context.</div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/webapp/components/urgeHelp/StageProgress.tsx
+++ b/webapp/components/urgeHelp/StageProgress.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+
+/** The four stages of the redesigned Help journey. The order is fixed and
+ *  the user is always on exactly one of these at any moment. */
+export type Stage = 'pause' | 'locate' | 'act' | 'reflect';
+
+const STAGES: { id: Stage; label: string }[] = [
+  { id: 'pause', label: 'Pause' },
+  { id: 'locate', label: 'Locate' },
+  { id: 'act', label: 'Act' },
+  { id: 'reflect', label: 'Reflect' },
+];
+
+interface StageProgressProps {
+  current: Stage;
+}
+
+/**
+ * Slim wizard-style progress indicator pinned to the top of every Help stage.
+ *
+ * Shows where the user is in the 4-stage journey (Pause → Locate → Act →
+ * Reflect) so they understand the structure of the experience and feel
+ * forward motion. Visual language mirrors Plan tab tokens (rounded pills,
+ * soft shadow, rose accent for the active step matching the emergency
+ * context). Decorative only — never receives focus.
+ */
+export const StageProgress: React.FC<StageProgressProps> = ({ current }) => {
+  const currentIdx = STAGES.findIndex((s) => s.id === current);
+
+  return (
+    <>
+      {/* Screen-reader-only stage announcement. The visual pill row below
+          is decorative; SR users get a single clear "where am I" line
+          instead of having every stage label announced as text. */}
+      <p className="sr-only" aria-live="polite">
+        Stage {currentIdx + 1} of {STAGES.length}: {STAGES[currentIdx].label}
+      </p>
+
+      <div
+        role="presentation"
+        aria-hidden="true"
+        className="flex items-center justify-center gap-2 px-4 pt-4 md:pt-6"
+      >
+      {STAGES.map((s, i) => {
+        const isCurrent = i === currentIdx;
+        const isDone = i < currentIdx;
+
+        return (
+          <React.Fragment key={s.id}>
+            <div className="flex items-center gap-1.5">
+              <span
+                className={`w-1.5 h-1.5 rounded-full transition-colors ${
+                  isCurrent
+                    ? 'bg-rose-700 ring-4 ring-rose-200'
+                    : isDone
+                      ? 'bg-rose-500'
+                      : 'bg-rose-200'
+                }`}
+              />
+              <span
+                className={`text-[10px] font-semibold uppercase tracking-wider transition-colors ${
+                  isCurrent ? 'text-rose-800' : isDone ? 'text-rose-600' : 'text-rose-300'
+                }`}
+              >
+                {s.label}
+              </span>
+            </div>
+            {i < STAGES.length - 1 && (
+              <span
+                className={`h-px w-4 md:w-6 transition-colors ${
+                  isDone ? 'bg-rose-400' : 'bg-rose-200'
+                }`}
+              />
+            )}
+          </React.Fragment>
+        );
+      })}
+      </div>
+    </>
+  );
+};

--- a/webapp/components/urgeHelp/SurfCelebration.tsx
+++ b/webapp/components/urgeHelp/SurfCelebration.tsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useMemo } from 'react';
+import { Sparkles } from 'lucide-react';
+
+interface SurfCelebrationProps {
+  /** Total surfs on record after the just-completed one. */
+  total: number;
+  /** Auto-fires after the celebration duration so the orchestrator can
+   *  reset back to the Pause stage. */
+  onDone: () => void;
+}
+
+/** Total time the celebration is on screen (ms). Long enough to read,
+ *  short enough that the user doesn't wait around for the next surf. */
+const VISIBLE_MS = 2400;
+
+/**
+ * Celebrates a completed urge surf. Distinct from the Dashboard streak
+ * celebration: this is a quieter, faster overlay since urges happen often
+ * and we don't want to over-celebrate one of many. Sparkles, not confetti.
+ */
+export const SurfCelebration: React.FC<SurfCelebrationProps> = ({ total, onDone }) => {
+  // Pre-generate a few sparkle positions so re-renders don't reshuffle.
+  const sparkles = useMemo(
+    () =>
+      Array.from({ length: 14 }, (_, i) => ({
+        id: i,
+        left: 5 + Math.random() * 90,
+        top: 10 + Math.random() * 80,
+        delay: Math.random() * 1.2,
+        size: 12 + Math.random() * 14,
+      })),
+    [],
+  );
+
+  useEffect(() => {
+    const id = window.setTimeout(onDone, VISIBLE_MS);
+    return () => window.clearTimeout(id);
+  }, [onDone]);
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="absolute inset-0 z-40 flex items-center justify-center bg-rose-50/95
+                 backdrop-blur-sm animate-in fade-in duration-300 pointer-events-none"
+    >
+      {/* Decorative sparkle field */}
+      {sparkles.map((s) => (
+        <Sparkles
+          key={s.id}
+          size={s.size}
+          aria-hidden="true"
+          className="absolute text-rose-500 animate-in fade-in zoom-in-50 duration-700"
+          style={{
+            left: `${s.left}%`,
+            top: `${s.top}%`,
+            animationDelay: `${s.delay}s`,
+            animationFillMode: 'backwards',
+          }}
+        />
+      ))}
+
+      {/* Centered message */}
+      <div className="relative text-center max-w-xs animate-in fade-in zoom-in-95 duration-500">
+        <p className="text-3xl md:text-4xl font-bold text-rose-900 mb-2">
+          You surfed it.
+        </p>
+        <p className="text-sm md:text-base text-rose-700">
+          Surf #{total} on your record.
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/webapp/data/urgeData.ts
+++ b/webapp/data/urgeData.ts
@@ -1,0 +1,179 @@
+// Static data driving the redesigned Help tab (Issue #34): the list of
+// feelings the user picks from on the Locate stage, and the registry of the
+// 10 evidence-based actions surfaced on the Act stage.
+//
+// Kept here (rather than inlined in components) so copy edits and the
+// recommended-action mapping stay easy to audit and update without touching
+// any rendering logic.
+
+import type { Feeling, UrgeAction, UrgeActionId } from '../types';
+
+/**
+ * The 7 feelings available on the Locate stage.
+ *
+ * Context lines mix a behavioral framing ("why this triggers") with a
+ * directional hint ("what tends to help") — short enough to fit two lines
+ * on mobile, long enough to make the picker informative on its own.
+ */
+export const FEELINGS: Feeling[] = [
+  {
+    id: 'boredom',
+    label: 'Boredom',
+    context: 'A craving for stimulation. Move your body or change context.',
+  },
+  {
+    id: 'anxiety',
+    label: 'Anxiety',
+    context: 'Nervous system on alert. Slow breathing or cold water resets it.',
+  },
+  {
+    id: 'loneliness',
+    label: 'Loneliness',
+    context: 'Reach out to someone real, even briefly. Connection is the fix.',
+  },
+  {
+    id: 'stress',
+    label: 'Stress',
+    context: 'Your body holds tension. Burn it off or write it down.',
+  },
+  {
+    id: 'frustration',
+    label: 'Frustration',
+    context: 'Anger looking for an outlet. Move first, decide later.',
+  },
+  {
+    id: 'tiredness',
+    label: 'Tiredness',
+    context: 'Low energy lowers self-control. Rest beats willpower.',
+  },
+  {
+    id: 'sexual_tension',
+    label: 'Sexual tension',
+    context: 'A wave, not an emergency. Delay 3 minutes and it weakens.',
+  },
+];
+
+/**
+ * The 10 urge-response actions, in display order grouped by category.
+ *
+ * Within each category the strongest / most physiological action comes first
+ * so the recommended-badge logic can default to the first match.
+ */
+export const URGE_ACTIONS: UrgeAction[] = [
+  // ── Reset (physiology) ──────────────────────────────────────────────────
+  {
+    id: 'box_breathing',
+    title: 'Box Breathing',
+    category: 'reset',
+    whyItWorks: 'Slows your nervous system in 4 cycles.',
+    recommendedFor: ['anxiety', 'stress', 'sexual_tension'],
+  },
+  {
+    id: 'cold_water',
+    title: 'Cold Water',
+    category: 'reset',
+    whyItWorks: "Triggers the diving reflex — the body's fastest reset.",
+    recommendedFor: ['anxiety', 'sexual_tension', 'frustration'],
+  },
+  {
+    id: 'physical_burst',
+    title: 'Physical Burst',
+    category: 'reset',
+    whyItWorks: 'Burns the adrenaline so the urge has nowhere to go.',
+    recommendedFor: ['frustration', 'boredom', 'sexual_tension'],
+  },
+
+  // ── Ground (presence) ───────────────────────────────────────────────────
+  {
+    id: 'grounding_54321',
+    title: '5-4-3-2-1 Grounding',
+    category: 'ground',
+    whyItWorks: 'Pulls your attention out of the loop and back into the room.',
+    recommendedFor: ['anxiety', 'stress'],
+  },
+  {
+    id: 'halt_check',
+    title: 'HALT Check',
+    category: 'ground',
+    whyItWorks: 'Names the real need under the urge.',
+    recommendedFor: ['boredom', 'tiredness', 'loneliness', 'frustration'],
+  },
+
+  // ── Protect (environment) ───────────────────────────────────────────────
+  {
+    id: 'leave_room',
+    title: 'Leave the Room',
+    category: 'protect',
+    whyItWorks: 'A new space breaks the pattern your brain just built.',
+    recommendedFor: ['boredom', 'stress'],
+  },
+  {
+    id: 'phone_away',
+    title: 'Phone Away',
+    category: 'protect',
+    whyItWorks: 'Distance from the trigger device drops urge intensity fast.',
+    recommendedFor: ['boredom', 'tiredness', 'sexual_tension'],
+  },
+
+  // ── Reframe (cognition) ─────────────────────────────────────────────────
+  {
+    id: 'urge_journal',
+    title: 'Urge Journal',
+    category: 'reframe',
+    whyItWorks: 'Naming the urge weakens it. The data helps future-you.',
+    recommendedFor: ['stress', 'frustration', 'loneliness'],
+  },
+  {
+    id: 'future_self_letter',
+    title: 'Future-Self Letter',
+    category: 'reframe',
+    whyItWorks: 'Hear from the version of you that already won this fight.',
+    recommendedFor: ['loneliness', 'tiredness'],
+  },
+  {
+    id: 'play_the_tape',
+    title: 'Play the Tape',
+    category: 'reframe',
+    whyItWorks: 'Visualizing the aftermath shifts the decision off autopilot.',
+    recommendedFor: ['sexual_tension', 'boredom'],
+  },
+];
+
+/** Quick lookup by id — used by the orchestrator and Coach context seed.
+ *  Typed as `Record<UrgeActionId, UrgeAction>` so callers get strong
+ *  inference without a `string` indirection. The cast is safe because
+ *  URGE_ACTIONS is exhaustive over UrgeActionId by construction. */
+export const URGE_ACTION_BY_ID: Record<UrgeActionId, UrgeAction> = Object.fromEntries(
+  URGE_ACTIONS.map((a) => [a.id, a]),
+) as Record<UrgeActionId, UrgeAction>;
+
+/** Category metadata for headers and subtle tints in the Act grid. */
+export const URGE_CATEGORY_META: Record<
+  UrgeAction['category'],
+  { label: string; subtitle: string; tint: string; accent: string }
+> = {
+  reset: {
+    label: 'Reset',
+    subtitle: 'Calm the body',
+    tint: 'bg-rose-100/60 border-rose-200',
+    accent: 'text-rose-700',
+  },
+  ground: {
+    label: 'Ground',
+    subtitle: 'Come back to now',
+    tint: 'bg-amber-100/60 border-amber-200',
+    accent: 'text-amber-800',
+  },
+  protect: {
+    label: 'Protect',
+    subtitle: 'Change your environment',
+    tint: 'bg-purple-100/60 border-purple-200',
+    accent: 'text-purple-800',
+  },
+  reframe: {
+    label: 'Reframe',
+    subtitle: 'Shift the story',
+    tint: 'bg-emerald-100/60 border-emerald-200',
+    accent: 'text-emerald-800',
+  },
+};

--- a/webapp/src/lib/urgeLog.ts
+++ b/webapp/src/lib/urgeLog.ts
@@ -1,0 +1,141 @@
+// localStorage helpers for the redesigned Help tab (Issue #34).
+//
+// Persistence rationale: see issue #34 exploration comment. We chose
+// localStorage-first so the feature can ship and iterate without a Supabase
+// schema migration. Keys are versioned (`.v1`) so a future migration to the
+// backend can read and clear old data cleanly.
+
+import type { UrgeLogEntry } from '../../types';
+import { logger } from './logger';
+
+const LOG_KEY = 'mc.urge_log.v1';
+const LETTER_KEY = 'mc.future_self_letter.v1';
+const JOURNAL_KEY = 'mc.urge_journal.v1';
+
+// ─── Urge log ──────────────────────────────────────────────────────────────
+
+/** Read the full urge log. Returns [] if storage is unavailable or corrupt. */
+export function readLog(): UrgeLogEntry[] {
+  try {
+    const raw = localStorage.getItem(LOG_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as UrgeLogEntry[]) : [];
+  } catch (err) {
+    // Corrupt JSON or storage disabled — fall back to empty so callers
+    // never have to defensively try/catch around reads. Surface the error
+    // to the logger so dev environments don't silently mask bugs.
+    logger.warn('urgeLog read failed', { error: err });
+    return [];
+  }
+}
+
+/** Append a single completed entry. Best-effort write; errors are logged
+ *  (not thrown) because the urge log is non-critical and we never want a
+ *  write failure to interfere with the user's just-finished surf. */
+export function appendEntry(entry: UrgeLogEntry): void {
+  try {
+    const existing = readLog();
+    existing.push(entry);
+    localStorage.setItem(LOG_KEY, JSON.stringify(existing));
+  } catch (err) {
+    logger.warn('urgeLog write failed', { error: err });
+  }
+}
+
+/** Convenience for the Dashboard tile. */
+export function count(): number {
+  return readLog().length;
+}
+
+// ─── Urge Journal (separate from urge log) ────────────────────────────────
+
+/** Structured note captured by the Urge Journal action. Kept in its own
+ *  store rather than embedded in `UrgeLogEntry` so the urge log stays a
+ *  uniform per-session row, and the journal can grow its own analytics
+ *  surface later (e.g. "your most common trigger this week"). */
+export interface UrgeJournalEntry {
+  /** Unix ms timestamp; doubles as id. */
+  id: number;
+  /** ISO timestamp the user tapped Done in the journal screen. */
+  savedAt: string;
+  /** One of UrgeJournalScreen's TRIGGER_CHIPS, or null if user skipped. */
+  trigger: string | null;
+  /** 1–10 self-rated intensity at the moment of writing. */
+  intensity: number;
+  /** Free-form note; trimmed but otherwise verbatim. */
+  note: string;
+}
+
+export function readJournal(): UrgeJournalEntry[] {
+  try {
+    const raw = localStorage.getItem(JOURNAL_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as UrgeJournalEntry[]) : [];
+  } catch (err) {
+    logger.warn('urgeJournal read failed', { error: err });
+    return [];
+  }
+}
+
+export function appendJournal(entry: UrgeJournalEntry): void {
+  try {
+    const existing = readJournal();
+    existing.push(entry);
+    localStorage.setItem(JOURNAL_KEY, JSON.stringify(existing));
+  } catch (err) {
+    logger.warn('urgeJournal write failed', { error: err });
+  }
+}
+
+// ─── Future-Self Letter ────────────────────────────────────────────────────
+
+/** Letter shape: kept structured so the editor can render fields, but the
+ *  Future-Self Letter mini-screen renders the combined message in flowing
+ *  prose. `null` (vs a record with empty strings) signals "never written
+ *  yet" so the action can show its first-time guided write flow. */
+export interface FutureSelfLetter {
+  /** "Three things that matter most to me" — comma-joined or freeform. */
+  values: string;
+  /** "Who I am becoming" — short identity statement. */
+  identity: string;
+  /** Free-form note from past-self to future-self. */
+  message: string;
+  /** ISO timestamp of last save. */
+  updatedAt: string;
+}
+
+export function readLetter(): FutureSelfLetter | null {
+  try {
+    const raw = localStorage.getItem(LETTER_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    // Validate the minimum shape so a partial/legacy record doesn't crash
+    // the consumer.
+    if (
+      parsed &&
+      typeof parsed.values === 'string' &&
+      typeof parsed.identity === 'string' &&
+      typeof parsed.message === 'string'
+    ) {
+      return parsed as FutureSelfLetter;
+    }
+    return null;
+  } catch (err) {
+    logger.warn('letter read failed', { error: err });
+    return null;
+  }
+}
+
+export function writeLetter(letter: Omit<FutureSelfLetter, 'updatedAt'>): void {
+  try {
+    const toStore: FutureSelfLetter = {
+      ...letter,
+      updatedAt: new Date().toISOString(),
+    };
+    localStorage.setItem(LETTER_KEY, JSON.stringify(toStore));
+  } catch (err) {
+    logger.warn('letter write failed', { error: err });
+  }
+}

--- a/webapp/types.ts
+++ b/webapp/types.ts
@@ -38,3 +38,86 @@ export interface ChatMessage {
   role: 'user' | 'assistant';
   content: string;
 }
+
+// ─── Urge Help (Issue #34) ─────────────────────────────────────────────────
+
+/** All 10 evidence-based urge-response actions. Stable string IDs so they
+ *  can be persisted into the urge log without breaking when ordering changes. */
+export type UrgeActionId =
+  | 'box_breathing'
+  | 'cold_water'
+  | 'physical_burst'
+  | 'grounding_54321'
+  | 'halt_check'
+  | 'leave_room'
+  | 'phone_away'
+  | 'urge_journal'
+  | 'future_self_letter'
+  | 'play_the_tape';
+
+/** The four therapeutic categories the 10 actions are grouped into. */
+export type UrgeActionCategory = 'reset' | 'ground' | 'protect' | 'reframe';
+
+/** Stable IDs for the feelings shown on the Locate stage. */
+export type FeelingId =
+  | 'boredom'
+  | 'anxiety'
+  | 'loneliness'
+  | 'stress'
+  | 'frustration'
+  | 'tiredness'
+  | 'sexual_tension';
+
+/** A single feeling option on the Locate stage. */
+export interface Feeling {
+  id: FeelingId;
+  label: string;
+  /** One-line context shown beneath the label — explains why this triggers
+   *  and how it tends to resolve. Keeps the picker informative without modal. */
+  context: string;
+}
+
+/** Action registry entry consumed by the Act stage and individual mini-screens.
+ *  `recommendedFor` drives the 1–2 highlighted "best fit" cards based on the
+ *  feeling the user picked in Stage 2. */
+export interface UrgeAction {
+  id: UrgeActionId;
+  title: string;
+  category: UrgeActionCategory;
+  /** One-line evidence anchor shown on the action card AND mini-screen header. */
+  whyItWorks: string;
+  /** Feelings this action is most useful for; drives recommended-badge logic. */
+  recommendedFor: FeelingId[];
+}
+
+/** Outcome of a completed Reflect-stage feedback. Mirrors the existing
+ *  `handleFeedback` discriminator so we can grow the analytics later. */
+export type UrgeOutcome = 'passed' | 'still_here' | 'escalated';
+
+/** A single completed urge-surf session. Written to localStorage on Reflect
+ *  feedback click; also powers the Dashboard "Urges Surfed" tile. */
+export interface UrgeLogEntry {
+  /** Unix ms timestamp; doubles as a unique-enough id. */
+  id: number;
+  /** ISO timestamp the user entered the Reflect stage. */
+  endedAt: string;
+  feeling: FeelingId | null;
+  /** 1–10, null when the user skipped the slider. */
+  intensity: number | null;
+  /** Action IDs the user opened during this session (deduped, in click order). */
+  actionsTried: UrgeActionId[];
+  outcome: UrgeOutcome;
+}
+
+/** Context handed to the AI Coach when it's invoked mid-flow as a modal.
+ *  Lets the system prompt seed Claude with what the user is working through
+ *  right now, so the very first response is targeted instead of generic. */
+export interface UrgeContextSeed {
+  stage: 'pause' | 'locate' | 'act' | 'reflect';
+  feeling: FeelingId | null;
+  intensity: number | null;
+  /** Most recent action the user opened (if any). */
+  actionAttempted: UrgeActionId | null;
+  /** Seconds since the user landed on the Help tab. */
+  elapsedSec: number;
+}


### PR DESCRIPTION
Closes #34

## Summary
- Rebuilds Help tab as 4-stage journey (Pause → Locate → Act → Reflect) with 10 evidence-based actions, each in its own interactive mini-screen
- AI Coach modal slides up over Help with full urge context (stage / feeling / intensity / actionAttempted / elapsed seconds)
- New Urges Surfed tile on Dashboard, sibling of Streak + Check-in
- localStorage-only persistence (Supabase deferred to follow-up)

## What changed
- **4 stages**: PauseStage (3-min timer + reframe), LocateStage (feeling picker as bottom sheet + 1-10 intensity), ActStage (10-action grid grouped by category), ReflectStage (terminal feedback)
- **10 mini-screens**: Box Breathing, Cold Water, Physical Burst, 5-4-3-2-1 Grounding, HALT Check, Leave the Room, Phone Away, Urge Journal, Future-Self Letter, Play the Tape Forward — each with own pacing, animations, and completion UX
- **AI Coach**: extended with `currentUrgeContext` + `compact` mode props
- **Urge log policy**: only `passed` / `escalated` outcomes recorded (still_here = mid-session feedback, doesn't inflate counter)
- **Dashboard**: third tile, full purple styling, decorative wave SVG; Urge Help banner now rose-accented (panic button signal)
- **A11y**: sr-only stage announcer in StageProgress, keyboard-tappable cards in Grounding, aria-live on completion banner

## Test plan
- [ ] Vercel preview deploy succeeds
- [ ] Open Help tab on mobile + desktop — 4 stages flow Pause → Locate → Act → Reflect
- [ ] Pick a feeling → bottom sheet rises with intensity + Continue
- [ ] All 10 actions open their mini-screen, each completes (Done CTA enables on completion)
- [ ] Box Breathing animates 4-4-4-4 × 5 cycles
- [ ] Grounding: tap anywhere on active card increments dots; auto-advances to next sense; completion banner appears + auto-routes
- [ ] Play the Tape: scenes auto-advance with per-scene timing; tap to skip works
- [ ] Reflect "passed" → confetti + return to Pause + Urges Surfed +1 on Dashboard
- [ ] Reflect "still here" → back to Act, prior actions still marked, NO log entry
- [ ] Reflect "talk it through" → Coach modal opens with urge context seed visible to Claude
- [ ] Future-Self Letter: first time = guided write; subsequent = display + Edit
- [ ] Urges Surfed tile updates on Dashboard after a completed surf
- [ ] No console errors, smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)