### PR TITLE
feat: fix day completion logic — task-based stones, day_completions table (#36)

### DIFF
--- a/supabase/migrations/20260513_day_completions.sql
+++ b/supabase/migrations/20260513_day_completions.sql
@@ -1,0 +1,30 @@
+-- Day-level completion tracking for the 28-day plan.
+--
+-- One row per (user, plan cycle, day_number). Written by the webapp when:
+--   lesson_completed_at    — the day's lesson slide-deck is finished
+--   all_tasks_completed_at — lesson + all morning/evening tasks are checked off
+--
+-- These two timestamps drive stone colour on the Journey path:
+--   GREEN (immediate) : all_tasks_completed_at IS NOT NULL
+--   GREEN (next day)  : lesson_completed_at exists AND its calendar date < today
+--   YELLOW (active)   : first day where neither condition is true
+--
+-- Run this SQL once in the Supabase Dashboard → SQL Editor.
+
+CREATE TABLE IF NOT EXISTS day_completions (
+  user_id                UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  plan_started_at        TIMESTAMPTZ NOT NULL,
+  day_number             SMALLINT    NOT NULL CHECK (day_number >= 0 AND day_number <= 28),
+  lesson_completed_at    TIMESTAMPTZ NOT NULL,
+  all_tasks_completed_at TIMESTAMPTZ,           -- NULL until fully done
+  PRIMARY KEY (user_id, plan_started_at, day_number)
+);
+
+ALTER TABLE day_completions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users manage own day completions" ON day_completions;
+CREATE POLICY "Users manage own day completions" ON day_completions
+  FOR ALL
+  TO authenticated
+  USING  (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);

--- a/webapp/App.tsx
+++ b/webapp/App.tsx
@@ -10,6 +10,8 @@ import { isSameDay, subDays } from 'date-fns';
 import { Plan28 } from './components/Plan28';
 import { Settings } from './components/Settings';
 import { supabase } from './src/lib/supabase';
+import { planData, getRequiredTaskKeys, DayCompletion } from './data/planData';
+import { lessonsData } from './data/lessonsData';
 
 // Hardcoded welcome message — never stored in DB, always prepended at load time.
 const WELCOME_MESSAGE: ChatMessage = {
@@ -36,6 +38,11 @@ export default function App() {
   // Active plan cycle start — used to scope plan_progress queries/writes.
   const [planStartedAt, setPlanStartedAt] = useState<string | null>(null);
   const [chatHistory, setChatHistory] = useState<ChatMessage[]>([WELCOME_MESSAGE]);
+
+  // Day-level completion timestamps — loaded from day_completions table.
+  // lesson_completed_at : when the lesson was finished (drives next-day green stone).
+  // all_tasks_completed_at : when lesson + all tasks were done (drives same-day green).
+  const [dayCompletions, setDayCompletions] = useState<Record<number, DayCompletion>>({});
 
   // ── Load all persisted data after authentication ──────────────────────────
   useEffect(() => {
@@ -105,12 +112,19 @@ export default function App() {
 
       setPlanStartedAt(activePlanStartedAt);
 
-      // Fetch plan_progress rows for the active cycle
-      const { data: progressRows } = await supabase!
-        .from('plan_progress')
-        .select('day_number, task_key')
-        .eq('user_id', user.id)
-        .eq('plan_started_at', activePlanStartedAt);
+      // Fetch plan_progress and day_completions in parallel — both depend only on activePlanStartedAt
+      const [{ data: progressRows }, { data: dayCompletionRows }] = await Promise.all([
+        supabase!
+          .from('plan_progress')
+          .select('day_number, task_key')
+          .eq('user_id', user.id)
+          .eq('plan_started_at', activePlanStartedAt),
+        supabase!
+          .from('day_completions')
+          .select('day_number, lesson_completed_at, all_tasks_completed_at')
+          .eq('user_id', user.id)
+          .eq('plan_started_at', activePlanStartedAt),
+      ]);
 
       if (progressRows) {
         const rebuilt: Record<number, Set<string>> = {};
@@ -119,6 +133,17 @@ export default function App() {
           rebuilt[row.day_number].add(row.task_key);
         }
         setCompletedPlanTasks(rebuilt);
+      }
+
+      if (dayCompletionRows) {
+        const rebuilt: Record<number, DayCompletion> = {};
+        for (const row of dayCompletionRows) {
+          rebuilt[row.day_number] = {
+            lesson_completed_at: row.lesson_completed_at,
+            all_tasks_completed_at: row.all_tasks_completed_at ?? null,
+          };
+        }
+        setDayCompletions(rebuilt);
       }
 
       // ── Coach messages ─────────────────────────────────────────────────────
@@ -184,6 +209,7 @@ export default function App() {
     // Reset all in-memory state on logout
     setCheckIns([]);
     setCompletedPlanTasks({});
+    setDayCompletions({});
     setPlanStartedAt(null);
     setChatHistory([WELCOME_MESSAGE]);
     setIsAuthenticated(false);
@@ -242,16 +268,19 @@ export default function App() {
 
     const isCurrentlyChecked = completedPlanTasks[dayNumber]?.has(taskKey) ?? false;
 
+    // Compute the new set of completed tasks for this day BEFORE the state
+    // update so we can use it synchronously in the day_completions logic below.
+    const newDaySet = new Set(completedPlanTasks[dayNumber] ?? []);
+    if (isCurrentlyChecked) {
+      newDaySet.delete(taskKey);
+    } else {
+      newDaySet.add(taskKey);
+    }
+
     // Optimistic UI update first
     setCompletedPlanTasks(prev => {
       const updated = { ...prev };
-      const daySet = new Set(updated[dayNumber] ?? []);
-      if (isCurrentlyChecked) {
-        daySet.delete(taskKey);
-      } else {
-        daySet.add(taskKey);
-      }
-      updated[dayNumber] = daySet;
+      updated[dayNumber] = new Set(newDaySet);
       return updated;
     });
 
@@ -260,7 +289,6 @@ export default function App() {
     if (!user) return;
 
     if (isCurrentlyChecked) {
-      // Remove completion
       await supabase
         .from('plan_progress')
         .delete()
@@ -269,7 +297,7 @@ export default function App() {
         .eq('day_number', dayNumber)
         .eq('task_key', taskKey);
     } else {
-      // Record completion — UNIQUE constraint prevents duplicates
+      // UNIQUE constraint prevents duplicates
       await supabase
         .from('plan_progress')
         .upsert({
@@ -278,6 +306,73 @@ export default function App() {
           day_number: dayNumber,
           task_key: taskKey,
         });
+    }
+
+    // ── day_completions sync ───────────────────────────────────────────────
+    // Determine whether the day is now fully complete (all required tasks done).
+    const dayEntry = planData.find(d => d.day === dayNumber);
+    if (!dayEntry) return;
+
+    const hasLesson = lessonsData.some(l => (l.day ?? l.lessonNumber) === dayNumber);
+    const requiredKeys = getRequiredTaskKeys(dayEntry, hasLesson);
+    const allDone = requiredKeys.length > 0 && requiredKeys.every(k => newDaySet.has(k));
+    const now = new Date().toISOString();
+
+    if (taskKey === 'lesson') {
+      if (!isCurrentlyChecked) {
+        // Optimistic update before DB write so the stone turns green immediately
+        // even if the table doesn't exist yet or the write is slow.
+        setDayCompletions(prev => ({
+          ...prev,
+          [dayNumber]: {
+            lesson_completed_at: now,
+            all_tasks_completed_at: allDone ? now : null,
+          },
+        }));
+        await supabase.from('day_completions').upsert({
+          user_id: user.id,
+          plan_started_at: planStartedAt,
+          day_number: dayNumber,
+          lesson_completed_at: now,
+          all_tasks_completed_at: allDone ? now : null,
+        });
+      } else {
+        // Lesson unchecked — remove optimistically, then delete from DB.
+        setDayCompletions(prev => {
+          const updated = { ...prev };
+          delete updated[dayNumber];
+          return updated;
+        });
+        await supabase
+          .from('day_completions')
+          .delete()
+          .eq('user_id', user.id)
+          .eq('plan_started_at', planStartedAt)
+          .eq('day_number', dayNumber);
+      }
+    } else {
+      // Non-lesson task toggled. Update all_tasks_completed_at only when a
+      // lesson row already exists for this day (lesson is required).
+      const existing = dayCompletions[dayNumber];
+      if (existing) {
+        // Preserve the original timestamp if the day was already fully done;
+        // don't overwrite an earlier completion time.
+        const newAllDoneAt = allDone ? (existing.all_tasks_completed_at ?? now) : null;
+
+        if (newAllDoneAt !== existing.all_tasks_completed_at) {
+          // Optimistic update first, then persist.
+          setDayCompletions(prev => ({
+            ...prev,
+            [dayNumber]: { ...existing, all_tasks_completed_at: newAllDoneAt },
+          }));
+          await supabase
+            .from('day_completions')
+            .update({ all_tasks_completed_at: newAllDoneAt })
+            .eq('user_id', user.id)
+            .eq('plan_started_at', planStartedAt)
+            .eq('day_number', dayNumber);
+        }
+      }
     }
   };
 
@@ -330,11 +425,11 @@ export default function App() {
 
         {currentView === View.PLAN_21 && (
           <Plan28
-            streak={streak}
             onOpenCheckIn={handleOpenCheckIn}
             hasCheckedInToday={hasCheckedInToday}
             completedTasks={completedPlanTasks}
             onTaskToggle={handlePlanTaskToggle}
+            dayCompletions={dayCompletions}
           />
         )}
 

--- a/webapp/components/JourneyPath.tsx
+++ b/webapp/components/JourneyPath.tsx
@@ -39,7 +39,10 @@ type Stone =
 
 interface JourneyPathProps {
   planData: PlanDay[];
-  currentPlanDay: number;
+  /** First day number whose stone should be yellow (active). */
+  activePlanDay: number;
+  /** Set of day numbers whose stone should be green (completed). */
+  completedDays: Set<number>;
   onSelectLesson: (day: PlanDay) => void;
 }
 
@@ -58,7 +61,8 @@ interface JourneyPathProps {
  */
 export const JourneyPath: React.FC<JourneyPathProps> = ({
   planData,
-  currentPlanDay,
+  activePlanDay,
+  completedDays,
   onSelectLesson,
 }) => {
   // Path column width — fixed at mount. Phone rotation is rare; mid-session
@@ -72,6 +76,12 @@ export const JourneyPath: React.FC<JourneyPathProps> = ({
    *  the upper-left, so it reads as a separate "start here" marker rather
    *  than just another step on the path. */
   const { introStone, stones, totalHeight } = useMemo(() => {
+    // Stone state helper — task-based, not date/streak-based.
+    const stoneState = (dayNum: number): LessonState => {
+      if (completedDays.has(dayNum)) return 'completed';
+      if (dayNum === activePlanDay) return 'current';
+      return 'future';
+    };
     const out: Stone[] = [];
     const centerX = containerWidth / 2;
     const amplitude = containerWidth * ZIGZAG_AMPLITUDE_RATIO;
@@ -114,8 +124,7 @@ export const JourneyPath: React.FC<JourneyPathProps> = ({
       y += STEP + LESSON_EXTRA_STEP;
 
       const day = sequencedDays[lessonIdx];
-      const state: LessonState =
-        day.day < currentPlanDay ? 'completed' : day.day === currentPlanDay ? 'current' : 'future';
+      const state: LessonState = stoneState(day.day);
       // Label on the OPPOSITE side of the column from the stone, so it stays
       // inside the column and never crosses the centerline.
       const labelSide: LabelSide = xOffset >= 0 ? 'left' : 'right';
@@ -140,12 +149,7 @@ export const JourneyPath: React.FC<JourneyPathProps> = ({
     // intro stone is well to its left, no visual collision.
     let intro: Stone | null = null;
     if (introDay) {
-      const introState: LessonState =
-        introDay.day < currentPlanDay
-          ? 'completed'
-          : introDay.day === currentPlanDay
-          ? 'current'
-          : 'future';
+      const introState: LessonState = stoneState(introDay.day);
       intro = {
         kind: 'lesson',
         index: -1,
@@ -159,16 +163,17 @@ export const JourneyPath: React.FC<JourneyPathProps> = ({
     }
 
     return { introStone: intro, stones: out, totalHeight: y + 80 };
-  }, [planData, currentPlanDay, containerWidth]);
+  }, [planData, activePlanDay, completedDays, containerWidth]);
 
   /** Ref on the current-day lesson stone — used to scroll into view on mount. */
   const currentStoneRef = useRef<HTMLButtonElement>(null);
 
+  // Re-scroll whenever the active stone changes (covers both initial mount and
+  // the moment a day is completed so the new yellow stone centres on screen).
+  // Plan28 remounts on every tab-open so this also fires on tab re-entry.
   useEffect(() => {
-    // 'auto' (instant) — smooth scroll on mount feels janky and competes with
-    // any concurrent enter animation if the user came from another tab.
     currentStoneRef.current?.scrollIntoView({ behavior: 'auto', block: 'center' });
-  }, []);
+  }, [activePlanDay]);
 
   return (
     <div className="relative bg-purple-100 min-h-full">

--- a/webapp/components/LessonBottomSheet.tsx
+++ b/webapp/components/LessonBottomSheet.tsx
@@ -6,11 +6,13 @@ interface LessonBottomSheetProps {
   day: PlanDay | null;
   isOpen: boolean;
   onClose: () => void;
-  currentPlanDay: number;
+  activePlanDay: number;
   hasCheckedInToday: boolean;
   completedTasks: Record<number, Set<string>>;
   onTaskToggle: (dayNumber: number, taskKey: string) => void;
   onOpenCheckIn: (payload: { tasksCompleted: boolean }) => void;
+  /** When true, PlanLessonContent shows an informational "come back tomorrow" banner. */
+  showComeTomorrow: boolean;
 }
 
 /** Exit animation duration — must match `.animate-sheet-down` in index.css. */
@@ -40,11 +42,12 @@ export const LessonBottomSheet: React.FC<LessonBottomSheetProps> = ({
   day,
   isOpen,
   onClose,
-  currentPlanDay,
+  activePlanDay,
   hasCheckedInToday,
   completedTasks,
   onTaskToggle,
   onOpenCheckIn,
+  showComeTomorrow,
 }) => {
   const [isClosing, setIsClosing] = useState(false);
   const [dragY, setDragY] = useState(0);
@@ -163,11 +166,12 @@ export const LessonBottomSheet: React.FC<LessonBottomSheetProps> = ({
         >
           <PlanLessonContent
             day={day}
-            currentPlanDay={currentPlanDay}
+            activePlanDay={activePlanDay}
             hasCheckedInToday={hasCheckedInToday}
             completedTasks={completedTasks}
             onTaskToggle={onTaskToggle}
             onOpenCheckIn={onOpenCheckIn}
+            showComeTomorrow={showComeTomorrow}
           />
         </div>
       </div>

--- a/webapp/components/Plan28.tsx
+++ b/webapp/components/Plan28.tsx
@@ -1,35 +1,83 @@
-import React, { useState } from 'react';
-import { planData, PlanDay } from '../data/planData';
+import React, { useMemo, useState } from 'react';
+import { planData, PlanDay, DayCompletion } from '../data/planData';
 import { JourneyPath } from './JourneyPath';
 import { LessonBottomSheet } from './LessonBottomSheet';
 
 interface Plan28Props {
-  streak: number;
   onOpenCheckIn: (payload: { tasksCompleted: boolean }) => void;
   hasCheckedInToday: boolean;
   completedTasks: Record<number, Set<string>>;
   onTaskToggle: (dayNumber: number, taskKey: string) => void;
+  // Timestamps from day_completions table — used to compute green/yellow stones.
+  dayCompletions: Record<number, DayCompletion>;
 }
 
 /**
  * Plan tab orchestrator. Renders the vertical stone-path journey and the
- * lesson bottom sheet that opens when the user taps a colored "lesson" stone.
+ * lesson bottom sheet that opens when the user taps a lesson stone.
  *
- * State is intentionally minimal — only the currently-open lesson and the
- * sheet visibility live here. All persistent progress (completed tasks,
- * streak, check-in status) is owned by App.tsx and passed through.
+ * Derives two key values from dayCompletions:
+ *   completedDays  — Set of day numbers whose stone should show green.
+ *   activePlanDay  — First day not in completedDays; the current yellow stone.
+ *
+ * Green stone rules (both checked client-side each render):
+ *   1. all_tasks_completed_at is set  → always green (immediate, same day).
+ *   2. lesson_completed_at is set AND it was on a prior calendar date → green.
+ *
+ * "Come back tomorrow" banner: shown inside the bottom sheet when the user opens
+ * activePlanDay and the previous day was fully completed today.
  */
 export const Plan28: React.FC<Plan28Props> = ({
-  streak,
   onOpenCheckIn,
   hasCheckedInToday,
   completedTasks,
   onTaskToggle,
+  dayCompletions,
 }) => {
-  // Streak → current plan day, capped at 28 (the final lesson).
-  // Day 0 is the intro: a new user (streak=0) lands on Day 0 as "current",
-  // their first CLEAN check-in advances them to Day 1, and so on.
-  const currentPlanDay = Math.min(streak, 28);
+  // today at midnight — stable for the component's lifetime (Plan28 remounts on
+  // tab switch so this is always fresh when the user re-opens the Journey tab).
+  const todayMidnight = useMemo(() => {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    return d;
+  }, []);
+
+  // Set of day numbers whose stone is green.
+  const completedDays = useMemo<Set<number>>(() => {
+    const result = new Set<number>();
+    for (const [dayStr, c] of Object.entries(dayCompletions)) {
+      const dayNum = Number(dayStr);
+      if (c.all_tasks_completed_at) {
+        // Fully done — green regardless of when.
+        result.add(dayNum);
+      } else if (c.lesson_completed_at) {
+        // Lesson done on a prior calendar day — green.
+        const lessonDate = new Date(c.lesson_completed_at);
+        lessonDate.setHours(0, 0, 0, 0);
+        if (lessonDate < todayMidnight) result.add(dayNum);
+      }
+    }
+    return result;
+  }, [dayCompletions, todayMidnight]);
+
+  // First plan day (sequential, 0 → 28) not in completedDays.
+  const activePlanDay = useMemo(() => {
+    for (const day of planData) {
+      if (!completedDays.has(day.day)) return day.day;
+    }
+    return 28;
+  }, [completedDays]);
+
+  // True when the previous day was fully completed today — triggers the
+  // "come back tomorrow" informational banner in the lesson bottom sheet.
+  const showComeTomorrow = useMemo(() => {
+    if (activePlanDay === 0) return false;
+    const prev = dayCompletions[activePlanDay - 1];
+    if (!prev?.all_tasks_completed_at) return false;
+    const completedDate = new Date(prev.all_tasks_completed_at);
+    completedDate.setHours(0, 0, 0, 0);
+    return completedDate.getTime() === todayMidnight.getTime();
+  }, [activePlanDay, dayCompletions, todayMidnight]);
 
   // Selected day is kept after close so the sheet can play its exit animation
   // without the content disappearing mid-slide.
@@ -45,18 +93,20 @@ export const Plan28: React.FC<Plan28Props> = ({
     <div className="h-full w-full overflow-y-auto bg-purple-100">
       <JourneyPath
         planData={planData}
-        currentPlanDay={currentPlanDay}
+        activePlanDay={activePlanDay}
+        completedDays={completedDays}
         onSelectLesson={handleSelectLesson}
       />
       <LessonBottomSheet
         day={selectedDay}
         isOpen={isSheetOpen}
         onClose={() => setIsSheetOpen(false)}
-        currentPlanDay={currentPlanDay}
+        activePlanDay={activePlanDay}
         hasCheckedInToday={hasCheckedInToday}
         completedTasks={completedTasks}
         onTaskToggle={onTaskToggle}
         onOpenCheckIn={onOpenCheckIn}
+        showComeTomorrow={showComeTomorrow}
       />
     </div>
   );

--- a/webapp/components/PlanLessonContent.tsx
+++ b/webapp/components/PlanLessonContent.tsx
@@ -1,35 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { PlanDay } from '../data/planData';
-import { Check, Award, CheckCircle, Info, BookOpen, CheckCircle2 } from 'lucide-react';
+import { Check, Award, CheckCircle, Info, BookOpen, CheckCircle2, Sun } from 'lucide-react';
 import { lessonsData } from '../data/lessonsData';
 import { LessonPlayer } from './LessonPlayer';
 
-/**
- * Interpolates the AccordionCard's checkmark color from stone-300 (incomplete)
- * toward emerald-500 (complete) as the user ticks off tasks. Identical to the
- * function previously inlined at the top of Plan28.tsx — kept here so the new
- * sheet does not need to depend on the legacy carousel file.
- */
-const calculateCheckmarkColor = (completed: number, total: number) => {
-  if (total === 0 || completed === 0) {
-    return { color: 'rgb(214, 211, 209)', fill: 'rgb(255, 255, 255)' }; // stone-300, white
-  }
-
-  const progress = completed / total;
-  const grayColor = [214, 211, 209];
-  const greenColor = [16, 185, 129];
-  const grayFill = [255, 255, 255];
-  const greenFill = [240, 253, 244];
-
-  const r = Math.round(grayColor[0] + (greenColor[0] - grayColor[0]) * progress);
-  const g = Math.round(grayColor[1] + (greenColor[1] - grayColor[1]) * progress);
-  const b = Math.round(grayColor[2] + (greenColor[2] - grayColor[2]) * progress);
-  const fillR = Math.round(grayFill[0] + (greenFill[0] - grayFill[0]) * progress);
-  const fillG = Math.round(grayFill[1] + (greenFill[1] - grayFill[1]) * progress);
-  const fillB = Math.round(grayFill[2] + (greenFill[2] - grayFill[2]) * progress);
-
-  return { color: `rgb(${r}, ${g}, ${b})`, fill: `rgb(${fillR}, ${fillG}, ${fillB})` };
-};
 
 const FormattedContent = ({ text }: { text: string }) => (
   <p className="leading-relaxed mb-4">{text}</p>
@@ -37,11 +11,13 @@ const FormattedContent = ({ text }: { text: string }) => (
 
 export interface PlanLessonContentProps {
   day: PlanDay;
-  currentPlanDay: number;
+  activePlanDay: number;
   hasCheckedInToday: boolean;
   completedTasks: Record<number, Set<string>>;
   onTaskToggle: (dayNumber: number, taskKey: string) => void;
   onOpenCheckIn: (payload: { tasksCompleted: boolean }) => void;
+  /** When true, shows an informational banner nudging the user to return tomorrow. */
+  showComeTomorrow?: boolean;
 }
 
 /**
@@ -51,11 +27,12 @@ export interface PlanLessonContentProps {
  */
 export const PlanLessonContent: React.FC<PlanLessonContentProps> = ({
   day,
-  currentPlanDay,
+  activePlanDay,
   hasCheckedInToday,
   completedTasks,
   onTaskToggle,
   onOpenCheckIn,
+  showComeTomorrow,
 }) => {
   const [openAccordion, setOpenAccordion] = useState<string | null>(null);
   const [isPlayerOpen, setIsPlayerOpen] = useState(false);
@@ -79,26 +56,20 @@ export const PlanLessonContent: React.FC<PlanLessonContentProps> = ({
 
   const handleCheck = (task: string) => onTaskToggle(day.day, task);
 
-  const morningTasksCompleted = day.morningProtocol?.reduce(
-    (acc, _item, index) => (checkedTasks.has(`m-${index}`) ? acc + 1 : acc),
-    0,
-  ) ?? 0;
   const totalMorningTasks = day.morningProtocol?.length ?? 0;
-  const morningCompletionColors = calculateCheckmarkColor(morningTasksCompleted, totalMorningTasks);
-  const isMorningComplete = totalMorningTasks > 0 && morningTasksCompleted === totalMorningTasks;
+  const isMorningComplete =
+    totalMorningTasks > 0 &&
+    day.morningProtocol!.every((_, i) => checkedTasks.has(`m-${i}`));
 
-  const eveningTasksCompleted = day.eveningProtocol?.reduce(
-    (acc, _item, index) => (checkedTasks.has(`e-${index}`) ? acc + 1 : acc),
-    0,
-  ) ?? 0;
   const totalEveningTasks = day.eveningProtocol?.length ?? 0;
-  const eveningCompletionColors = calculateCheckmarkColor(eveningTasksCompleted, totalEveningTasks);
-  const isEveningComplete = totalEveningTasks > 0 && eveningTasksCompleted === totalEveningTasks;
+  const isEveningComplete =
+    totalEveningTasks > 0 &&
+    day.eveningProtocol!.every((_, i) => checkedTasks.has(`e-${i}`));
 
   const handleOpenCheckIn = () => {
-    const isForCurrentPlanDay = day.day === currentPlanDay;
     onOpenCheckIn({
-      tasksCompleted: isMorningComplete && isEveningComplete && isLessonCompleted && isForCurrentPlanDay,
+      tasksCompleted:
+        isMorningComplete && isEveningComplete && isLessonCompleted && day.day === activePlanDay,
     });
   };
 
@@ -130,8 +101,6 @@ export const PlanLessonContent: React.FC<PlanLessonContentProps> = ({
     title,
     subtitle,
     isComplete,
-    checkmarkColor,
-    checkmarkFill,
     isOpen,
     onToggle,
     children,
@@ -140,15 +109,13 @@ export const PlanLessonContent: React.FC<PlanLessonContentProps> = ({
     title: string;
     subtitle: string;
     isComplete?: boolean;
-    checkmarkColor?: string;
-    checkmarkFill?: string;
     isOpen: boolean;
     onToggle: () => void;
     children: React.ReactNode;
     iconIndex?: number;
   }) => {
-    const color = checkmarkColor || (isComplete ? 'rgb(16, 185, 129)' : 'rgb(214, 211, 209)');
-    const fill = checkmarkFill || (isComplete ? 'rgb(240, 253, 244)' : 'rgb(255, 255, 255)');
+    const color = isComplete ? 'rgb(16, 185, 129)' : 'rgb(214, 211, 209)';
+    const fill = isComplete ? 'rgb(240, 253, 244)' : 'rgb(255, 255, 255)';
 
     return (
       <div className="bg-white rounded-2xl border border-purple-100 shadow-sm overflow-hidden transition-all relative">
@@ -244,6 +211,19 @@ export const PlanLessonContent: React.FC<PlanLessonContentProps> = ({
   if (day.morningProtocol && day.eveningProtocol) {
     return (
       <div className="space-y-4 animate-in fade-in duration-300">
+        {/* Informational banner: user already completed today's activities and is
+            peeking at the next day's content. Not blocking — just a nudge. */}
+        {showComeTomorrow && day.day === activePlanDay && (
+          <div className="flex items-start gap-3 p-4 bg-amber-50 border border-amber-200 rounded-2xl">
+            <Sun size={18} className="text-amber-500 flex-shrink-0 mt-0.5" />
+            <div>
+              <p className="text-sm font-semibold text-amber-800">You're ahead!</p>
+              <p className="text-xs text-amber-700 mt-0.5">
+                You've completed today's activities. Come back tomorrow for Day {activePlanDay + 1}.
+              </p>
+            </div>
+          </div>
+        )}
         <header className="mb-6">
           <span className="text-sm font-bold text-emerald-600 uppercase tracking-wider">Day {day.day}</span>
           <div className="flex items-center gap-2 mt-1">
@@ -330,8 +310,7 @@ export const PlanLessonContent: React.FC<PlanLessonContentProps> = ({
           <AccordionCard
             title="Morning Protocol"
             subtitle="Start strong. Set the tone."
-            checkmarkColor={morningCompletionColors.color}
-            checkmarkFill={morningCompletionColors.fill}
+            isComplete={isMorningComplete}
             isOpen={openAccordion === 'morning'}
             onToggle={() => handleAccordionToggle('morning')}
             iconIndex={1}
@@ -348,8 +327,7 @@ export const PlanLessonContent: React.FC<PlanLessonContentProps> = ({
           <AccordionCard
             title="Evening Protocol"
             subtitle="Slow down. Lock it in."
-            checkmarkColor={eveningCompletionColors.color}
-            checkmarkFill={eveningCompletionColors.fill}
+            isComplete={isEveningComplete}
             isOpen={openAccordion === 'evening'}
             onToggle={() => handleAccordionToggle('evening')}
             iconIndex={3}

--- a/webapp/data/planData.ts
+++ b/webapp/data/planData.ts
@@ -1,3 +1,9 @@
+/** One row from the `day_completions` table, keyed by day number. */
+export type DayCompletion = {
+  lesson_completed_at: string;
+  all_tasks_completed_at: string | null;
+};
+
 export interface PlanDay {
   day: number;
   title: string;
@@ -8,6 +14,23 @@ export interface PlanDay {
   tipOfTheDay?: string | { mistake: string; practice: string; };
   eveningProtocol?: { main: string; details: string }[];
   whatToExpectToday?: string[];
+}
+
+/**
+ * Returns the full set of task keys required to mark a day as fully complete.
+ * Keys match the format used in plan_progress (and completedPlanTasks state):
+ *   morning items → 'm-0', 'm-1', ...
+ *   evening items → 'e-0', 'e-1', ...
+ *   lesson        → 'lesson' (only when the day has a lesson in lessonsData)
+ *
+ * Day 0 has no morning/evening protocol so only 'lesson' is required (if present).
+ */
+export function getRequiredTaskKeys(day: PlanDay, hasLesson: boolean): string[] {
+  const keys: string[] = [];
+  day.morningProtocol?.forEach((_, i) => keys.push(`m-${i}`));
+  day.eveningProtocol?.forEach((_, i) => keys.push(`e-${i}`));
+  if (hasLesson) keys.push('lesson');
+  return keys;
 }
 
 export const planData: PlanDay[] = [


### PR DESCRIPTION
Replaces the streak/check-in-based stone colours on the Journey path with real task completion logic persisted to Supabase.

Closes #36

## What changed

- **New `day_completions` Supabase table** (`supabase/migrations/20260513_day_completions.sql`) — stores `lesson_completed_at` and `all_tasks_completed_at` per (user, plan cycle, day)
- **Two-tier green logic** — stone turns green immediately when all tasks done same-day; green on next calendar day if only the lesson was finished
- **`activePlanDay`** now derived from lesson completion (first day without `lesson_completed_at`), replacing streak-based `currentPlanDay`
- **Optimistic UI** — `setDayCompletions` fires before DB awaits so the stone updates instantly
- **Binary accordion states** — removed gradient `calculateCheckmarkColor`; morning/evening headers are now emerald (complete) or stone-300 (incomplete)
- **"Come back tomorrow" banner** — informational amber banner shown when the user opens the active day after fully completing the previous day same-session
- **Auto-scroll** — `useEffect` dep changed from `[]` to `[activePlanDay]`; re-fires on every tab open since Plan28 remounts
- **Code quality** — `DayCompletion` type extracted to `planData.ts` (single source of truth); `plan_progress` + `day_completions` fetches parallelized in `loadUserData`; dead `checkmarkColor`/`checkmarkFill` props removed from `AccordionCard`

## Commits
- `539651b` feat: task-based day completion logic for Journey path (Issue #36)

Smoke test runs automatically on push via Claude Code hook.