### PR TITLE
fix: legal docs — workstream A quick fixes (#50)

### DIFF
--- a/.claude/plans/issue-50-legal-quick-fixes.md
+++ b/.claude/plans/issue-50-legal-quick-fixes.md
@@ -1,0 +1,53 @@
+# Feature Implementation Plan — Issue #50: Legal quick fixes (Workstream A)
+
+**Overall Progress:** `100%`
+
+## TLDR
+First PR off the legal-audit umbrella issue (#50). Ships **workstream A only** — 8 text/CSS-level fixes within the 4 `funnel/legal/*.html` files. Closes a real doc/product mismatch (in-app cancel exists; docs say email-only) and several minor regulatory hygiene items. No new compliance content (that's workstream B) and no engineering (that's workstream C).
+
+## Critical Decisions
+- **Medical disclaimer as visual callout box** (light amber bg, left border) at top of Terms + Subscription only — most professional, most clearly "conspicuous" per regulatory expectations.
+- **Refund "pointer" pattern** — Terms §6.3 references Subscription §6 instead of duplicating refund text.
+- **Cancellation: in-account primary, email alternative** — describes product reality (`webapp/components/CancelFlow.tsx` exists) AND closes audit Critical #3.
+- **Combined Steps 3+4 into one §6.3 rewrite** — both touched the same paragraph; cleaner to land both in one Edit.
+- **Skip date refresh** — `Last updated: June 1, 2026` already matches today; no change needed.
+- **CSS duplicated across 4 files** — kept existing pattern; just added `.medical-disclaimer` to Terms + Subscription.
+
+## Tasks
+
+- [x] 🟩 **Step 1: Medical disclaimer callout** (Terms + Subscription)
+  - [x] 🟩 `.medical-disclaimer` CSS class in both files' `<style>` blocks (amber `#FEF3C7` bg, `#F59E0B` left border, `#78350F` text)
+  - [x] 🟩 `<div class="medical-disclaimer">` inserted after `<p class="last-updated">` in both, with merged §1+§9.2 wording
+  - [x] 🟩 Existing §1 + §10.2 (renumbered) paragraphs preserved
+
+- [x] 🟩 **Step 2: Eligibility / age gate in Terms**
+  - [x] 🟩 New `<h2>2. Eligibility</h2>` + paragraph inserted between current §1 and former §2
+  - [x] 🟩 Renumbered §2 → §3 through §17 → §18 (all `<h2>` and `<h3>` subsections)
+  - [x] 🟩 Updated single cross-reference: `Section 16.1` → `Section 17.1` in §13.2
+
+- [x] 🟩 **Step 3 + 4 (combined): Cancel + refund rewrite in §6.3**
+  - [x] 🟩 §6.3 now: in-app cancel primary ("Profile → Subscription → Cancel Subscription"), email alternative, refund eligibility points to Subscription §6
+  - [x] 🟩 `subscription-policy.html` §5 mirrors same wording
+
+- [x] 🟩 **Step 5: 30 vs 45-day timeline (Privacy §11)**
+  - [x] 🟩 Now reads: "thirty (30) days under the GDPR, or forty-five (45) days for California residents under the CCPA, or such longer period…"
+
+- [x] 🟩 **Step 6: Trade-name disclosure parity** (Subscription + Cookie)
+  - [x] 🟩 Pre-incorporation `<p>` added to bottom of both, matching Privacy + Terms wording
+
+- [x] 🟩 **Step 7: Currency conversion clarity** (Subscription §4)
+  - [x] 🟩 Now explicitly: "Prices on the Mind Compass website are displayed in EUR. If your payment method is denominated in a different currency, your bank or card issuer performs the conversion at its own rate."
+
+- [x] 🟩 **Step 8: Date refresh** — no-op, already at today's date (June 1, 2026)
+
+- [x] 🟩 **Step 9: Local verification**
+  - [x] 🟩 All 4 `localhost:8080/legal/*.html` → 200 OK
+  - [x] 🟩 Internal links between docs intact (verified via grep)
+
+- [x] 🟩 **Step 10: Pre-PR sanity**
+  - [x] 🟩 `git diff --stat`: 4 files, +76/-43
+  - [x] 🟩 Email retained as alternative cancel method (not primary)
+  - [x] 🟩 Trade-name disclosure now in all 4 docs (was 2)
+  - [x] 🟩 Medical disclaimer only in Terms + Subscription (correct scope)
+  - [x] 🟩 In-app cancel ("Profile → Subscription") in both Terms + Subscription
+  - [x] 🟩 Age gate ("eighteen (18) years or older") in Terms

--- a/funnel/legal/cookie-policy.html
+++ b/funnel/legal/cookie-policy.html
@@ -264,6 +264,7 @@
         Email: <a href="mailto:aicompass.tech@gmail.com">aicompass.tech@gmail.com</a><br>
         Website: <a href="https://ai-dopamine-cursor.vercel.app">ai-dopamine-cursor.vercel.app</a>
     </p>
+    <p style="font-size: 13px; color: #6b7280; margin-top: 16px;">Mind Compass is currently operated as a trade name and is not yet a registered legal entity. A registered legal entity name, registered office address, and company registration number will be added to this Policy upon incorporation.</p>
 </div>
 </body>
 </html>

--- a/funnel/legal/privacy-policy.html
+++ b/funnel/legal/privacy-policy.html
@@ -232,7 +232,7 @@
         <li><strong>Right to restrict processing:</strong> you have the right to request that we restrict the processing of your personal data in certain circumstances;</li>
         <li><strong>Right to lodge a complaint:</strong> you have the right to lodge a complaint with a data protection supervisory authority in your country of residence if you believe that our processing of your personal data violates applicable law.</li>
     </ul>
-    <p>To exercise any of these rights, please contact us at <a href="mailto:aicompass.tech@gmail.com">aicompass.tech@gmail.com</a>. We will respond to your request within thirty (30) days, or such longer period as permitted by applicable law.</p>
+    <p>To exercise any of these rights, please contact us at <a href="mailto:aicompass.tech@gmail.com">aicompass.tech@gmail.com</a>. We will respond to your request within thirty (30) days under the GDPR, or forty-five (45) days for California residents under the CCPA, or such longer period as permitted by applicable law.</p>
 
     <h2><span class="section-number">12.</span> Do Not Track</h2>
     <p>Some web browsers transmit "Do Not Track" (DNT) signals to websites. Because there is no universally accepted standard for how to respond to DNT signals, the Service does not currently respond to DNT browser signals or headers. We will continue to monitor developments regarding DNT and may adopt a standard once one is established.</p>

--- a/funnel/legal/subscription-policy.html
+++ b/funnel/legal/subscription-policy.html
@@ -82,6 +82,15 @@
             font-size: 14px;
             color: #6b7280;
         }
+        .medical-disclaimer {
+            margin-bottom: 32px;
+            padding: 16px 20px;
+            background: #FEF3C7;
+            border-left: 4px solid #F59E0B;
+            border-radius: 8px;
+            font-size: 15px;
+            color: #78350F;
+        }
         @media (max-width: 600px) {
             .container {
                 padding: 20px 16px calc(40px + env(safe-area-inset-bottom, 0px));
@@ -101,6 +110,10 @@
 
     <h1>Subscription Policy</h1>
     <p class="last-updated">Last updated: June 1, 2026</p>
+
+    <div class="medical-disclaimer">
+        <strong>Not a medical service.</strong> Mind Compass is a self-development program, not a substitute for professional medical advice, diagnosis, treatment, therapy, or mental health care. Always seek the advice of a qualified healthcare provider with any questions regarding a medical or mental health condition. Never disregard professional medical advice or delay in seeking it because of content accessed through the Service.
+    </div>
 
     <p>This Subscription Policy outlines the terms governing subscriptions to the Mind Compass service operated under the trade name Mind Compass ("Mind Compass," "we," "us," or "our"). By subscribing to the Service, you agree to the terms set forth in this policy, in addition to our <a href="terms-of-use.html">Terms of Use</a> and <a href="privacy-policy.html">Privacy Policy</a>.</p>
 
@@ -124,10 +137,10 @@
     <p>All payments are processed through Stripe (which may include Apple Pay or Google Pay where available and enabled by your device). Mind Compass does not directly store your full payment card details. Your payment information is handled in accordance with the payment processor's security standards and privacy policies.</p>
     <p>Subscription fees are charged in advance at the beginning of each billing period. The billing cycle is determined by the subscription plan you select.</p>
     <p>If your payment method is declined or fails for any reason, Mind Compass may attempt to charge the payment method again. If payment cannot be successfully processed, Mind Compass reserves the right to suspend or terminate your access to the Service until payment is received.</p>
-    <p>All prices are displayed in the currency indicated at the time of purchase. You are responsible for any applicable taxes, currency conversion fees, or other charges imposed by your financial institution.</p>
+    <p>Prices on the Mind Compass website are displayed in your detected local currency (currently EUR, USD, GBP, CAD, or AUD). If your payment method is denominated in a different currency, your bank or card issuer performs the conversion at its own rate. You are responsible for any applicable taxes, currency conversion fees, or other charges imposed by your financial institution.</p>
 
     <h2><span class="section-number">5.</span> Cancellation</h2>
-    <p>You may cancel your subscription at any time by contacting our support team at <a href="mailto:aicompass.tech@gmail.com">aicompass.tech@gmail.com</a>. Please include your account email address and a clear request to cancel your subscription.</p>
+    <p>You may cancel your subscription at any time directly from your account on the Mind Compass web app: <strong>Sidebar Profile → Access tab</strong>, then click <strong>Cancel</strong> on your subscription. Cancellation takes effect immediately and no further charges will be made; you retain access through the end of your current billing period. You may alternatively email <a href="mailto:aicompass.tech@gmail.com">aicompass.tech@gmail.com</a> with your account email address and a clear request to cancel.</p>
     <p>Upon cancellation:</p>
     <ul>
         <li>Your subscription will remain active until the end of the current billing period;</li>
@@ -172,6 +185,7 @@
         Email: <a href="mailto:aicompass.tech@gmail.com">aicompass.tech@gmail.com</a><br>
         Website: <a href="https://ai-dopamine-cursor.vercel.app">ai-dopamine-cursor.vercel.app</a>
     </p>
+    <p style="font-size: 13px; color: #6b7280; margin-top: 16px;">Mind Compass is currently operated as a trade name and is not yet a registered legal entity. A registered legal entity name, registered office address, and company registration number will be added to this Policy upon incorporation.</p>
 </div>
 </body>
 </html>

--- a/funnel/legal/terms-of-use.html
+++ b/funnel/legal/terms-of-use.html
@@ -82,6 +82,15 @@
             font-size: 14px;
             color: #6b7280;
         }
+        .medical-disclaimer {
+            margin-bottom: 32px;
+            padding: 16px 20px;
+            background: #FEF3C7;
+            border-left: 4px solid #F59E0B;
+            border-radius: 8px;
+            font-size: 15px;
+            color: #78350F;
+        }
         @media (max-width: 600px) {
             .container {
                 padding: 20px 16px calc(40px + env(safe-area-inset-bottom, 0px));
@@ -102,6 +111,10 @@
     <h1>Terms of Use and Service</h1>
     <p class="last-updated">Last updated: June 1, 2026</p>
 
+    <div class="medical-disclaimer">
+        <strong>Not a medical service.</strong> Mind Compass is a self-development program, not a substitute for professional medical advice, diagnosis, treatment, therapy, or mental health care. Always seek the advice of a qualified healthcare provider with any questions regarding a medical or mental health condition. Never disregard professional medical advice or delay in seeking it because of content accessed through the Service.
+    </div>
+
     <p>Welcome to Mind Compass. These Terms of Use and Service ("Terms") govern your access to and use of the Mind Compass website, applications, and services (collectively, the "Service") operated under the trade name Mind Compass ("Mind Compass," "we," "us," or "our").</p>
 
     <p>By accessing or using the Service, you agree to be bound by these Terms. If you do not agree to these Terms, you may not access or use the Service.</p>
@@ -113,7 +126,10 @@
     <p>The Service is provided for informational, educational, and self-improvement purposes only. Mind Compass is not, and is not intended to be, a substitute for professional medical advice, diagnosis, treatment, therapy, or mental health care. Always seek the advice of a qualified healthcare provider regarding any medical or mental health condition.</p>
     <p>We reserve the right to modify, suspend, or discontinue any part of the Service at any time, with or without notice. We shall not be liable to you or any third party for any modification, suspension, or discontinuation of the Service.</p>
 
-    <h2><span class="section-number">2.</span> License and Restrictions</h2>
+    <h2><span class="section-number">2.</span> Eligibility</h2>
+    <p>The Service is intended solely for adults aged eighteen (18) years or older. By accessing or using the Service, you represent and warrant that you are at least 18 years of age and have the legal capacity to enter into a binding contract. If you are under 18, you may not access, use, register for, or purchase a subscription to the Service. Mind Compass reserves the right to terminate any account it reasonably believes belongs to a person under 18.</p>
+
+    <h2><span class="section-number">3.</span> License and Restrictions</h2>
     <p>Subject to your compliance with these Terms, Mind Compass grants you a limited, non-exclusive, non-transferable, non-sublicensable, revocable license to access and use the Service and Content for your personal, non-commercial use only.</p>
     <p>You agree not to:</p>
     <ul>
@@ -127,23 +143,23 @@
         <li>Use the Service in any manner that could damage, disable, overburden, or impair the Service.</li>
     </ul>
 
-    <h2><span class="section-number">3.</span> Intellectual Property Rights</h2>
+    <h2><span class="section-number">4.</span> Intellectual Property Rights</h2>
 
-    <h3>3.1 Ownership</h3>
+    <h3>4.1 Ownership</h3>
     <p>The Service and all Content, features, and functionality (including but not limited to all information, software, text, displays, images, video, audio, and the design, selection, and arrangement thereof) are owned by Mind Compass, its licensors, or other providers of such material and are protected by international copyright, trademark, patent, trade secret, and other intellectual property or proprietary rights laws.</p>
 
-    <h3>3.2 Content</h3>
+    <h3>4.2 Content</h3>
     <p>All Content available through the Service, including text, graphics, logos, icons, images, audio clips, digital downloads, and data compilations, is the property of Mind Compass or its content suppliers and is protected by international copyright laws.</p>
 
-    <h3>3.3 Use of Content</h3>
+    <h3>4.3 Use of Content</h3>
     <p>You may access and display Content solely for your personal, non-commercial use. You may not republish, reproduce, duplicate, copy, sell, resell, or exploit any Content or any portion of the Service without express written consent from Mind Compass.</p>
 
-    <h3>3.4 Third Party Software</h3>
+    <h3>4.4 Third Party Software</h3>
     <p>The Service may include third-party software that is subject to its own terms and conditions. Nothing in these Terms shall be construed as granting you any rights to such third-party software beyond what is permitted by the applicable third-party license.</p>
 
-    <h2><span class="section-number">4.</span> User Submissions</h2>
+    <h2><span class="section-number">5.</span> User Submissions</h2>
 
-    <h3>4.1 User Submissions</h3>
+    <h3>5.1 User Submissions</h3>
     <p>The Service may allow you to submit, post, or transmit content, including but not limited to text, data, feedback, suggestions, and other materials ("User Submissions"). You are solely responsible for your User Submissions and the consequences of posting or publishing them.</p>
     <p>By providing User Submissions, you represent and warrant that:</p>
     <ul>
@@ -152,32 +168,32 @@
         <li>Your User Submissions do not contain any material that is unlawful, defamatory, obscene, or otherwise objectionable.</li>
     </ul>
 
-    <h3>4.2 License to User Submissions</h3>
+    <h3>5.2 License to User Submissions</h3>
     <p>By submitting User Submissions, you grant Mind Compass a worldwide, non-exclusive, royalty-free, perpetual, irrevocable, sublicensable, and transferable license to use, reproduce, modify, adapt, publish, translate, create derivative works from, distribute, perform, and display such User Submissions in any media or distribution method now known or later developed, in connection with the Service and the business of Mind Compass.</p>
 
-    <h2><span class="section-number">5.</span> Terms of Payment</h2>
+    <h2><span class="section-number">6.</span> Terms of Payment</h2>
 
-    <h3>5.1 General Provisions</h3>
+    <h3>6.1 General Provisions</h3>
     <p>Access to certain features of the Service requires a paid subscription. Prices, billing periods, renewal terms, and any applicable taxes or fees are displayed at the time of purchase. By completing a purchase, you agree to pay the price and any applicable charges shown at checkout. Subscriptions renew automatically unless cancelled before the renewal date, as further described in our <a href="subscription-policy.html">Subscription Policy</a>.</p>
     <p>You authorize Mind Compass to charge the payment method you provide for all subscription fees. If your payment method fails or your account is past due, Mind Compass may collect fees using other collection mechanisms, and Mind Compass reserves the right to suspend or terminate your access to the Service.</p>
 
-    <h3>5.2 Refunds</h3>
+    <h3>6.2 Refunds</h3>
     <p>Refunds are governed by the money-back guarantee terms described in our <a href="subscription-policy.html">Subscription Policy</a>, where expressly advertised on the applicable offer or checkout page. All refund requests should be submitted to <a href="mailto:aicompass.tech@gmail.com">aicompass.tech@gmail.com</a>. Nothing in these Terms limits any statutory refund or cancellation rights you may have under the mandatory consumer protection laws of your country of residence.</p>
 
-    <h3>5.3 Subscription Cancellation</h3>
-    <p>You may cancel your subscription at any time by contacting us at <a href="mailto:aicompass.tech@gmail.com">aicompass.tech@gmail.com</a>. Upon cancellation, you will continue to have access to the Service through the end of your current billing period. No refunds will be issued for the remaining portion of the current billing period unless otherwise required by applicable law or our money-back guarantee terms.</p>
+    <h3>6.3 Subscription Cancellation</h3>
+    <p>You may cancel your subscription at any time directly from your account on the Mind Compass web app: <strong>Sidebar Profile → Access tab</strong>, then click <strong>Cancel</strong> on your subscription. Cancellation takes effect immediately and no further charges will be made; you retain access through the end of your current billing period. You may alternatively email <a href="mailto:aicompass.tech@gmail.com">aicompass.tech@gmail.com</a> with your account email address and a clear request to cancel. Refund eligibility for the current billing period is governed by §6 of our <a href="subscription-policy.html">Subscription Policy</a> and by the mandatory consumer protection laws of your country of residence.</p>
 
-    <h2><span class="section-number">6.</span> Privacy</h2>
+    <h2><span class="section-number">7.</span> Privacy</h2>
     <p>Your use of the Service is also governed by our <a href="privacy-policy.html">Privacy Policy</a>, which is incorporated into these Terms by reference. Please review our Privacy Policy to understand our practices regarding the collection, use, and disclosure of your personal data.</p>
 
-    <h2><span class="section-number">7.</span> Termination of Account</h2>
+    <h2><span class="section-number">8.</span> Termination of Account</h2>
     <p>Mind Compass may terminate or suspend your account and access to the Service immediately, without prior notice or liability, for any reason, including without limitation if you breach these Terms. Upon termination, your right to use the Service will immediately cease.</p>
     <p>You may terminate your account at any time by contacting us at <a href="mailto:aicompass.tech@gmail.com">aicompass.tech@gmail.com</a>. Upon termination of your account, your right to access and use the Service will end immediately. Mind Compass is not obligated to retain, store, or provide you with any data or content associated with your account after termination.</p>
     <p>All provisions of these Terms which by their nature should survive termination shall survive, including without limitation ownership provisions, warranty disclaimers, indemnity, and limitations of liability.</p>
 
-    <h2><span class="section-number">8.</span> Copyright Policy</h2>
+    <h2><span class="section-number">9.</span> Copyright Policy</h2>
 
-    <h3>8.1 Reporting Claimed Infringement</h3>
+    <h3>9.1 Reporting Claimed Infringement</h3>
     <p>If you believe that any content available through the Service infringes your copyright, you may submit a notification of claimed infringement to our designated agent. Your notification must include:</p>
     <ul>
         <li>A physical or electronic signature of the copyright owner or a person authorized to act on their behalf;</li>
@@ -188,67 +204,67 @@
         <li>A statement, made under penalty of perjury, that the information in the notification is accurate and that you are authorized to act on behalf of the copyright owner.</li>
     </ul>
 
-    <h3>8.2 Designated Agent</h3>
+    <h3>9.2 Designated Agent</h3>
     <p>Our designated agent for receiving notifications of claimed infringement can be reached at: <a href="mailto:aicompass.tech@gmail.com">aicompass.tech@gmail.com</a>.</p>
 
-    <h3>8.3 False Notifications</h3>
+    <h3>9.3 False Notifications</h3>
     <p>Please be aware that under applicable law, any person who knowingly materially misrepresents that material or activity is infringing may be subject to liability for damages, including costs and attorneys' fees incurred by Mind Compass, the alleged infringer, or any copyright owner or authorized licensee who is injured by such misrepresentation.</p>
 
-    <h2><span class="section-number">9.</span> Disclaimers of Warranties</h2>
+    <h2><span class="section-number">10.</span> Disclaimers of Warranties</h2>
 
-    <h3>9.1 Basic Disclaimer</h3>
+    <h3>10.1 Basic Disclaimer</h3>
     <p>THE SERVICE AND ALL CONTENT ARE PROVIDED ON AN "AS IS" AND "AS AVAILABLE" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED. MIND COMPASS DISCLAIMS ALL WARRANTIES, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT. MIND COMPASS DOES NOT WARRANT THAT THE SERVICE WILL BE UNINTERRUPTED, ERROR-FREE, SECURE, OR FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS.</p>
 
-    <h3>9.2 Absence of Professional Advice</h3>
+    <h3>10.2 Absence of Professional Advice</h3>
     <p>The Content provided through the Service is for informational and educational purposes only. Mind Compass is not, and is not intended to be, a substitute for professional medical advice, diagnosis, treatment, therapy, mental health care, or any other professional service. Always seek the advice of a qualified healthcare provider with any questions you may have regarding a medical or mental health condition. Never disregard professional medical advice or delay in seeking it because of Content accessed through the Service. Mind Compass does not recommend or endorse any specific tests, physicians, products, procedures, opinions, or other information that may be mentioned through the Service.</p>
 
-    <h3>9.3 Website Changes</h3>
+    <h3>10.3 Website Changes</h3>
     <p>Mind Compass reserves the right to modify, update, or discontinue the Service or any part thereof at any time without notice. We shall not be liable to you or any third party for any modification, price change, suspension, or discontinuation of the Service.</p>
 
-    <h2><span class="section-number">10.</span> Limitation of Liability</h2>
+    <h2><span class="section-number">11.</span> Limitation of Liability</h2>
     <p>TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL MIND COMPASS, ITS AFFILIATES, OPERATORS, EMPLOYEES, AGENTS, SUPPLIERS, OR LICENSORS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, PUNITIVE, OR EXEMPLARY DAMAGES, INCLUDING BUT NOT LIMITED TO DAMAGES FOR LOSS OF PROFITS, GOODWILL, USE, DATA, OR OTHER INTANGIBLE LOSSES, ARISING OUT OF OR IN CONNECTION WITH YOUR ACCESS TO OR USE OF (OR INABILITY TO ACCESS OR USE) THE SERVICE.</p>
     <p>TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW, THE TOTAL AGGREGATE LIABILITY OF MIND COMPASS TO YOU FOR ALL CLAIMS ARISING OUT OF OR RELATING TO THE SERVICE SHALL NOT EXCEED THE GREATER OF (A) THE TOTAL AMOUNT OF FEES PAID BY YOU TO MIND COMPASS DURING THE TWELVE (12) MONTHS PRECEDING THE DATE OF THE CLAIM, OR (B) ONE HUNDRED U.S. DOLLARS ($100).</p>
     <p>SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF CERTAIN DAMAGES, SO SOME OF THE ABOVE LIMITATIONS MAY NOT APPLY TO YOU. NOTHING IN THESE TERMS LIMITS ANY LIABILITY THAT CANNOT BE EXCLUDED OR LIMITED UNDER APPLICABLE LAW.</p>
 
-    <h2><span class="section-number">11.</span> Indemnity</h2>
+    <h2><span class="section-number">12.</span> Indemnity</h2>
     <p>You agree to indemnify, defend, and hold harmless Mind Compass and its affiliates, operators, employees, agents, suppliers, and licensors from and against any and all claims, liabilities, damages, losses, costs, and expenses (including reasonable attorneys' fees) arising out of or in connection with: (a) your use of the Service; (b) your violation of these Terms; (c) your violation of any rights of any third party; or (d) your User Submissions.</p>
 
-    <h2><span class="section-number">12.</span> Dispute Resolution</h2>
+    <h2><span class="section-number">13.</span> Dispute Resolution</h2>
 
-    <h3>12.1 Informal Resolution</h3>
+    <h3>13.1 Informal Resolution</h3>
     <p>Before initiating any formal dispute resolution proceedings, you agree to first contact us at <a href="mailto:aicompass.tech@gmail.com">aicompass.tech@gmail.com</a> and attempt to resolve the dispute informally in good faith for at least thirty (30) days. We will respond to your notice within a reasonable time and work cooperatively with you to resolve the matter.</p>
 
-    <h3>12.2 Court Jurisdiction</h3>
-    <p>If a dispute cannot be resolved informally, it shall be resolved through the courts of competent jurisdiction in accordance with Section 16.1 (Governing Law). Nothing in this Section limits any statutory right you may have to bring proceedings in the courts of your country of residence under mandatory consumer protection laws.</p>
+    <h3>13.2 Court Jurisdiction</h3>
+    <p>If a dispute cannot be resolved informally, it shall be resolved through the courts of competent jurisdiction in accordance with Section 17.1 (Governing Law). Nothing in this Section limits any statutory right you may have to bring proceedings in the courts of your country of residence under mandatory consumer protection laws.</p>
 
-    <h2><span class="section-number">13.</span> Changes and Notices</h2>
+    <h2><span class="section-number">14.</span> Changes and Notices</h2>
     <p>Mind Compass reserves the right to update or modify these Terms at any time. If we make material changes, we will notify you by posting the updated Terms on our website and updating the "Last updated" date at the top of this page. We may also provide additional notice, such as by sending you an email notification. Your continued use of the Service after the effective date of any changes constitutes your acceptance of the revised Terms.</p>
     <p>It is your responsibility to review these Terms periodically for changes. If you do not agree to the revised Terms, you must stop using the Service.</p>
 
-    <h2><span class="section-number">14.</span> Agreement Term</h2>
+    <h2><span class="section-number">15.</span> Agreement Term</h2>
     <p>These Terms shall remain in full force and effect while you use the Service. You may terminate your use of the Service at any time. Mind Compass may terminate or suspend your access to the Service at any time, without prior notice or liability, for any reason. Upon termination, the provisions of these Terms that by their nature should survive termination shall continue in effect.</p>
 
-    <h2><span class="section-number">15.</span> Electronic Signature</h2>
+    <h2><span class="section-number">16.</span> Electronic Signature</h2>
     <p>By using the Service, you agree that your electronic acceptance of these Terms (including via click-through or other electronic means) constitutes your signature, acceptance, and agreement to be bound by these Terms, as if you had signed these Terms in writing. You acknowledge that your electronic submissions constitute your agreement and intent to be bound by these Terms and any applicable policies.</p>
 
-    <h2><span class="section-number">16.</span> Miscellaneous</h2>
+    <h2><span class="section-number">17.</span> Miscellaneous</h2>
 
-    <h3>16.1 Governing Law</h3>
+    <h3>17.1 Governing Law</h3>
     <p>These Terms are intended to be governed by and construed in accordance with the laws of the Republic of Cyprus, to the extent legally applicable, without regard to its conflict of law provisions. Nothing in these Terms limits or excludes any mandatory consumer protection rights you may have under the laws of your country of residence, which shall continue to apply.</p>
 
-    <h3>16.2 Entire Agreement</h3>
+    <h3>17.2 Entire Agreement</h3>
     <p>These Terms, together with the <a href="privacy-policy.html">Privacy Policy</a>, <a href="subscription-policy.html">Subscription Policy</a>, <a href="cookie-policy.html">Cookie Policy</a>, and any other agreements or policies referenced herein, constitute the entire agreement between you and Mind Compass regarding your use of the Service and supersede all prior and contemporaneous understandings, agreements, representations, and warranties.</p>
 
-    <h3>16.3 No Waiver</h3>
+    <h3>17.3 No Waiver</h3>
     <p>The failure of Mind Compass to enforce any right or provision of these Terms shall not constitute a waiver of such right or provision. Any waiver of any provision of these Terms will be effective only if in writing and signed by Mind Compass.</p>
 
-    <h3>16.4 Force Majeure</h3>
+    <h3>17.4 Force Majeure</h3>
     <p>Mind Compass shall not be liable for any failure or delay in performing its obligations under these Terms due to causes beyond its reasonable control, including but not limited to acts of God, natural disasters, war, terrorism, riots, embargoes, acts of civil or military authorities, fire, floods, accidents, epidemics, pandemics, strikes, or shortages of transportation, facilities, fuel, energy, labor, or materials.</p>
 
-    <h3>16.5 Legal Status of Mind Compass</h3>
+    <h3>17.5 Legal Status of Mind Compass</h3>
     <p>Mind Compass is currently operated as a trade name and is not yet a registered legal entity. A registered legal entity name, registered office address, and company registration number will be added to these Terms upon incorporation. References to "Mind Compass," "we," "us," or "our" in these Terms shall, upon incorporation, be deemed to refer to the registered legal entity operating the Service.</p>
 
-    <h2><span class="section-number">17.</span> Contact Information</h2>
+    <h2><span class="section-number">18.</span> Contact Information</h2>
     <p>If you have any questions about these Terms, please contact us at:</p>
     <p>
         <strong>Mind Compass</strong><br>


### PR DESCRIPTION
## Summary

First PR off the legal-audit umbrella issue (#50). Text/CSS-only fixes within the 4 `funnel/legal/*.html` files. Closes a real doc/product mismatch (docs said email-only cancellation; product has had in-app cancel via `webapp/components/CancelFlow.tsx` + `Settings.tsx`).

Refs #50 — **workstream A only**; B (compliance content) and C (engineering blockers) remain in backlog as follow-up PRs (do not auto-close the umbrella).

## Commits
- fix: legal docs — workstream A quick fixes (audit Issue #50)

## Key changes

- **Medical disclaimer callout** (`.medical-disclaimer` CSS class, amber bg + left border) at top of Terms + Subscription — most conspicuous treatment for the regulatory requirement. Privacy/Cookie excluded (data docs, not service docs).
- **Terms §2 Eligibility** (new) — explicit 18+ representation. Renumbered §2→§3 through §17→§18; updated single internal cross-ref (§13.2 `Section 16.1` → `Section 17.1`).
- **Cancellation rewrite** (Terms §6.3 + Subscription §5) — in-app cancellation primary (`Sidebar Profile → Access tab, then click Cancel`), email kept as alternative. Closes audit Critical #3 (CA ARL / FTC Click-to-Cancel violation) at the documentation layer.
- **Privacy §11** — resolved 30-vs-45-day contradiction with §5: `30 days under GDPR, 45 days for California (CCPA)`.
- **Trade-name disclosure parity** — pre-incorporation `<p>` added to Subscription + Cookie footers (was only in Privacy footer + Terms §17.5).
- **Currency clarity** (Subscription §4) — lists all 5 detected currencies (EUR/USD/GBP/CAD/AUD per `engine/app.js DISCLAIMERS` map). Caught by peer-review: my first draft said EUR-only which directly contradicted the multi-currency paywall.

Net: +127/-43.

## Test plan
- [x] Localhost: all 4 `/legal/*.html` → 200 OK, internal links intact
- [x] Section renumber sanity: §1 → §18 sequential, all subsections numbered, only internal cross-ref (§13.2 → §17.1) updated
- [x] No external references to Terms sections by number (grep `engine/`, `screens.json`, sibling legal docs)
- [x] No `id=` anchors / `href="#…"` fragments in any legal doc → renumber cannot break deep-links
- [x] Cancel UI labels verified against `Sidebar.tsx` + `Settings.tsx` (label "Profile", tab "Access", button "Cancel")
- [x] Peer-reviewed: caught + fixed EUR-only currency mismatch, dead `.medical-disclaimer strong` CSS rule
- [ ] Vercel preview: render check on Terms callout + Subscription callout
- [ ] Production smoke (runs automatically via hook on push)

Smoke test runs automatically on push via Claude Code hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)