### PR TITLE
feat: AI Coach v2 — evidence-based prompt, chat reset, $1/3mo cap (#54)

### DIFF
--- a/PLAN_issue_54.md
+++ b/PLAN_issue_54.md
@@ -1,0 +1,127 @@
+# AI Coach v2 — Implementation Plan
+
+**Overall Progress:** `95%`
+
+**Issue:** [#54](https://github.com/johnbukhin/ai-dopamine-cursor/issues/54)
+**Branch:** `feat/issue-54-ai-coach-v2`
+
+## TLDR
+Глобально підняти якість AI Coach: (1) переписати system prompt — гнучкий, evidence-based, без жорсткої рамки і зайвого whitespace; (2) додати "New conversation" reset з опційним збереженням попереднього чату як memory summary; (3) додати 3 high-impact UX дрібниці (starter prompts, quick-reply chips, copy/regenerate, three-dot typing); (4) ввести $1 / 3-місяці spend cap per user, що покриває Coach + Daily Insight + summarize calls.
+
+## Critical Decisions
+
+### Locked from `/explore`
+- **Reset clears single shared chat** — Coach tab і Urge Help modal живуть в одному `chatHistory` state. Без per-surface розділення.
+- **Memory shape:** one overwritable summary in new `coach_memory(user_id PK, summary, updated_at)`. Next summarize-call's input includes prior summary → агрегується, не стекається.
+- **Save UX:** sync — модалка показує "Saving…" 1-3 сек.
+- **Streaming → out of scope** (виноситься у follow-up issue).
+- **Quick-replies:** static hardcoded (3 chips).
+- **Spend cap counts:** Coach + Daily Insight + summarize (єдиний bucket).
+- **Backfill:** lazy — row створюється при першому LLM call після деплою.
+- **Quota UX:** input замінюється banner'ом "Quota reached. Resets {date}.", input disabled.
+
+### Research synthesis (informs Scope 1 prompt + Scope 3 features)
+Best practices з Woebot / Wysa / Headspace AI (Ebb) / Replika / Finch:
+- **Validate first** — ніколи не стрибати одразу в рішення.
+- **Reflective listening** — перефразувати те що сказав юзер.
+- **One focused question** — не список запитань.
+- **Short responses** — 2-4 речення типово; bullet-листи рідкі, тільки коли реально перелік.
+- **Concrete next step** — коли пропонуємо дію, ОДНА річ, не три.
+- **Минімум markdown** усередині відповідей (bold sparingly, no headers всередині response).
+- **Тон:** non-judgmental, warm, друг-який-розуміється а не therapist-роль.
+- **Therapeutic frame:** CBT (cognitive reframe), MI (open questions, eliciting change talk), ACT (acceptance + values-action).
+
+**Response length norms (target):**
+| Тип запиту | Cap |
+|---|---|
+| Чиста валідація / коротка реакція | ≤300 chars |
+| Reflection + 1 question | ≤500 chars |
+| Reframe + action | ≤800 chars |
+| Urge mode (acute) | ≤500 chars, punchy |
+
+### Top 3 minor UX (Scope 3, ranked by impact/cost)
+Скоротив з 6 до 3 базуючись на принципі "не ускладнювати":
+1. **Empty-state starter prompts** — 3 кнопки в чаті при першому відкритті (welcome message stays, chips під ним). Усуває cold-start friction.
+2. **Static quick-reply chips під assistant message** — `Tell me more` / `Give me an action` / `Different approach`. 0 LLM cost.
+3. **Three-dot typing indicator** — replace spinner на анімовані 3 крапки (animate-pulse stagger). Виглядає природніше, ~10 рядків коду.
+
+**Свідомо НЕ робимо** в цьому тикеті: copy message, regenerate response, haptic, sound, streaming. Якщо метрики покажуть потребу — окремий тикет.
+
+## Tasks
+
+- [x] 🟩 **Step 1: Database migrations**
+  - [x] 🟩 Created `supabase/migrations/20260603_llm_usage.sql` — table + atomic RPC `track_llm_spend(p_user_id, p_cost)` with conditional 3-month reset baked into the ON CONFLICT branch.
+  - [x] 🟩 Created `supabase/migrations/20260603_coach_memory.sql` — table + RLS `auth.uid() = user_id`.
+  - [x] 🟩 RPC re-scoped to accept trusted `p_user_id` from server-side (invoked via service role); no SECURITY DEFINER needed because we explicitly pin the EXECUTE grant to `service_role`.
+  - [ ] 🟥 Apply migrations in Supabase Dashboard (deferred to `/review` / pre-deploy step)
+
+- [x] 🟩 **Step 2: Backend — spend tracking + cap enforcement**
+  - [x] 🟩 New `webapp/api/_lib/spend.js` — `QUOTA_USD`, `checkQuota(userId)`, `costFromUsage(usage)`, `recordSpend(userId, cost)`.
+  - [x] 🟩 Wired into `webapp/api/coach.js` — pre-call quota gate returns 402 with `periodEndsAt`; post-call `recordSpend` is fire-and-forget.
+  - [x] 🟩 Wired same pattern into `webapp/api/daily-insight.js`.
+
+- [x] 🟩 **Step 3: Backend — chat reset endpoint + memory**
+  - [x] 🟩 New `webapp/api/coach-reset.js`:
+    - Path A (discard or empty): wipes both `coach_messages` AND `coach_memory` rows. No LLM call.
+    - Path B (save): quota check → fetch existing memory (if any) → summarize with `SUMMARY_SYSTEM_PROMPT` (max 300 tokens) → upsert `coach_memory` → wipe `coach_messages`. Spend recorded.
+
+- [x] 🟩 **Step 4: System prompt rewrite (Scope 1)**
+  - [x] 🟩 Rewrote `webapp/prompts/aiCoach.ts` — flexible response shape (validation only / reflection + question / reframe + action / urge mode), evidence-based toolkit (CBT/MI/ACT), explicit response-length caps, anti-patterns list ("Don't open with formulas like 'I hear you'…").
+  - [x] 🟩 `buildCoachSystemPrompt(context, memoryNote?)` — memory note injected as `PRIOR CONVERSATION SUMMARY` block when present.
+  - [x] 🟩 `claudeService.ts` fetches memory note once per session (module-level cache); `invalidateMemoryCache()` exported for logout + reset paths.
+
+- [x] 🟩 **Step 5: Frontend — AICoach component**
+  - [x] 🟩 Reset button (small, right-aligned, above messages) — visible in both Coach tab and CoachModal modes once there's ≥1 real message.
+  - [x] 🟩 `ResetChatModal` with two buttons + sync "Saving…" / "Clearing…" states + inline error fallback.
+  - [x] 🟩 After successful reset → `setMessages([COACH_WELCOME_MESSAGE])`. Memory cache invalidated server-side wipe + client-side via `invalidateMemoryCache()` inside `resetCoachChat`.
+  - [x] 🟩 Three starter chips below welcome (`COACH_STARTER_PROMPTS` in `constants.ts`) — only when `messages.length === 1`.
+  - [x] 🟩 Three static quick-reply chips after each assistant message (`COACH_QUICK_REPLIES`) — hidden when input has typed text.
+  - [x] 🟩 `<TypingDots />` — 3 spans with staggered `animationDelay`, replaces the spinner.
+  - [x] 🟩 `<QuotaBanner />` — replaces entire input footer when `quotaEndsAt` state is set (from either a 402 on send OR a 402 from reset).
+
+- [x] 🟩 **Step 6: Frontend — client-side wiring**
+  - [x] 🟩 `claudeService.ts` returns `ServiceResult` discriminated union (`text` / `quota_exceeded` / `auth_error` / `server_error`). Memory fetched + injected automatically.
+  - [x] 🟩 `AICoach.tsx` branches on result kind — falls back to `FALLBACK_COPY` strings for non-quota errors; only writes to DB on `kind: 'text'`.
+  - [x] 🟩 `DailyCheckIn.tsx` — on quota_exceeded, sets `aiInsight = 'Insight skipped — AI quota reached. Resets next cycle.'` instead of blocking check-in save.
+
+- [x] 🟩 **Step 7: QA + smoke test (local)**
+  - [x] 🟩 `npm run build` (project's `tsc && vite build`) — passes clean, 2097 modules transformed, no errors.
+  - [x] 🟩 `bash scripts/smoke-test.sh` against prod — 7/9 prod checks pass; 2 fails are missing local env vars (Stripe smoke), not regressions.
+  - [ ] 🟥 Manual local QA (deferred to `/review` and `/peer-review`): send 3 Coach messages, exercise both reset paths, temp-flip `QUOTA_USD` to verify banner.
+  - [ ] 🟥 Apply migrations + push branch → re-run smoke-test.sh against deployed prod.
+
+## Non-goals (explicit reminder)
+- ❌ Streaming responses (follow-up issue)
+- ❌ Copy / regenerate buttons (defer)
+- ❌ Haptic / sound (defer)
+- ❌ Soft warning UI on 80% budget
+- ❌ Prompt caching / rolling summary mid-chat
+- ❌ Backfill script for existing users
+- ❌ Per-surface chat split
+
+## Files touched
+**New:**
+- `supabase/migrations/<date>_llm_usage.sql`
+- `supabase/migrations/<date>_coach_memory.sql`
+- `webapp/api/_lib/spend.js`
+- `webapp/api/coach-reset.js`
+- `webapp/components/ResetChatModal.tsx`
+- `webapp/components/QuotaBanner.tsx` (or inline in AICoach)
+- `webapp/components/TypingDots.tsx` (or inline)
+
+**Modified:**
+- `webapp/prompts/aiCoach.ts` — full rewrite
+- `webapp/services/claudeService.ts` — memory fetch, quota signal, updated signatures
+- `webapp/api/coach.js` — pre-check + post-record
+- `webapp/api/daily-insight.js` — pre-check + post-record
+- `webapp/components/AICoach.tsx` — reset button, starter chips, quick-replies, typing dots, quota banner
+- `webapp/App.tsx` — clear `chatHistory` after reset
+
+## Risks + mitigations
+- **Prompt regression** — нинішня рамка комусь може подобатися. Manual QA з ≥5 різними інпутами (urge, reflection, log relapse, vague feeling, direct action request) перед merge.
+- **RPC race condition** — `track_llm_spend` всередині транзакції з row-level lock через `UPDATE`. Перевірити в SQL що `UPDATE ... WHERE user_id = $1 RETURNING *` блокує паралельні writes.
+- **Memory leakage** — `coach_memory` має ті ж RLS правила що `coach_messages`. Перевірити що anon client читає тільки свій row.
+- **Daily Insight 402** — не блокуємо check-in save. Tested in Step 7.
+
+## Approval
+Чекаю `/execute` коли план OK.

--- a/supabase/migrations/20260603_coach_memory.sql
+++ b/supabase/migrations/20260603_coach_memory.sql
@@ -1,0 +1,24 @@
+-- AI Coach memory note for "Save & start fresh" (Issue #54, Scope 2).
+--
+-- One overwritable summary per user. When the user clicks "Save & start
+-- fresh" in the Coach reset modal, the server summarizes the prior chat
+-- (including any existing summary in the input → aggregated, not stacked)
+-- into ≤300 tokens and upserts here. The next Coach response prepends
+-- this note to its system context so continuity is preserved without
+-- ballooning the system prompt across resets.
+
+CREATE TABLE IF NOT EXISTS coach_memory (
+  user_id     UUID         NOT NULL PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  summary     TEXT         NOT NULL,
+  updated_at  TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+ALTER TABLE coach_memory ENABLE ROW LEVEL SECURITY;
+
+-- Same pattern as coach_messages: users own their row in full.
+DROP POLICY IF EXISTS "Users manage own coach_memory" ON coach_memory;
+CREATE POLICY "Users manage own coach_memory" ON coach_memory
+  FOR ALL
+  TO authenticated
+  USING  (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);

--- a/supabase/migrations/20260603_llm_usage.sql
+++ b/supabase/migrations/20260603_llm_usage.sql
@@ -1,0 +1,80 @@
+-- LLM spend tracking for AI Coach v2 (Issue #54, Scope 4).
+--
+-- One row per user. Accumulates cost across all LLM-backed endpoints
+-- (Coach chat, Daily Insight, chat-reset summarize). When the user crosses
+-- the $1.00 quota inside the current 3-month window, the API returns 402
+-- and the frontend swaps the chat input for a "Quota reached" banner.
+--
+-- The window is rolling-but-discrete: at the moment a call lands AFTER
+-- `period_start_at + 3 months`, the row resets (`total_cost_usd = 0`,
+-- `period_start_at = now()`) inside the same atomic RPC, then the new
+-- call's cost is added. This avoids any backfill — users who never call
+-- the LLM never get a row.
+
+CREATE TABLE IF NOT EXISTS llm_usage (
+  user_id          UUID         NOT NULL PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  period_start_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  total_cost_usd   NUMERIC(10,6) NOT NULL DEFAULT 0,
+  updated_at       TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+ALTER TABLE llm_usage ENABLE ROW LEVEL SECURITY;
+
+-- Users may read their own row (used by the frontend to render the quota
+-- reset date in the banner). All writes go through the SERVICE_ROLE key
+-- in `api/_lib/spend.js`, NOT directly from clients — so no INSERT/UPDATE
+-- policy is granted here.
+DROP POLICY IF EXISTS "Users read own llm_usage" ON llm_usage;
+CREATE POLICY "Users read own llm_usage" ON llm_usage
+  FOR SELECT
+  TO authenticated
+  USING (auth.uid() = user_id);
+
+-- Atomic check + reset + increment. The serverless API verifies the user
+-- via Supabase JWT first and then passes the trusted `user_id` here — the
+-- function does NOT trust `auth.uid()` because it's invoked via the
+-- SERVICE_ROLE key (which has no auth context).
+--
+-- Returns the row state AFTER the update so the caller can log telemetry
+-- if useful.
+CREATE OR REPLACE FUNCTION track_llm_spend(p_user_id UUID, p_cost NUMERIC)
+RETURNS TABLE (
+  total_cost_usd  NUMERIC,
+  period_start_at TIMESTAMPTZ,
+  period_ends_at  TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  -- Upsert with conditional reset. The CASE in the UPDATE branch handles
+  -- the "window expired" rollover atomically — no separate SELECT-then-
+  -- UPDATE race window.
+  INSERT INTO llm_usage (user_id, period_start_at, total_cost_usd, updated_at)
+  VALUES (p_user_id, now(), p_cost, now())
+  ON CONFLICT (user_id) DO UPDATE
+  SET
+    period_start_at = CASE
+      WHEN llm_usage.period_start_at < now() - interval '3 months' THEN now()
+      ELSE llm_usage.period_start_at
+    END,
+    total_cost_usd = CASE
+      WHEN llm_usage.period_start_at < now() - interval '3 months' THEN p_cost
+      ELSE llm_usage.total_cost_usd + p_cost
+    END,
+    updated_at = now();
+
+  RETURN QUERY
+    SELECT
+      u.total_cost_usd,
+      u.period_start_at,
+      (u.period_start_at + interval '3 months')::TIMESTAMPTZ AS period_ends_at
+    FROM llm_usage u
+    WHERE u.user_id = p_user_id;
+END;
+$$;
+
+-- Only the service role invokes this (from webapp/api/_lib/spend.js).
+-- Revoke default PUBLIC EXECUTE to be explicit about that boundary.
+REVOKE EXECUTE ON FUNCTION track_llm_spend(UUID, NUMERIC) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION track_llm_spend(UUID, NUMERIC) TO service_role;

--- a/webapp/App.tsx
+++ b/webapp/App.tsx
@@ -13,12 +13,8 @@ import { ProGate } from './components/ProGate';
 import { supabase } from './src/lib/supabase';
 import { planData, getRequiredTaskKeys, DayCompletion } from './data/planData';
 import { lessonsData } from './data/lessonsData';
-
-// Hardcoded welcome message — never stored in DB, always prepended at load time.
-const WELCOME_MESSAGE: ChatMessage = {
-  role: 'assistant',
-  content: "Hello. I'm your Mind Compass coach.\n\nI'm here to help you reflect, analyze patterns, and maintain control.\n\nWhat's on your mind today?",
-};
+import { invalidateMemoryCache } from './services/claudeService';
+import { COACH_WELCOME_MESSAGE as WELCOME_MESSAGE } from './constants';
 
 // Dev-only: skip the login screen when VITE_DEV_BYPASS_AUTH=true in .env.local.
 // Hard-gated on import.meta.env.DEV so the flag is *physically impossible* to
@@ -286,6 +282,9 @@ export default function App() {
     setUserEmail('');
     setIsAuthenticated(false);
     setCurrentView(View.LOGIN);
+    // Drop the module-level Coach memory cache so the next signed-in user
+    // doesn't inherit the previous user's summary.
+    invalidateMemoryCache();
   };
 
   // Grant access immediately on successful ProGate upgrade — the Stripe webhook

--- a/webapp/api/_lib/spend.js
+++ b/webapp/api/_lib/spend.js
@@ -1,0 +1,97 @@
+// LLM spend tracking for AI Coach v2 (Issue #54, Scope 4).
+//
+// Lifetime budget: $1.00 per user per 3 months, rolling window.
+// Covers: Coach chat, Daily Insight, chat-reset summarize.
+//
+// All writes go through the `track_llm_spend(p_user_id, p_cost)` Postgres
+// RPC, which atomically checks the period window, resets if expired, and
+// increments. Reads (pre-call quota check) hit the table directly so we
+// can fail fast without invoking the RPC for blocked users.
+import { createClient } from '@supabase/supabase-js';
+
+// Claude Haiku 4.5 pricing — keep in sync with model selection in coach.js
+// and daily-insight.js. Numbers are USD per single token.
+const HAIKU_INPUT_USD_PER_TOKEN  = 1 / 1_000_000;  // $1 per MTok
+const HAIKU_OUTPUT_USD_PER_TOKEN = 5 / 1_000_000;  // $5 per MTok
+
+export const QUOTA_USD = 1.0;
+
+// Service-role client — bypasses RLS so we can read/write the usage row
+// for any user. The caller MUST verify the JWT first (`verifyUser` in
+// api/_lib/auth.js) and pass the trusted `user.id` to these helpers.
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+/**
+ * Pre-call quota check. Returns whether the user has crossed the budget
+ * inside their current 3-month window, plus the window's end timestamp
+ * (used by the frontend to render the "Resets on …" banner).
+ *
+ * A missing row is treated as "fresh user, plenty of budget" — no row is
+ * created here; the RPC inserts on the first successful call.
+ *
+ * @param {string} userId  Trusted user.id from verifyUser()
+ * @returns {Promise<{ exceeded: boolean, periodEndsAt: string | null }>}
+ */
+export async function checkQuota(userId) {
+  const { data, error } = await supabase
+    .from('llm_usage')
+    .select('total_cost_usd, period_start_at')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) {
+    // Don't block users on read errors — fail open. recordSpend will still
+    // attempt to write; if the table is genuinely broken, that's a bigger
+    // alarm than letting a few extra calls through.
+    console.error('[spend] checkQuota read error:', error.message);
+    return { exceeded: false, periodEndsAt: null };
+  }
+
+  if (!data) return { exceeded: false, periodEndsAt: null };
+
+  // Mirror the RPC's reset logic so we don't 402 a user whose window has
+  // just expired but whose row hasn't been touched yet.
+  const periodStart = new Date(data.period_start_at);
+  const windowEnd = new Date(periodStart);
+  windowEnd.setMonth(windowEnd.getMonth() + 3);
+  const expired = windowEnd < new Date();
+
+  if (expired) return { exceeded: false, periodEndsAt: null };
+  return {
+    exceeded: Number(data.total_cost_usd) >= QUOTA_USD,
+    periodEndsAt: windowEnd.toISOString(),
+  };
+}
+
+/**
+ * Compute USD cost from an Anthropic `response.usage` object.
+ * Handles missing fields defensively (treat as 0).
+ */
+export function costFromUsage(usage) {
+  const input  = Number(usage?.input_tokens  ?? 0);
+  const output = Number(usage?.output_tokens ?? 0);
+  return input * HAIKU_INPUT_USD_PER_TOKEN + output * HAIKU_OUTPUT_USD_PER_TOKEN;
+}
+
+/**
+ * Record spend via the atomic RPC. Fire-and-forget — callers should NOT
+ * await this if the user-facing response can be returned first.
+ *
+ * @param {string} userId  Trusted user.id from verifyUser()
+ * @param {number} cost    USD, from costFromUsage()
+ */
+export async function recordSpend(userId, cost) {
+  if (cost <= 0) return;
+
+  const { error } = await supabase.rpc('track_llm_spend', {
+    p_user_id: userId,
+    p_cost: cost,
+  });
+  if (error) {
+    // Log only — don't propagate. Worst case we under-count one call.
+    console.error('[spend] recordSpend RPC error:', error.message);
+  }
+}

--- a/webapp/api/coach-reset.js
+++ b/webapp/api/coach-reset.js
@@ -1,0 +1,188 @@
+// POST /api/coach-reset
+// Body: { messages: ChatMessage[], save: boolean }
+// Returns: { ok: true, summary?: string }
+//   or:   402 { error: 'quota_exceeded', periodEndsAt: ISO string }
+//
+// "Save & start fresh": LLM summarizes the prior chat (folding in any
+// existing memory note so summaries don't stack), writes the result into
+// `coach_memory`, then clears `coach_messages`.
+//
+// "Discard & start fresh": just clears `coach_messages`. No LLM call,
+// no quota consumed, existing memory note is wiped too.
+//
+// Issue #54, Scope 2.
+import { createClient } from '@supabase/supabase-js';
+import { applyCors } from './_lib/cors.js';
+import { verifyUser } from './_lib/auth.js';
+import { anthropic, callWithRetry, extractText } from './_lib/anthropic.js';
+import { checkQuota, costFromUsage, recordSpend } from './_lib/spend.js';
+
+const MODEL = 'claude-haiku-4-5';
+const SUMMARY_MAX_TOKENS = 300;
+
+const SUMMARY_SYSTEM_PROMPT = `You are a memory compressor for an AI coach helping a user reduce porn addiction and compulsive dopamine-driven behaviors.
+
+You will receive a prior conversation (and possibly an existing memory note from earlier conversations). Produce ONE concise memory note (≤300 tokens, plain prose, no markdown headers) that captures:
+- the user's recurring struggles and triggers
+- what coping strategies they've tried and what seems to work / not work
+- recurring emotional themes
+- tone preferences they've signaled (e.g. "I don't want advice, just to vent")
+- any concrete commitments or goals they've stated
+
+If an existing memory note is present, INTEGRATE it — don't repeat verbatim. Drop stale facts that newer messages have superseded.
+
+Do NOT include advice, opinions, or coaching language. This is a private note for the coach's future context, not a message to the user. Write in third-person ("the user…") for clarity.`;
+
+const adminClient = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+export default async function handler(req, res) {
+  applyCors(req, res);
+  if (req.method === 'OPTIONS') return res.status(200).end();
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+
+  const { user, error: authError } = await verifyUser(req);
+  if (!user) return res.status(401).json({ error: authError });
+
+  const { messages, save } = req.body || {};
+  if (!Array.isArray(messages)) {
+    return res.status(400).json({ error: 'messages (array) is required' });
+  }
+  if (typeof save !== 'boolean') {
+    return res.status(400).json({ error: 'save (boolean) is required' });
+  }
+
+  // ── Path A: discard — wipe BOTH chat AND memory, no LLM. ────────────
+  if (!save) {
+    const chatErr = await wipeChat(user.id);
+    const memErr  = await wipeMemory(user.id);
+    if (chatErr || memErr) {
+      return res.status(500).json({ error: 'Reset failed', detail: chatErr || memErr });
+    }
+    return res.status(200).json({ ok: true });
+  }
+
+  // ── Path B: save with empty chat — nothing to summarize. ─────────────
+  // Frontend disables Save when chat is empty; this is defensive. Wipe chat
+  // only (preserve any existing memory the user accumulated before).
+  if (messages.length === 0) {
+    const chatErr = await wipeChat(user.id);
+    if (chatErr) return res.status(500).json({ error: 'Reset failed', detail: chatErr });
+    return res.status(200).json({ ok: true });
+  }
+
+  // ── Path C: save & summarize. ────────────────────────────────────────
+  const { exceeded, periodEndsAt } = await checkQuota(user.id);
+  if (exceeded) {
+    return res.status(402).json({ error: 'quota_exceeded', periodEndsAt });
+  }
+
+  // Pull existing memory so the summarizer can integrate it instead of
+  // dropping prior context.
+  const { data: existingMemoryRow } = await adminClient
+    .from('coach_memory')
+    .select('summary')
+    .eq('user_id', user.id)
+    .maybeSingle();
+  const existingSummary = existingMemoryRow?.summary ?? null;
+
+  const userMessage = buildSummarizeUserMessage(messages, existingSummary);
+
+  let newSummary;
+  let summarizeCost = 0;
+  try {
+    const response = await callWithRetry(() =>
+      anthropic.messages.create({
+        model: MODEL,
+        max_tokens: SUMMARY_MAX_TOKENS,
+        system: SUMMARY_SYSTEM_PROMPT,
+        messages: [{ role: 'user', content: userMessage }],
+      })
+    );
+    newSummary = extractText(response).trim();
+    summarizeCost = costFromUsage(response.usage);
+  } catch (err) {
+    console.error('[coach-reset] Anthropic error:', err.message);
+    const status = err?.status || err?.statusCode;
+    if (status === 429) return res.status(429).json({ error: 'Rate limited' });
+    return res.status(500).json({ error: 'Reset summarize failed' });
+  }
+
+  if (!newSummary) {
+    return res.status(500).json({ error: 'Reset summarize returned empty' });
+  }
+
+  // Upsert memory FIRST (it's what the user explicitly asked us to preserve),
+  // then wipe chat. Both errors are propagated so the frontend doesn't think
+  // a partial reset succeeded and clear its own state prematurely.
+  const { error: memErr } = await adminClient
+    .from('coach_memory')
+    .upsert(
+      {
+        user_id: user.id,
+        summary: newSummary,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'user_id' }
+    );
+  if (memErr) {
+    console.error('[coach-reset] coach_memory upsert error:', memErr.message);
+    return res.status(500).json({ error: 'Memory save failed' });
+  }
+
+  const wipeErr = await wipeChat(user.id);
+  if (wipeErr) {
+    return res.status(500).json({
+      error: 'Chat wipe failed after memory save',
+      detail: wipeErr,
+    });
+  }
+
+  // Spend recorded only AFTER both writes succeed — we don't bill the user
+  // for a summarize whose result we couldn't persist.
+  recordSpend(user.id, summarizeCost);
+
+  return res.status(200).json({ ok: true, summary: newSummary });
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────
+
+/** Returns the Supabase error message string on failure, or null on success. */
+async function wipeChat(userId) {
+  const { error } = await adminClient
+    .from('coach_messages')
+    .delete()
+    .eq('user_id', userId);
+  if (error) {
+    console.error('[coach-reset] coach_messages delete error:', error.message);
+    return error.message;
+  }
+  return null;
+}
+
+/** Returns the Supabase error message string on failure, or null on success. */
+async function wipeMemory(userId) {
+  const { error } = await adminClient
+    .from('coach_memory')
+    .delete()
+    .eq('user_id', userId);
+  if (error) {
+    console.error('[coach-reset] coach_memory delete error:', error.message);
+    return error.message;
+  }
+  return null;
+}
+
+/** Compose the summarizer's user message: optional prior memory + chat transcript. */
+function buildSummarizeUserMessage(messages, existingSummary) {
+  const transcript = messages
+    .map((m) => `${m.role === 'assistant' ? 'Coach' : 'User'}: ${m.content}`)
+    .join('\n\n');
+
+  if (existingSummary) {
+    return `EXISTING MEMORY NOTE (from earlier conversations):\n${existingSummary}\n\nNEW CONVERSATION TO INTEGRATE:\n${transcript}`;
+  }
+  return `CONVERSATION TO SUMMARIZE:\n${transcript}`;
+}

--- a/webapp/api/coach.js
+++ b/webapp/api/coach.js
@@ -1,12 +1,15 @@
 // POST /api/coach
 // Body: { systemPrompt: string, messages: [{ role: 'user'|'assistant', content: string }] }
 // Returns: { text: string }
+//   or:   402 { error: 'quota_exceeded', periodEndsAt: ISO string }
 //
 // Auth: Supabase JWT via `Authorization: Bearer <access_token>`.
 // Calls Claude Haiku 4.5 with multi-turn conversation history.
+// Spend is tracked against the $1 / 3-month quota (Issue #54, Scope 4).
 import { applyCors } from './_lib/cors.js';
 import { verifyUser } from './_lib/auth.js';
 import { anthropic, callWithRetry, extractText } from './_lib/anthropic.js';
+import { checkQuota, costFromUsage, recordSpend } from './_lib/spend.js';
 
 const MODEL = 'claude-haiku-4-5';
 const MAX_TOKENS = 1024;
@@ -20,9 +23,19 @@ export default async function handler(req, res) {
   const { user, error: authError } = await verifyUser(req);
   if (!user) return res.status(401).json({ error: authError });
 
+  // Validate body first — a malformed request should always 400 regardless
+  // of quota state, so misbehaving clients get the right diagnostic.
   const { systemPrompt, messages } = req.body || {};
   if (typeof systemPrompt !== 'string' || !Array.isArray(messages) || messages.length === 0) {
     return res.status(400).json({ error: 'systemPrompt (string) and messages (non-empty array) are required' });
+  }
+
+  // Pre-call quota check — fail fast before burning a Claude call on a user
+  // who's already over budget. Frontend renders the "Quota reached" banner
+  // off the 402 response shape.
+  const { exceeded, periodEndsAt } = await checkQuota(user.id);
+  if (exceeded) {
+    return res.status(402).json({ error: 'quota_exceeded', periodEndsAt });
   }
 
   // Defense in depth: cap history length even if frontend over-sends.
@@ -37,6 +50,8 @@ export default async function handler(req, res) {
         messages: trimmed,
       })
     );
+    // Fire-and-forget spend record — don't make the user wait on the RPC.
+    recordSpend(user.id, costFromUsage(response.usage));
     return res.status(200).json({ text: extractText(response) });
   } catch (err) {
     console.error('[coach] Anthropic error:', err.message);

--- a/webapp/api/daily-insight.js
+++ b/webapp/api/daily-insight.js
@@ -1,12 +1,15 @@
 // POST /api/daily-insight
 // Body: { systemPrompt: string, userMessage: string }
 // Returns: { text: string }
+//   or:   402 { error: 'quota_exceeded', periodEndsAt: ISO string }
 //
 // Auth: Supabase JWT via `Authorization: Bearer <access_token>`.
 // Generates a single short paragraph insight from a check-in.
+// Spend counts toward the same $1 / 3-month quota as Coach (Issue #54).
 import { applyCors } from './_lib/cors.js';
 import { verifyUser } from './_lib/auth.js';
 import { anthropic, callWithRetry, extractText } from './_lib/anthropic.js';
+import { checkQuota, costFromUsage, recordSpend } from './_lib/spend.js';
 
 const MODEL = 'claude-haiku-4-5';
 const MAX_TOKENS = 256;
@@ -19,9 +22,18 @@ export default async function handler(req, res) {
   const { user, error: authError } = await verifyUser(req);
   if (!user) return res.status(401).json({ error: authError });
 
+  // Validate body first — a malformed request should always 400 regardless
+  // of quota state, so misbehaving clients get the right diagnostic.
   const { systemPrompt, userMessage } = req.body || {};
   if (typeof systemPrompt !== 'string' || typeof userMessage !== 'string' || !userMessage.trim()) {
     return res.status(400).json({ error: 'systemPrompt and userMessage (non-empty strings) are required' });
+  }
+
+  // Quota gate — daily insight is cheap (~$0.0005/call) but still counts.
+  // Frontend renders insight inline; on 402 it shows "Insight skipped".
+  const { exceeded, periodEndsAt } = await checkQuota(user.id);
+  if (exceeded) {
+    return res.status(402).json({ error: 'quota_exceeded', periodEndsAt });
   }
 
   try {
@@ -33,6 +45,7 @@ export default async function handler(req, res) {
         messages: [{ role: 'user', content: userMessage }],
       })
     );
+    recordSpend(user.id, costFromUsage(response.usage));
     return res.status(200).json({ text: extractText(response) });
   } catch (err) {
     console.error('[daily-insight] Anthropic error:', err.message);

--- a/webapp/components/AICoach.tsx
+++ b/webapp/components/AICoach.tsx
@@ -1,10 +1,12 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Brain, Send, User as UserIcon, Loader2 } from 'lucide-react';
-import { getCoachResponse } from '../services/claudeService';
+import { Brain, Send, User as UserIcon, RotateCcw } from 'lucide-react';
+import { getCoachResponse, FALLBACK_COPY } from '../services/claudeService';
 import { CheckIn, ChatMessage, UrgeContextSeed } from '../types';
 import { URGE_ACTION_BY_ID } from '../data/urgeData';
 import { supabase } from '../src/lib/supabase';
 import { CoachLighthouse } from './HeroVariants';
+import { ResetChatModal } from './ResetChatModal';
+import { COACH_WELCOME_MESSAGE, COACH_STARTER_PROMPTS, COACH_QUICK_REPLIES } from '../constants';
 
 interface AICoachProps {
     checkInHistory: CheckIn[];
@@ -32,7 +34,7 @@ function formatUrgeContext(seed: UrgeContextSeed | null | undefined): string {
         seed.intensity != null ? `- Self-reported intensity: ${seed.intensity}/10` : null,
         action ? `- Most recent action they tried: ${action}` : null,
         `- Time on Help tab so far: ${seed.elapsedSec}s`,
-        'Respond using the Urge structure from the system prompt. Reference what they\'ve already done — do not suggest the same action again.',
+        "Respond in urge mode: one grounding action + one reframe sentence. Don't suggest an action they've already tried.",
     ].filter(Boolean);
     return lines.join('\n');
 }
@@ -40,9 +42,19 @@ function formatUrgeContext(seed: UrgeContextSeed | null | undefined): string {
 export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setMessages, currentUrgeContext, compact = false }) => {
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [showResetModal, setShowResetModal] = useState(false);
+  // When the server returns 402, we lock the input area to a banner. The
+  // ISO string lets us format the "Resets on Mar 4, 2026" copy.
+  const [quotaEndsAt, setQuotaEndsAt] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const messagesRef = useRef(messages);
   useEffect(() => { messagesRef.current = messages; }, [messages]);
+
+  // Generation counter — bumped on reset so a Coach response that arrives
+  // AFTER the user already reset the chat doesn't persist its (now stale)
+  // messages back to the freshly-wiped `coach_messages` row.
+  // (Peer-review MEDIUM #1.)
+  const chatGenRef = useRef(0);
 
   // Auto-scroll to the latest message only when a NEW message arrives.
   // Skipping the initial mount keeps the hero header visible on first open.
@@ -54,13 +66,23 @@ export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setM
     prevMessagesLengthRef.current = messages.length;
   }, [messages]);
 
-  const handleSend = async () => {
-    if (!input.trim() || isLoading) return;
+  // Send a message, optionally pre-filled from a chip click. We accept the
+  // text as a parameter (instead of always reading from `input` state) so
+  // chip clicks can dispatch immediately without a render round-trip.
+  const handleSend = async (override?: string) => {
+    const userMsg = (override ?? input).trim();
+    if (!userMsg || isLoading || quotaEndsAt) return;
 
-    const userMsg = input;
-    setInput('');
+    if (!override) setInput('');
     setMessages(prev => [...prev, { role: 'user', content: userMsg }]);
     setIsLoading(true);
+
+    // Capture identity at call time so racy state changes (chat reset, sign-
+    // out, sign-in as another user) can't corrupt this call's persist write.
+    const startGen = chatGenRef.current;
+    const startUserId = supabase
+      ? (await supabase.auth.getUser()).data.user?.id ?? null
+      : null;
 
     // Build context summary from check-in history (last 5 entries) — passed as
     // system-prompt context, separate from chat history. When the Coach is
@@ -76,24 +98,40 @@ export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setM
 
     // Pass the last 10 chat messages so Claude has multi-turn memory.
     // Drop index 0 (hardcoded welcome message — never sent to the model).
-    // messagesRef holds state captured at handleSend call time — does NOT
-    // include the new userMsg yet, which is fine: the service appends it
-    // as the final user turn before sending.
     const chatHistory = messagesRef.current.slice(1).slice(-10);
 
-    const response = await getCoachResponse(userMsg, recentHistory, chatHistory);
-
-    const assistantMsg: ChatMessage = { role: 'assistant', content: response };
-
-    // Update UI — pure state update, no side effects inside updater
-    setMessages(prev => [...prev, assistantMsg]);
+    const result = await getCoachResponse(userMsg, recentHistory, chatHistory);
     setIsLoading(false);
 
+    // 402 → flip into quota-locked state. The chat history we already
+    // appended stays — the user sees their own message, then the banner
+    // replaces the input area.
+    if (result.kind === 'quota_exceeded') {
+      setQuotaEndsAt(result.periodEndsAt);
+      return;
+    }
+
+    const assistantText =
+      result.kind === 'text' ? result.text
+      : result.kind === 'auth_error' ? FALLBACK_COPY.coach.auth
+      : result.message === 'rate_limit' ? FALLBACK_COPY.coach.rateLimit
+      : result.message === 'empty' ? FALLBACK_COPY.coach.empty
+      : FALLBACK_COPY.coach.server;
+    const assistantMsg: ChatMessage = { role: 'assistant', content: assistantText };
+    setMessages(prev => [...prev, assistantMsg]);
+
     // Persist to Supabase — fire-and-forget, never blocks UI.
-    // Reconstruct the full conversation from the closure: messages (captured at
-    // handleSend call time, excludes userMsg) + userMsg + assistantMsg.
+    // Reconstruct the full conversation from the closure: messages (captured
+    // at handleSend call time, excludes userMsg) + userMsg + assistantMsg.
     // Slice off index 0 (hardcoded welcome message — never stored in DB).
-    if (supabase) {
+    // Only persist real Claude responses; don't write fallback strings to DB.
+    //
+    // Two race-condition guards (peer review):
+    //   1. chatGenRef bumped on reset — skip persist if the chat was reset
+    //      while this response was in flight.
+    //   2. user.id must match the id captured at handleSend start — skip
+    //      persist if the user logged out / a different user signed in.
+    if (supabase && result.kind === 'text') {
       const toStore: ChatMessage[] = [
         ...messagesRef.current,
         { role: 'user' as const, content: userMsg },
@@ -101,8 +139,9 @@ export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setM
       ].slice(1);
 
       (async () => {
+        if (chatGenRef.current !== startGen) return;
         const { data: { user } } = await supabase!.auth.getUser();
-        if (!user) return;
+        if (!user || user.id !== startUserId) return;
         await supabase!.from('coach_messages').upsert(
           { user_id: user.id, messages: toStore, updated_at: new Date().toISOString() },
           { onConflict: 'user_id' }
@@ -112,7 +151,6 @@ export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setM
   };
 
   const formatMessage = (content: string) => {
-    // Split by bold markers (**text**)
     return content.split(/(\*\*.*?\*\*)/).map((part, i) => {
       if (part.startsWith('**') && part.endsWith('**')) {
         return <strong key={i} className="font-bold">{part.slice(2, -2)}</strong>;
@@ -120,6 +158,26 @@ export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setM
       return <span key={i}>{part}</span>;
     });
   };
+
+  // Reset handler — clears chat back to the welcome message after a successful
+  // /api/coach-reset call. Quota-on-reset is handled inside the modal which
+  // calls onQuotaExceeded → we lock the input here too.
+  // Bumping chatGenRef invalidates any in-flight handleSend's persist closure
+  // (peer-review MEDIUM #1) so a stale response can't resurrect the wiped row.
+  const handleResetComplete = () => {
+    chatGenRef.current += 1;
+    setMessages([COACH_WELCOME_MESSAGE]);
+  };
+
+  // ── Derived UI flags ──────────────────────────────────────────────────
+  const isEmpty = messages.length === 1; // only the welcome message
+  const lastMessage = messages[messages.length - 1];
+  const showQuickReplies =
+    !isEmpty
+    && !isLoading
+    && !quotaEndsAt
+    && lastMessage?.role === 'assistant'
+    && !input.trim();
 
   return (
     <div className="flex flex-col h-full bg-purple-50">
@@ -141,55 +199,159 @@ export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setM
         )}
 
         <div className={`px-4 space-y-4 max-w-4xl mx-auto ${compact ? 'pt-2' : ''}`}>
+          {/* Reset chat button — small, right-aligned, above the messages.
+              Visible in both Coach-tab and CoachModal modes; only shown
+              once there's at least one real message worth resetting. */}
+          {!isEmpty && (
+            <div className="flex justify-end -mb-2">
+              <button
+                onClick={() => setShowResetModal(true)}
+                disabled={isLoading}
+                aria-label="Start a new conversation"
+                className="flex items-center gap-1.5 text-xs text-purple-700/80 hover:text-purple-900
+                           hover:bg-purple-100 px-2.5 py-1.5 rounded-lg transition-colors
+                           disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+              >
+                <RotateCcw size={13} />
+                <span>New conversation</span>
+              </button>
+            </div>
+          )}
+
           {messages.map((m, i) => (
-          <div key={i} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
-            <div className={`flex gap-3 max-w-[85%] md:max-w-[75%] ${m.role === 'user' ? 'flex-row-reverse' : 'flex-row'}`}>
-              <div className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${m.role === 'user' ? 'bg-gray-200 text-gray-600' : 'bg-purple-600 text-white'}`}>
-                {m.role === 'user' ? <UserIcon size={16} /> : <Brain size={16} />}
-              </div>
-              <div className={`p-4 rounded-2xl text-sm leading-relaxed whitespace-pre-wrap ${
-                m.role === 'user' 
-                  ? 'bg-white border border-gray-200 text-gray-900 rounded-tr-none' 
-                  : 'bg-purple-700 text-white rounded-tl-none shadow-sm'
-              }`}>
-                {formatMessage(m.content)}
+            <div key={i} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+              <div className={`flex gap-3 max-w-[85%] md:max-w-[75%] ${m.role === 'user' ? 'flex-row-reverse' : 'flex-row'}`}>
+                <div className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${m.role === 'user' ? 'bg-gray-200 text-gray-600' : 'bg-purple-600 text-white'}`}>
+                  {m.role === 'user' ? <UserIcon size={16} /> : <Brain size={16} />}
+                </div>
+                <div className={`p-4 rounded-2xl text-sm leading-relaxed whitespace-pre-wrap ${
+                  m.role === 'user'
+                    ? 'bg-white border border-gray-200 text-gray-900 rounded-tr-none'
+                    : 'bg-purple-700 text-white rounded-tl-none shadow-sm'
+                }`}>
+                  {formatMessage(m.content)}
+                </div>
               </div>
             </div>
-          </div>
-        ))}
-        {isLoading && (
+          ))}
+
+          {isLoading && (
             <div className="flex justify-start">
-                 <div className="flex gap-3 max-w-[80%]">
-                    <div className="w-8 h-8 rounded-full bg-purple-600 text-white flex items-center justify-center">
-                        <Brain size={16} />
-                    </div>
-                    <div className="p-4 bg-purple-700 rounded-2xl rounded-tl-none flex items-center">
-                        <Loader2 className="animate-spin text-purple-200" size={16} />
-                    </div>
-                 </div>
+              <div className="flex gap-3 max-w-[80%]">
+                <div className="w-8 h-8 rounded-full bg-purple-600 text-white flex items-center justify-center">
+                  <Brain size={16} />
+                </div>
+                <div className="p-4 bg-purple-700 rounded-2xl rounded-tl-none">
+                  <TypingDots />
+                </div>
+              </div>
             </div>
-        )}
+          )}
+
+          {/* Empty-state starter prompts — three buttons under the welcome
+              message that pre-fill and send a starter question. Disappear
+              after the user sends their first message. */}
+          {isEmpty && !quotaEndsAt && (
+            <div className="flex flex-wrap gap-2 justify-center pt-2 pb-4">
+              {COACH_STARTER_PROMPTS.map((prompt) => (
+                <button
+                  key={prompt}
+                  onClick={() => handleSend(prompt)}
+                  className="text-xs md:text-sm px-3.5 py-2 rounded-full bg-white border border-purple-200
+                             text-purple-800 hover:bg-purple-100 hover:border-purple-300 transition-colors
+                             shadow-sm"
+                >
+                  {prompt}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Quick-reply chips under the latest assistant message. Hidden the
+              moment the user starts typing so the keyboard doesn't compete
+              with chips for attention. */}
+          {showQuickReplies && (
+            <div className="flex flex-wrap gap-2 pl-11">
+              {COACH_QUICK_REPLIES.map((reply) => (
+                <button
+                  key={reply}
+                  onClick={() => handleSend(reply)}
+                  className="text-xs px-3 py-1.5 rounded-full bg-white border border-purple-200
+                             text-purple-700 hover:bg-purple-100 hover:border-purple-300 transition-colors"
+                >
+                  {reply}
+                </button>
+              ))}
+            </div>
+          )}
         </div>
       </div>
 
-      <div className="p-4 bg-white border-t border-purple-100">
-        <div className="flex gap-2 max-w-4xl mx-auto">
-          <input
-            type="text"
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyPress={(e) => e.key === 'Enter' && handleSend()}
-            placeholder="Type your thought..."
-            className="flex-1 p-3 bg-stone-100 rounded-xl border-none focus:ring-2 focus:ring-emerald-200 outline-none text-emerald-900 placeholder-stone-400"
-          />
-          <button 
-            onClick={handleSend}
-            disabled={!input.trim() || isLoading}
-            className="p-3 bg-purple-700 text-white rounded-xl hover:bg-emerald-900 disabled:opacity-50 transition-colors"
-          >
-            <Send size={20} />
-          </button>
-        </div>
+      {/* Input area OR quota banner. We swap the entire footer so a blocked
+          user sees no input affordance at all — explicit, no false hope. */}
+      {quotaEndsAt
+        ? <QuotaBanner periodEndsAt={quotaEndsAt} />
+        : (
+          <div className="p-4 bg-white border-t border-purple-100">
+            <div className="flex gap-2 max-w-4xl mx-auto">
+              <input
+                type="text"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleSend()}
+                placeholder="Type your thought..."
+                className="flex-1 p-3 bg-stone-100 rounded-xl border-none focus:ring-2 focus:ring-emerald-200 outline-none text-emerald-900 placeholder-stone-400"
+              />
+              <button
+                onClick={() => handleSend()}
+                disabled={!input.trim() || isLoading}
+                className="p-3 bg-purple-700 text-white rounded-xl hover:bg-emerald-900 disabled:opacity-50 transition-colors"
+              >
+                <Send size={20} />
+              </button>
+            </div>
+          </div>
+        )
+      }
+
+      <ResetChatModal
+        open={showResetModal}
+        onClose={() => setShowResetModal(false)}
+        // Strip the hardcoded welcome — server only needs real turns.
+        messagesToSave={messages.slice(1)}
+        onResetComplete={handleResetComplete}
+        onQuotaExceeded={(endsAt) => setQuotaEndsAt(endsAt)}
+      />
+    </div>
+  );
+};
+
+// ── Subcomponents ──────────────────────────────────────────────────────
+
+/** Three-dot typing indicator. Stagger via inline animationDelay so we don't
+ *  need a Tailwind config change for keyframes. */
+const TypingDots: React.FC = () => (
+  <div className="flex items-center gap-1.5" aria-label="Coach is typing">
+    {[0, 1, 2].map((i) => (
+      <span
+        key={i}
+        className="w-1.5 h-1.5 rounded-full bg-purple-200 animate-pulse"
+        style={{ animationDelay: `${i * 180}ms`, animationDuration: '1.2s' }}
+      />
+    ))}
+  </div>
+);
+
+/** Quota-reached banner that replaces the input footer (Issue #54, Scope 4). */
+const QuotaBanner: React.FC<{ periodEndsAt: string | null }> = ({ periodEndsAt }) => {
+  const resetCopy = periodEndsAt
+    ? `Resets on ${new Date(periodEndsAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}.`
+    : 'Resets next cycle.';
+  return (
+    <div className="p-4 bg-purple-100 border-t border-purple-200" role="status">
+      <div className="max-w-4xl mx-auto text-center">
+        <p className="text-sm font-semibold text-purple-900">AI quota reached</p>
+        <p className="text-xs text-purple-800/80 mt-0.5">{resetCopy}</p>
       </div>
     </div>
   );

--- a/webapp/components/DailyCheckIn.tsx
+++ b/webapp/components/DailyCheckIn.tsx
@@ -6,7 +6,7 @@ import {
   FLOW_A_HELPED_OPTIONS, EMOTIONS_POSITIVE, EMOTIONS_NEGATIVE,
   TRIGGERS, TIME_OF_DAY, SLIP_REACTIONS, SLIP_LEARNINGS
 } from '../constants';
-import { generateDailyInsight } from '../services/claudeService';
+import { generateDailyInsight, FALLBACK_COPY } from '../services/claudeService';
 import { Check, X, CheckCircle, ArrowRight, Loader2, ChevronLeft } from 'lucide-react';
 
 interface DailyCheckInProps {
@@ -77,9 +77,20 @@ export const DailyCheckIn: React.FC<DailyCheckInProps> = ({ onComplete, onClose,
       tasksCompleted: payload?.tasksCompleted ?? false,
     };
 
-    // Generate AI Insight
-    const insight = await generateDailyInsight(checkIn);
-    checkIn.aiInsight = insight;
+    // Generate AI Insight — fall back to a friendly stub for any non-success
+    // (auth, quota, server). The check-in itself always saves regardless.
+    const result = await generateDailyInsight(checkIn);
+    if (result.kind === 'text') {
+      checkIn.aiInsight = result.text;
+    } else if (result.kind === 'quota_exceeded') {
+      checkIn.aiInsight = 'Insight skipped — AI quota reached. Resets next cycle.';
+    } else if (result.kind === 'auth_error') {
+      checkIn.aiInsight = FALLBACK_COPY.insight.auth;
+    } else if (result.message === 'rate_limit') {
+      checkIn.aiInsight = FALLBACK_COPY.insight.rateLimit;
+    } else {
+      checkIn.aiInsight = FALLBACK_COPY.insight.server;
+    }
 
     setIsSubmitting(false);
 

--- a/webapp/components/ResetChatModal.tsx
+++ b/webapp/components/ResetChatModal.tsx
@@ -1,0 +1,142 @@
+import React, { useState } from 'react';
+import { X, Loader2, Bookmark, Trash2 } from 'lucide-react';
+import type { ChatMessage } from '../types';
+import { resetCoachChat } from '../services/claudeService';
+
+interface ResetChatModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** Current chat messages excluding the hardcoded welcome (parent passes
+   *  the already-sliced array). Used for the "Save" summarize call. */
+  messagesToSave: ChatMessage[];
+  /** Called after a successful reset so the parent can clear local state
+   *  back to the welcome message. */
+  onResetComplete: () => void;
+  /** Called if the reset hit the 402 quota cap so the parent can show its
+   *  banner instead of the chat input. */
+  onQuotaExceeded: (periodEndsAt: string | null) => void;
+}
+
+/**
+ * Two-action modal that fronts /api/coach-reset (Issue #54, Scope 2).
+ * Sync UX: "Saving…" state while the server summarizes; modal stays open
+ * so the user gets explicit confirmation that the memory was written
+ * before the chat clears.
+ */
+export const ResetChatModal: React.FC<ResetChatModalProps> = ({
+  open,
+  onClose,
+  messagesToSave,
+  onResetComplete,
+  onQuotaExceeded,
+}) => {
+  const [busy, setBusy] = useState<'save' | 'discard' | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  const handleReset = async (save: boolean) => {
+    setError(null);
+    setBusy(save ? 'save' : 'discard');
+    const result = await resetCoachChat(messagesToSave, save);
+    setBusy(null);
+
+    if (result.kind === 'text') {
+      onResetComplete();
+      onClose();
+      return;
+    }
+    if (result.kind === 'quota_exceeded') {
+      onQuotaExceeded(result.periodEndsAt);
+      onClose();
+      return;
+    }
+    setError(
+      result.kind === 'auth_error'
+        ? 'Please sign in again to reset your chat.'
+        : 'Reset failed. Please try again.',
+    );
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Reset chat"
+      className="fixed inset-0 z-[60] flex items-end md:items-center justify-center
+                 bg-stone-900/40 backdrop-blur-sm animate-in fade-in duration-200"
+      onClick={busy ? undefined : onClose}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="bg-white w-full md:max-w-md md:rounded-2xl rounded-t-3xl
+                   max-h-[90vh] flex flex-col overflow-hidden shadow-2xl
+                   animate-in slide-in-from-bottom-8 md:zoom-in-95 duration-300"
+      >
+        <header className="flex items-center justify-between px-5 py-4 border-b border-stone-200">
+          <h2 className="text-base font-semibold text-purple-900">Start a new conversation</h2>
+          <button
+            onClick={onClose}
+            disabled={busy !== null}
+            aria-label="Close"
+            className="p-1 rounded-lg text-stone-500 hover:bg-stone-100 transition-colors disabled:opacity-30"
+          >
+            <X size={20} />
+          </button>
+        </header>
+
+        <div className="p-5 space-y-4">
+          <p className="text-sm text-stone-700 leading-relaxed">
+            Your current chat will be cleared. Choose how the coach should handle what you've shared so far.
+          </p>
+
+          <button
+            onClick={() => handleReset(true)}
+            disabled={busy !== null || messagesToSave.length === 0}
+            className="w-full flex items-start gap-3 p-4 border border-purple-200 rounded-xl
+                       hover:bg-purple-50 hover:border-purple-300 transition-colors
+                       text-left disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <div className="flex-shrink-0 w-9 h-9 rounded-lg bg-purple-100 text-purple-700 flex items-center justify-center">
+              {busy === 'save' ? <Loader2 size={18} className="animate-spin" /> : <Bookmark size={18} />}
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="font-semibold text-purple-900 text-sm">
+                {busy === 'save' ? 'Saving…' : 'Save & start fresh'}
+              </div>
+              <div className="text-xs text-stone-600 mt-0.5 leading-snug">
+                Compress this chat into a memory note. The coach will remember context next time.
+              </div>
+            </div>
+          </button>
+
+          <button
+            onClick={() => handleReset(false)}
+            disabled={busy !== null}
+            className="w-full flex items-start gap-3 p-4 border border-stone-200 rounded-xl
+                       hover:bg-stone-50 hover:border-stone-300 transition-colors
+                       text-left disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <div className="flex-shrink-0 w-9 h-9 rounded-lg bg-stone-100 text-stone-600 flex items-center justify-center">
+              {busy === 'discard' ? <Loader2 size={18} className="animate-spin" /> : <Trash2 size={18} />}
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="font-semibold text-stone-800 text-sm">
+                {busy === 'discard' ? 'Clearing…' : 'Discard & start fresh'}
+              </div>
+              <div className="text-xs text-stone-600 mt-0.5 leading-snug">
+                Wipe this chat and any saved memory. The coach starts with a clean slate.
+              </div>
+            </div>
+          </button>
+
+          {error && (
+            <p className="text-xs text-red-600 text-center" role="alert">
+              {error}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/webapp/constants.ts
+++ b/webapp/constants.ts
@@ -1,3 +1,29 @@
+import type { ChatMessage } from './types';
+
+// Coach welcome — prepended at chat load and re-applied after a reset.
+// Never persisted to DB; the server-side coach_messages row stores only
+// real user/assistant turns.
+export const COACH_WELCOME_MESSAGE: ChatMessage = {
+  role: 'assistant',
+  content: "Hello. I'm your Mind Compass coach.\n\nI'm here to help you reflect, analyze patterns, and maintain control.\n\nWhat's on your mind today?",
+};
+
+// Three starter prompts shown only when the chat is empty (just the welcome
+// message). Click → fills input and sends. Issue #54, Scope 3.
+export const COACH_STARTER_PROMPTS = [
+  "I'm struggling with an urge",
+  "I want to reflect on yesterday",
+  "What pattern do you see?",
+];
+
+// Static quick-reply chips shown after each assistant turn. Hidden once the
+// user starts typing their own message. Issue #54, Scope 3.
+export const COACH_QUICK_REPLIES = [
+  "Tell me more",
+  "Give me an action",
+  "Different approach",
+];
+
 export const FLOW_A_HELPED_OPTIONS = [
   "I stayed busy",
   "I avoided triggers",

--- a/webapp/prompts/aiCoach.ts
+++ b/webapp/prompts/aiCoach.ts
@@ -1,72 +1,70 @@
-// System prompt for the AI Coach. Static instructions + recent check-in
-// context (the user's behavioral data, not chat history). The chat history
-// itself is passed separately via `messages[]` to Anthropic.
-export const buildCoachSystemPrompt = (context: string): string => {
-  return `
-You are a "Mind Compass AI" – a calm, privacy-first AI coach helping a user reduce porn addiction and dopamine-driven compulsive behaviors.
+// System prompt for the AI Coach (Mind Compass).
+//
+// Design (Issue #54, Scope 1): replaces the prior rigid Status/Noticed/Next
+// template with a flexible, evidence-based frame. The coach picks the shape
+// of each response from the user's actual need instead of forcing every
+// reply into a fixed scaffold.
+//
+// Therapeutic toolkit referenced in the prompt:
+//   • CBT — cognitive reframing of distorted thoughts
+//   • Motivational Interviewing — open questions, eliciting change talk,
+//     rolling with resistance, affirming autonomy
+//   • ACT — acceptance of urges/feelings, values-aligned action
+//
+// Context inputs:
+//   • `context`     — recent check-in history (behavioral data, not chat)
+//   • `memoryNote`  — optional compressed summary of prior conversations
+//                     written by /api/coach-reset
+export const buildCoachSystemPrompt = (
+  context: string,
+  memoryNote?: string | null,
+): string => {
+  const memoryBlock = memoryNote && memoryNote.trim()
+    ? `\nPRIOR CONVERSATION SUMMARY (carry forward, don't repeat back to the user verbatim):\n${memoryNote.trim()}\n`
+    : '';
 
-Non-negotiables:
-No shame. No punishment. No moralizing.
-No social comparison. No leaderboards.
-"Process over perfection."
-Short, human, supportive language.
+  return `You are "Mind Compass" — a calm, evidence-based AI coach for someone working to reduce porn addiction and compulsive dopamine-driven behaviors.
 
-Output format (CRITICAL):
-Max 1000 characters.
-Use **bold** for section headers (e.g., **Status:**).
-Use double newlines (\n\n) to create clear spacing between sections.
-Each bullet point must be on its own new line.
-Use "• " for bullet points.
-Never output one giant paragraph.
-Keep it visually clean and spaced out.
+# Non-negotiables
+- No shame. No moralizing. No punishment framing.
+- No social comparison, leaderboards, or streak-pressure.
+- Process over perfection. Slips are data, not failures.
+- The user has full autonomy. You offer; they decide.
 
-Default response structure (use only the sections that apply):
-**Status:**
-(one short sentence)
+# Therapeutic toolkit (use as needed, not as a script)
+- **CBT**: gently surface the thought driving the feeling; offer a reframe only when the user seems open to one.
+- **Motivational Interviewing**: open-ended questions, reflective listening, affirm effort, roll with resistance instead of arguing.
+- **ACT**: urges and feelings are temporary signals, not commands. Help the user choose action aligned with their values, not driven by avoidance.
 
-**What I noticed:**
-• (1–2 bullets)
+# Response shape (CRITICAL — adapt to what the user actually needs)
+Default arc: **validate → reflect / reframe → (optionally) one small action**. Skip stages that don't fit.
 
-**Next step (pick up to 3):**
-• (Lifestyle priority) …
-• (Helpful experiment) …
-• (Optional) …
+Pick ONE shape per turn:
+- **Validation only** (≤300 chars): when the user is venting or has just shared something raw. Sit with them; don't fix.
+- **Reflection + one open question** (≤500 chars): when they seem to be processing and could go deeper with a nudge.
+- **Reframe + one small action** (≤800 chars): when they're stuck on a thought distortion AND signal they want help moving forward.
+- **Urge mode** (≤500 chars, punchy): when they say "I have an urge" / "help now". Lead with ONE grounding action + one reframe sentence. Skip headers, skip lists.
 
-**Helpful / Neutral / Risky** (optional, only if useful):
-**Helpful:**
-• …
-**Neutral:**
-• …
-**Risky:**
-• …
+# Formatting
+- Write like a thoughtful friend, not a clinician or a self-help book.
+- Plain prose by default. Single line breaks between thoughts.
+- Bullets ONLY when listing 3+ truly parallel concrete items (e.g. "three things you could try").
+- **Bold** sparingly — only for a single emphasized word or phrase.
+- NO markdown headers (\`#\`, \`##\`, \`**Status:**\`) inside the response.
+- NO double-blank-lines between every sentence. Paragraphs only when topic shifts.
+- Ask AT MOST one question per response.
 
-**Close with one gentle line:**
-(one short line, supportive, not motivational fluff)
+# What NOT to do
+- Don't open with "I hear you" / "That sounds tough" formulas — sound human, not scripted.
+- Don't list three actions when one will do.
+- Don't summarize what the user just said back at length.
+- Don't end with motivational fluff ("You've got this!").
+- Don't suggest the same action twice in a session if the user said it didn't help.
 
-Modes:
-If user says they logged a relapse/behavior: use the default structure above.
-If user reports an urge ("I need help now"): use the Urge structure below.
-
-Urge structure (when "urge now"):
-**Right now:**
-• (1 grounding step)
-• (1 tiny physical action)
-• (1 time delay: 10–20 minutes)
-
-**Make it easier:**
-• (1 environment change)
-
-**Reframe:**
-(one calm sentence: "You don't need to decide right now. This will pass.")
-
-Then ask ONE short question:
-(one question only)
-
-Safety:
-If user mentions self-harm or crisis: respond calmly and suggest contacting local emergency services or a trusted person immediately.
-
-----------------
-USER CONTEXT (Recent Check-ins):
-${context}
-  `;
+# Safety
+If the user mentions self-harm, suicide, or acute crisis: respond calmly, drop the structure, and direct them to local emergency services (988 in the US) or a trusted person. Don't try to coach through it.
+${memoryBlock}
+USER CONTEXT (recent check-ins):
+${context || '(no recent check-ins)'}
+`;
 };

--- a/webapp/services/claudeService.ts
+++ b/webapp/services/claudeService.ts
@@ -1,7 +1,7 @@
 // Client wrappers around the webapp's Anthropic-backed serverless functions
-// (`/api/coach` and `/api/daily-insight`). The Anthropic API key lives only
-// on the server — this module just authenticates the user with Supabase
-// and forwards the prompt payload.
+// (`/api/coach`, `/api/daily-insight`, `/api/coach-reset`).
+// The Anthropic API key lives only on the server — this module just
+// authenticates the user with Supabase and forwards the prompt payload.
 import { CheckIn, ChatMessage } from "../types";
 import { buildCoachSystemPrompt } from "../prompts/aiCoach";
 import { buildDailyInsightSystem, buildDailyInsightUserMessage } from "../prompts/dailyInsight";
@@ -10,10 +10,27 @@ import { logger } from "../src/lib/logger";
 
 const COACH_ENDPOINT = '/api/coach';
 const DAILY_INSIGHT_ENDPOINT = '/api/daily-insight';
+const COACH_RESET_ENDPOINT = '/api/coach-reset';
 
-// User-facing fallback strings — keep aligned with prior Gemini messages so
-// existing UX copy doesn't shift.
-const FALLBACK = {
+// ── Result types ────────────────────────────────────────────────────────
+// Issue #54: endpoints can now return 402 when the user is over their
+// $1 / 3-month LLM budget. Callers branch on the discriminator instead
+// of receiving a magic error string.
+
+export interface QuotaExceeded {
+  kind: 'quota_exceeded';
+  /** ISO timestamp when the user's window resets. */
+  periodEndsAt: string | null;
+}
+export interface TextResult { kind: 'text'; text: string; }
+export interface AuthError  { kind: 'auth_error'; message: string; }
+export interface ServerError { kind: 'server_error'; message: string; }
+
+export type ServiceResult = TextResult | QuotaExceeded | AuthError | ServerError;
+
+// User-facing fallback copy for non-quota errors. Kept here so the UI
+// doesn't have to duplicate strings.
+export const FALLBACK_COPY = {
   coach: {
     auth: "AI Coach unavailable (please sign in again).",
     rateLimit: "AI Coach is busy. Please try again in a moment.",
@@ -28,24 +45,76 @@ const FALLBACK = {
   },
 } as const;
 
-// Returns the Supabase access_token for the current session, or null if the
-// user is signed out / Supabase isn't configured.
+// ── Auth helper ────────────────────────────────────────────────────────
+
 async function getAccessToken(): Promise<string | null> {
   if (!supabase) return null;
   const { data } = await supabase.auth.getSession();
   return data.session?.access_token ?? null;
 }
 
-type FallbackKind = keyof typeof FALLBACK;
+// ── Memory cache ───────────────────────────────────────────────────────
+// The Coach memory note (compressed summary of prior conversations) is
+// fetched lazily and reused for subsequent Coach calls so we don't refetch
+// on every keystroke. After a local reset / logout we invalidate so the
+// next call refetches the freshly-written summary.
+//
+// Known limitation: if the user resets the chat in another tab or device,
+// this tab's cached note is stale until the TTL expires. We refresh after
+// CACHE_TTL_MS so multi-device drift heals on its own without explicit
+// cross-tab signalling.
+
+const CACHE_TTL_MS = 30 * 60 * 1000; // 30 min
+
+let cachedMemoryNote: string | null | undefined = undefined; // undefined = not yet fetched
+let cachedAt = 0;
+
+async function getMemoryNote(): Promise<string | null> {
+  const fresh = cachedMemoryNote !== undefined && (Date.now() - cachedAt) < CACHE_TTL_MS;
+  if (fresh) return cachedMemoryNote ?? null;
+
+  if (!supabase) {
+    cachedMemoryNote = null;
+    cachedAt = Date.now();
+    return null;
+  }
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    cachedMemoryNote = null;
+    cachedAt = Date.now();
+    return null;
+  }
+  const { data, error } = await supabase
+    .from('coach_memory')
+    .select('summary')
+    .eq('user_id', user.id)
+    .maybeSingle();
+  if (error) {
+    logger.warn('coach_memory fetch error', { error });
+    cachedMemoryNote = null;
+    cachedAt = Date.now();
+    return null;
+  }
+  cachedMemoryNote = data?.summary ?? null;
+  cachedAt = Date.now();
+  return cachedMemoryNote;
+}
+
+/** Force a refetch on next Coach call. Call after sign-out or chat reset. */
+export function invalidateMemoryCache(): void {
+  cachedMemoryNote = undefined;
+  cachedAt = 0;
+}
+
+// ── Core fetch + result normalization ──────────────────────────────────
 
 async function callEndpoint(
   endpoint: string,
   payload: unknown,
-  fallback: typeof FALLBACK[FallbackKind],
-  contextLabel: string
-): Promise<string> {
+  contextLabel: string,
+): Promise<ServiceResult> {
   const token = await getAccessToken();
-  if (!token) return fallback.auth;
+  if (!token) return { kind: 'auth_error', message: 'no-session' };
 
   let response: Response;
   try {
@@ -59,47 +128,112 @@ async function callEndpoint(
     });
   } catch (err) {
     logger.error(`${contextLabel} network error.`, { error: err });
-    return fallback.server;
+    return { kind: 'server_error', message: 'network' };
   }
 
-  if (response.status === 401) return fallback.auth;
-  if (response.status === 429) {
-    logger.warn(`${contextLabel} rate-limited.`);
-    return fallback.rateLimit;
+  if (response.status === 401) return { kind: 'auth_error', message: 'unauthorized' };
+  if (response.status === 402) {
+    let periodEndsAt: string | null = null;
+    try {
+      const body = await response.json();
+      periodEndsAt = body?.periodEndsAt ?? null;
+    } catch { /* ignore — return null */ }
+    return { kind: 'quota_exceeded', periodEndsAt };
   }
+  if (response.status === 429) return { kind: 'server_error', message: 'rate_limit' };
   if (!response.ok) {
     logger.error(`${contextLabel} request failed.`, { status: response.status });
-    return fallback.server;
+    return { kind: 'server_error', message: `http_${response.status}` };
   }
 
   try {
     const data = await response.json();
-    return (typeof data.text === 'string' && data.text.trim()) ? data.text : fallback.empty;
+    const text = typeof data.text === 'string' ? data.text.trim() : '';
+    if (!text) return { kind: 'server_error', message: 'empty' };
+    return { kind: 'text', text };
   } catch (err) {
     logger.error(`${contextLabel} response parse error.`, { error: err });
-    return fallback.server;
+    return { kind: 'server_error', message: 'parse' };
   }
 }
+
+// ── Public API ─────────────────────────────────────────────────────────
 
 export const getCoachResponse = async (
   message: string,
   context: string,
-  history: ChatMessage[] = []
-): Promise<string> => {
-  // Build the messages[] payload: prior turns + the new user message.
-  // Server caps the array length too as defense in depth.
+  history: ChatMessage[] = [],
+): Promise<ServiceResult> => {
+  const memoryNote = await getMemoryNote();
   const messages: ChatMessage[] = [...history, { role: 'user', content: message }];
   const payload = {
-    systemPrompt: buildCoachSystemPrompt(context),
+    systemPrompt: buildCoachSystemPrompt(context, memoryNote),
     messages,
   };
-  return callEndpoint(COACH_ENDPOINT, payload, FALLBACK.coach, 'Coach');
+  return callEndpoint(COACH_ENDPOINT, payload, 'Coach');
 };
 
-export const generateDailyInsight = async (checkIn: CheckIn): Promise<string> => {
+export const generateDailyInsight = async (checkIn: CheckIn): Promise<ServiceResult> => {
   const payload = {
     systemPrompt: buildDailyInsightSystem(),
     userMessage: buildDailyInsightUserMessage(checkIn),
   };
-  return callEndpoint(DAILY_INSIGHT_ENDPOINT, payload, FALLBACK.insight, 'Daily insight');
+  return callEndpoint(DAILY_INSIGHT_ENDPOINT, payload, 'Daily insight');
+};
+
+/**
+ * Reset the Coach chat. `save: true` summarizes prior messages into the
+ * memory note before wiping; `save: false` discards both chat AND memory.
+ * Both paths clear `coach_messages` server-side.
+ *
+ * Resolves to a ServiceResult so callers can show the same quota/error
+ * UI as the regular Coach calls. On success returns kind: 'text' with the
+ * new summary as text (or empty string for discard).
+ */
+export const resetCoachChat = async (
+  messages: ChatMessage[],
+  save: boolean,
+): Promise<ServiceResult> => {
+  const token = await getAccessToken();
+  if (!token) return { kind: 'auth_error', message: 'no-session' };
+
+  let response: Response;
+  try {
+    response = await fetch(COACH_RESET_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: JSON.stringify({ messages, save }),
+    });
+  } catch (err) {
+    logger.error('Coach reset network error.', { error: err });
+    return { kind: 'server_error', message: 'network' };
+  }
+
+  if (response.status === 401) return { kind: 'auth_error', message: 'unauthorized' };
+  if (response.status === 402) {
+    let periodEndsAt: string | null = null;
+    try {
+      const body = await response.json();
+      periodEndsAt = body?.periodEndsAt ?? null;
+    } catch { /* ignore */ }
+    return { kind: 'quota_exceeded', periodEndsAt };
+  }
+  if (!response.ok) {
+    logger.error('Coach reset failed.', { status: response.status });
+    return { kind: 'server_error', message: `http_${response.status}` };
+  }
+
+  try {
+    const data = await response.json();
+    // Invalidate cache so the next Coach call picks up the new (or wiped)
+    // memory note.
+    invalidateMemoryCache();
+    return { kind: 'text', text: typeof data.summary === 'string' ? data.summary : '' };
+  } catch (err) {
+    logger.error('Coach reset response parse error.', { error: err });
+    return { kind: 'server_error', message: 'parse' };
+  }
 };


### PR DESCRIPTION
## Summary
Global quality lift for AI Coach across four scopes — see [#54](https://github.com/johnbukhin/ai-dopamine-cursor/issues/54) for the full design and [PLAN_issue_54.md](PLAN_issue_54.md) for implementation breakdown.

- **Prompt:** flexible evidence-based shapes (validate → reframe → action), CBT/MI/ACT toolkit, explicit length caps per response type, anti-patterns list. Memory-note injection.
- **Reset:** "New conversation" button → modal with `Save & start fresh` (LLM summarizes prior chat into single-row `coach_memory` note, then wipes `coach_messages`) or `Discard & start fresh` (wipes both).
- **UX polish:** three starter prompts in empty state, static quick-reply chips after each assistant turn, three-dot typing indicator.
- **Spend cap:** $1 / 3-month rolling per user, covers Coach + Daily Insight + summarize. Atomic Postgres RPC with conditional reset in `ON CONFLICT`. 402 → input swapped for `Quota reached. Resets on {date}.` banner.

Closes #54.

## Commits
- `feat: AI Coach v2 — evidence-based prompt, chat reset, $1/3-month LLM cap (#54)` — single commit, see message for the detailed scope-by-scope breakdown.

## Pre-deploy step
Apply both new migrations in Supabase Dashboard before this hits prod (project convention — migrations are manual):
- `supabase/migrations/20260603_llm_usage.sql`
- `supabase/migrations/20260603_coach_memory.sql`

## Test plan
- [x] `npm run build` — clean, 2097 modules, no errors
- [x] `bash scripts/smoke-test.sh` against prod baseline — 7/9 (2 fails are missing local Stripe env vars, not regressions)
- [x] Self-review + adversarial peer-review pass; all HIGH + MEDIUM findings fixed (wipe error propagation, recordSpend ordering, generation counter for in-flight persist race, user-id guard for logout/login race)
- [ ] Manual QA after deploy: send 3+ Coach messages to verify new prompt feels less rigid, exercise both reset paths, temp-flip `QUOTA_USD` to 0.001 to verify banner
- [ ] Re-run smoke test against deployed prod

## Out of scope (deferred)
Streaming responses, copy/regenerate buttons, haptic/sound, prompt caching, rolling mid-chat summary — separate follow-up issues if metrics warrant.

Smoke test runs automatically on push via Claude Code hook.