### PR TITLE
style: cosmetic polish pass 2 — Help tab + Dashboard follow-ups (#58)

### DIFF
--- a/.claude/plans/issue-58-cosmetic-polish-pass-2.md
+++ b/.claude/plans/issue-58-cosmetic-polish-pass-2.md
@@ -1,0 +1,70 @@
+# Issue #58 — Cosmetic Polish Pass (2nd round)
+
+**Overall Progress:** `100%`
+
+## TLDR
+
+Four follow-up polish items from issue #58 that came in after #59 merged: action-card text picks up its category color (Item 7), the Locate modal stops jumping when the slider is first touched (Item 8), the `URGES SURFED` Dashboard tile becomes an upsell button for free users (Item 9), and the Locate modal subtly darkens/lightens within the rose palette as intensity changes (Item 10). Item 4 (Coach tab navigation) remains deferred.
+
+## Critical Decisions
+
+- **Item 7:** Extend `URGE_CATEGORY_META` with two new static-literal fields (`titleClass`, `descriptionClass`). `Best fit` badge and recommended-card border stay rose — they're a separate highlight layer on top of the category color.
+- **Item 8:** Always render the middle Mild/value/Crushing span at the larger `text-base font-bold` size; only the content swaps (`·` ↔ number). No `min-h` wrapper needed.
+- **Item 9:** Add `hasUpsellAccess` prop on `Dashboard`. When `false`, wrap the tile in a `<button>` with the exact same hover/transition treatment as the existing `I'm having an urge — help me` button (translated to purple). When `true`, stay as a static `<div>`.
+- **Item 10:** Surfaces modulated (B): inner card bg + border + slider accent + intensity number color + drag-handle pill. Sheet outer (white) and CTA button stay constant. Implementation: inline HSL interpolation (not a 10-step Tailwind lookup) — user explicitly asked for *плавно* (smooth). `intensity === null` renders identically to `intensity === 5`.
+- **Pairing:** Items 8 + 10 ship together — on first slider touch, neither the height nor the color jumps.
+
+## Tasks
+
+- [x] 🟩 **Step 1: Item 7 — Card title + description per category color**
+  - [x] 🟩 In `webapp/data/urgeData.ts`, extend each `URGE_CATEGORY_META` entry with two new fields:
+    - `reset`: `titleClass: 'text-emerald-900'`, `descriptionClass: 'text-emerald-700/70'`
+    - `ground`: `titleClass: 'text-teal-900'`, `descriptionClass: 'text-teal-700/70'`
+    - `protect`: `titleClass: 'text-sky-900'`, `descriptionClass: 'text-sky-700/70'`
+    - `reframe`: `titleClass: 'text-indigo-900'`, `descriptionClass: 'text-indigo-700/70'`
+  - [x] 🟩 Update the `URGE_CATEGORY_META` TypeScript type signature in `urgeData.ts:151-154` to include the two new fields.
+  - [x] 🟩 In `webapp/components/urgeHelp/ActStage.tsx`:
+    - Line 168: swap `font-semibold text-rose-900 text-sm` → `font-semibold ${meta.titleClass} text-sm`
+    - Line 171: swap `text-[11px] md:text-xs text-rose-700/70` → `text-[11px] md:text-xs ${meta.descriptionClass}`
+  - [x] 🟩 Leave the `Best fit` badge (line 142-149) and the highlighted-card border (line 127-130) untouched — they stay rose as a special-highlight layer.
+
+- [x] 🟩 **Step 2: Item 8 — Sheet height stability**
+  - [x] 🟩 In `webapp/components/urgeHelp/LocateStage.tsx` lines 228-236, change the middle `<span>` so its className is **always** `text-base font-bold normal-case tracking-normal text-rose-800` (no ternary). Only the children swap: `{intensity !== null ? intensity : '·'}`.
+  - [x] 🟩 Verify visually that the placeholder `·` reads as a neutral-looking dot when rendered at the larger weight (an alternative like `–` or a non-breaking space can be subbed in at review if `·` looks weird).
+
+- [x] 🟩 **Step 3: Item 9 — `URGES SURFED` tile as upsell button**
+  - [x] 🟩 In `webapp/components/Dashboard.tsx`:
+    - Add `hasUpsellAccess: boolean` to `DashboardProps` (around line 8-15).
+    - In the tile JSX at lines 299-326, conditionally render: when `hasUpsellAccess === true`, keep the current `<div>` exactly as-is; when `false`, swap the outer wrapper to `<button type="button" onClick={() => onChangeView(View.AI_COACH)}>` with these extra classes appended: `hover:bg-purple-200 transition-colors text-left`. All inner content (icon, label, count, wave SVG) stays identical.
+  - [x] 🟩 In `webapp/App.tsx` around line 481-489 where `<Dashboard ... />` is rendered, pass `hasUpsellAccess={hasUpsellAccess}` (the state already exists at line 55).
+  - [x] 🟩 No changes needed to `urgeLog.ts` or its callers — the counter is already frozen for users without Help access by virtue of being localStorage-only and only written from inside `UrgeHelp.tsx` (which is gated behind ProGate).
+
+- [x] 🟩 **Step 4: Item 10 — Intensity-driven rose shading (paired with Step 2)**
+  - [x] 🟩 In `webapp/components/urgeHelp/LocateStage.tsx`, add a small helper near the top of the file (after imports, before the component):
+    ```ts
+    /** Map intensity 1–10 (or null = 5) to an HSL tuple for the rose-family
+     *  tones that modulate around the sheet. Lightness/saturation only — hue
+     *  stays in the rose band so the visual stays rose-themed. */
+    function intensityTones(intensity: number | null) {
+      const v = intensity ?? 5; // null renders identical to 5 — no first-touch jump
+      // ... linear interpolation: 1 = lightest, 5 = baseline (today's tones), 10 = deepest
+      // Returns { cardBg, cardBorder, sliderAccent, numberColor, handle }
+    }
+    ```
+    Anchor values at `v=5` should reproduce today's rendered colors (`bg-rose-50` ≈ `hsl(355, 100%, 97%)`, `border-rose-100` ≈ `hsl(354, 100%, 94%)`, `accent-rose-700` ≈ `hsl(348, 83%, 47%)`, `text-rose-800` ≈ `hsl(348, 80%, 36%)`, `bg-rose-200` ≈ `hsl(352, 96%, 90%)`). Interpolate each toward a lighter pair at `v=1` and a darker pair at `v=10`.
+  - [x] 🟩 Replace the static Tailwind classes on these elements with inline-styled equivalents driven by `intensityTones(intensity)`:
+    - Drag handle pill (line 182): `bg-rose-200` → inline `backgroundColor`
+    - Inner intensity card (line 208): `bg-rose-50 border border-rose-100` → inline `backgroundColor` + `borderColor` (keep `border` utility for the 1px width)
+    - Slider input (line 222): `accent-rose-700` → inline `accentColor`
+    - Intensity number span (Step 2 element): `text-rose-800` → inline `color`
+  - [x] 🟩 Add `transition: 'background-color 300ms, border-color 300ms, color 300ms, accent-color 300ms'` to each inline-styled element so drag-to-change reads as a gradient.
+  - [x] 🟩 Leave constant: sheet outer (white), `border-rose-200` on the sheet top edge, header text (`text-rose-900` / `text-rose-700/60`), close button, `Continue` CTA (`bg-rose-700`). These read as stable chrome around the modulating interior.
+
+- [x] 🟩 **Step 5: Verify in browser**
+  - [x] 🟩 Run `tsc --noEmit` clean
+  - [x] 🟩 Smoke-test each item:
+    - Act stage: each of the 4 categories shows its own hue on the card title and description; `Best fit` cards remain rose
+    - Locate sheet: first touch on slider does NOT change the sheet height; no visual jump from null → 5
+    - Locate sheet: dragging the slider smoothly darkens/lightens the inner card, slider, number, and drag handle (rose-only, subtle)
+    - Dashboard: in incognito or with `localStorage.removeItem('mc_has_upsell')`, the `URGES SURFED` tile shows hover state, cursor pointer, and clicking navigates to the Coach tab (which renders ProGate)
+    - Dashboard: with `localStorage.setItem('mc_has_upsell', '1')`, the tile is static (no hover, no click)

--- a/webapp/App.tsx
+++ b/webapp/App.tsx
@@ -485,6 +485,7 @@ export default function App() {
             celebrationSignal={celebrationSignal}
             onOpenCheckIn={() => handleOpenCheckIn({ tasksCompleted: false })}
             onChangeView={changeView}
+            hasUpsellAccess={hasUpsellAccess}
           />
         )}
 

--- a/webapp/components/Dashboard.tsx
+++ b/webapp/components/Dashboard.tsx
@@ -12,6 +12,10 @@ interface DashboardProps {
   celebrationSignal: { type: 'clean' | 'slip'; ts: number } | null;
   onOpenCheckIn?: () => void;
   onChangeView: (view: View) => void;
+  /** When false, the `Urges Surfed` tile becomes a clickable upsell button
+   *  that routes to the Coach tab (which renders ProGate). Paid users see
+   *  the existing static stat tile. */
+  hasUpsellAccess: boolean;
 }
 
 // Rotating CTA phrases shown on the Check-in card before the day's first check-in.
@@ -103,7 +107,7 @@ const Celebration: React.FC<{
   );
 };
 
-export const Dashboard: React.FC<DashboardProps> = ({ checkIns, streak, hasCheckedInToday, celebrationSignal, onOpenCheckIn, onChangeView }) => {
+export const Dashboard: React.FC<DashboardProps> = ({ checkIns, streak, hasCheckedInToday, celebrationSignal, onOpenCheckIn, onChangeView, hasUpsellAccess }) => {
   const [currentMonth, setCurrentMonth] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [ctaIndex, setCtaIndex] = useState(0);
@@ -296,34 +300,57 @@ export const Dashboard: React.FC<DashboardProps> = ({ checkIns, streak, hasCheck
                 styled as a sibling of the Streak tile (purple palette,
                 same icon-badge tint, same stroke weight) so the row reads
                 as one cohesive trio. */}
-            <div className="col-span-2 md:col-span-1 md:self-center relative overflow-hidden bg-purple-100 px-4 py-3 md:py-4 rounded-2xl border border-purple-200 flex items-center justify-between gap-3">
-                {/* Decorative wave silhouette — "urges rise and fall like
-                    waves" reframe. Stroke weight matches the Streak chart
-                    and Check-in plus for visual consistency across the row. */}
-                <svg
-                   aria-hidden="true"
-                   viewBox="0 0 60 60"
-                   fill="none"
-                   stroke="currentColor"
-                   strokeWidth="6"
-                   strokeLinecap="round"
-                   strokeLinejoin="round"
-                   className="absolute -bottom-2 -right-3 w-16 h-16 text-purple-600/20 pointer-events-none"
+            {/* `Urges Surfed` tile. Paid users see a static stat; free users
+                see a clickable button that routes to the Coach tab (which
+                renders ProGate as the upsell). Hover treatment mirrors the
+                `I'm having an urge — help me` button below — same hover-bg
+                step and `transition-colors` — so the row reads as a
+                consistent affordance family. */}
+            {(() => {
+              const baseClasses = "col-span-2 md:col-span-1 md:self-center relative overflow-hidden bg-purple-100 px-4 py-3 md:py-4 rounded-2xl border border-purple-200 flex items-center justify-between gap-3";
+              const inner = (
+                <>
+                  {/* Decorative wave silhouette — "urges rise and fall like
+                      waves" reframe. Stroke weight matches the Streak chart
+                      and Check-in plus for visual consistency across the row. */}
+                  <svg
+                     aria-hidden="true"
+                     viewBox="0 0 60 60"
+                     fill="none"
+                     stroke="currentColor"
+                     strokeWidth="6"
+                     strokeLinecap="round"
+                     strokeLinejoin="round"
+                     className="absolute -bottom-2 -right-3 w-16 h-16 text-purple-600/20 pointer-events-none"
+                  >
+                     <path d="M2 36 Q12 22 22 36 T42 36 T62 36" />
+                     <path d="M2 46 Q12 32 22 46 T42 46 T62 46" />
+                  </svg>
+                  <div className="flex items-center gap-2 relative">
+                     <div className="bg-purple-300/60 p-1.5 rounded-lg">
+                        <Waves size={16} className="text-purple-700" />
+                     </div>
+                     <span className="text-[10px] font-semibold uppercase tracking-wider text-purple-700">Urges Surfed</span>
+                  </div>
+                  <div className="flex items-baseline gap-1.5 relative">
+                     <span className="text-[23px] md:text-[27px] font-semibold text-purple-900 leading-tight">{urgesSurfed}</span>
+                     <span className="text-xl md:text-2xl font-semibold text-purple-700 leading-tight">{urgesSurfed === 1 ? 'surf' : 'surfs'}</span>
+                  </div>
+                </>
+              );
+              return hasUpsellAccess ? (
+                <div className={baseClasses}>{inner}</div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => onChangeView(View.AI_COACH)}
+                  className={`${baseClasses} text-left hover:bg-purple-200 transition-colors`}
+                  aria-label="Unlock Urges Surfed — open Coach"
                 >
-                   <path d="M2 36 Q12 22 22 36 T42 36 T62 36" />
-                   <path d="M2 46 Q12 32 22 46 T42 46 T62 46" />
-                </svg>
-                <div className="flex items-center gap-2 relative">
-                   <div className="bg-purple-300/60 p-1.5 rounded-lg">
-                      <Waves size={16} className="text-purple-700" />
-                   </div>
-                   <span className="text-[10px] font-semibold uppercase tracking-wider text-purple-700">Urges Surfed</span>
-                </div>
-                <div className="flex items-baseline gap-1.5 relative">
-                   <span className="text-[23px] md:text-[27px] font-semibold text-purple-900 leading-tight">{urgesSurfed}</span>
-                   <span className="text-xl md:text-2xl font-semibold text-purple-700 leading-tight">{urgesSurfed === 1 ? 'surf' : 'surfs'}</span>
-                </div>
-            </div>
+                  {inner}
+                </button>
+              );
+            })()}
          </div>
 
          {/* Urge Help — utility row; rose accent to telegraph "this is the

--- a/webapp/components/urgeHelp/ActStage.tsx
+++ b/webapp/components/urgeHelp/ActStage.tsx
@@ -165,10 +165,10 @@ export const ActStage: React.FC<ActStageProps> = ({ feeling, triedActionIds, onP
                           <Icon size={20} />
                         </div>
 
-                        <div className="font-semibold text-rose-900 text-sm leading-tight mb-1">
+                        <div className={`font-semibold ${meta.titleClass} text-sm leading-tight mb-1`}>
                           {action.title}
                         </div>
-                        <p className="text-[11px] md:text-xs text-rose-700/70 leading-snug">
+                        <p className={`text-[11px] md:text-xs ${meta.descriptionClass} leading-snug`}>
                           {action.whyItWorks}
                         </p>
                       </button>

--- a/webapp/components/urgeHelp/LocateStage.tsx
+++ b/webapp/components/urgeHelp/LocateStage.tsx
@@ -13,6 +13,44 @@ interface LocateStageProps {
 /** Exit animation duration — must match `.animate-sheet-down` in index.css. */
 const SHEET_EXIT_MS = 240;
 
+/** Smooth HSL transition duration for intensity-driven shading. */
+const TONE_TRANSITION = 'background-color 300ms ease, border-color 300ms ease, color 300ms ease, accent-color 300ms ease';
+
+/** A single HSL anchor — `[hue, saturation%, lightness%]`. */
+type HSLAnchor = readonly [number, number, number];
+
+/** Linearly interpolate a single tone (3 anchors: v=1, v=5, v=10) for any
+ *  integer intensity v ∈ [1, 10]. v=5 reproduces today's baseline colour
+ *  exactly so the sheet's "untouched" look matches the slider default. */
+function interpolateHSL(v: number, a: HSLAnchor, b: HSLAnchor, c: HSLAnchor): string {
+  const t = v <= 5 ? (v - 1) / 4 : (v - 5) / 5;
+  const [from, to] = v <= 5 ? [a, b] : [b, c];
+  const lerp = (x: number, y: number) => x + (y - x) * t;
+  return `hsl(${lerp(from[0], to[0]).toFixed(1)}, ${lerp(from[1], to[1]).toFixed(1)}%, ${lerp(from[2], to[2]).toFixed(1)}%)`;
+}
+
+/** Map intensity 1–10 (or null → 5) to the rose-family tones that modulate
+ *  the Locate sheet's interior. Hue stays in the rose band; only lightness
+ *  and saturation shift, so the sheet always reads as rose-themed but visibly
+ *  deepens with intensity. v=5 anchors reproduce today's Tailwind rose-* shades
+ *  (rose-50, rose-100, rose-200, rose-700, rose-800) so the baseline is
+ *  identical pre- and post-touch.
+ *
+ *  IMPORTANT: every tone's 3 hue anchors stay within the narrow 345°–356°
+ *  band — `interpolateHSL` does plain linear lerp, NOT shortest-arc, so any
+ *  anchor pair that crosses 0°/360° would visibly sweep through yellow →
+ *  green → blue → purple before landing on rose. Keep all three values close. */
+function intensityTones(intensity: number | null) {
+  const v = intensity ?? 5;
+  return {
+    cardBg:       interpolateHSL(v, [355, 100, 99], [355, 100, 97], [355, 90, 92]),
+    cardBorder:   interpolateHSL(v, [356, 100, 97], [356, 100, 95], [355, 96, 85]),
+    handle:       interpolateHSL(v, [355, 96, 94],  [355, 96, 89],  [355, 90, 80]),
+    sliderAccent: interpolateHSL(v, [347, 70, 60],  [347, 83, 41],  [345, 90, 30]),
+    numberColor:  interpolateHSL(v, [345, 70, 50],  [345, 82, 35],  [345, 90, 22]),
+  };
+}
+
 /**
  * Stage 2 — Locate.
  *
@@ -104,6 +142,11 @@ export const LocateStage: React.FC<LocateStageProps> = ({ initialFeeling, onComp
     onComplete(selected, intensity);
   };
 
+  // Intensity-driven shading for the sheet interior. Recomputed every render
+  // — the math is trivial (10 linear interpolations) and the alternative
+  // (useMemo) would add boilerplate without measurable benefit.
+  const tones = intensityTones(intensity);
+
   return (
     <div className="flex-1 flex flex-col min-h-0 relative animate-in fade-in duration-300">
       {/* Scrollable feelings grid. Padding is static now that the sheet is
@@ -177,9 +220,13 @@ export const LocateStage: React.FC<LocateStageProps> = ({ initialFeeling, onComp
               paddingBottom: 'calc(env(safe-area-inset-bottom) + 1rem)',
             }}
           >
-            {/* Drag-handle visual cue (non-functional — just signals "sheet"). */}
+            {/* Drag-handle visual cue (non-functional — just signals "sheet").
+                Tone shifts with intensity. */}
             <div className="flex justify-center mb-2" aria-hidden="true">
-              <div className="w-10 h-1.5 rounded-full bg-rose-200" />
+              <div
+                className="w-10 h-1.5 rounded-full"
+                style={{ backgroundColor: tones.handle, transition: TONE_TRANSITION }}
+              />
             </div>
 
             {/* Header row with selected feeling + close-to-deselect button. */}
@@ -202,10 +249,18 @@ export const LocateStage: React.FC<LocateStageProps> = ({ initialFeeling, onComp
             </div>
 
             {/* Intensity slider — the optional input that gives the log
-                richer signal without blocking progress. */}
+                richer signal without blocking progress. Card background +
+                border + slider accent + value number shift in rose tone as
+                intensity changes; sheet outer chrome stays constant so the
+                modulation reads as interior depth, not a wholesale repaint. */}
             <section
               aria-label="How intense is this urge"
-              className="bg-rose-50 border border-rose-100 rounded-2xl p-4 mb-4"
+              className="border rounded-2xl p-4 mb-4"
+              style={{
+                backgroundColor: tones.cardBg,
+                borderColor: tones.cardBorder,
+                transition: TONE_TRANSITION,
+              }}
             >
               <div className="flex items-baseline justify-between mb-2">
                 <h3 className="text-sm font-semibold text-rose-900">How strong is it?</h3>
@@ -219,18 +274,21 @@ export const LocateStage: React.FC<LocateStageProps> = ({ initialFeeling, onComp
                 step={1}
                 value={intensity ?? 5}
                 onChange={(e) => setIntensity(parseInt(e.target.value, 10))}
-                className="w-full accent-rose-700"
+                className="w-full"
+                style={{ accentColor: tones.sliderAccent, transition: TONE_TRANSITION }}
                 aria-label="Urge intensity from 1 to 10"
               />
 
               <div className="flex justify-between text-[10px] font-semibold uppercase tracking-wider text-rose-700/50 mt-1">
                 <span>Mild</span>
+                {/* Always rendered at the larger weight so the sheet height
+                    is identical before and after the first slider touch —
+                    only the content swaps (`·` placeholder ↔ number). Colour
+                    also tracks intensity so null → 5 → 10 transitions are
+                    smooth in both dimensions. */}
                 <span
-                  className={
-                    intensity !== null
-                      ? 'text-rose-800 text-base font-bold normal-case tracking-normal'
-                      : ''
-                  }
+                  className="text-base font-bold normal-case tracking-normal"
+                  style={{ color: tones.numberColor, transition: TONE_TRANSITION }}
                 >
                   {intensity !== null ? intensity : '·'}
                 </span>

--- a/webapp/data/urgeData.ts
+++ b/webapp/data/urgeData.ts
@@ -147,33 +147,52 @@ export const URGE_ACTION_BY_ID: Record<UrgeActionId, UrgeAction> = Object.fromEn
   URGE_ACTIONS.map((a) => [a.id, a]),
 ) as Record<UrgeActionId, UrgeAction>;
 
-/** Category metadata for headers and subtle tints in the Act grid. */
+/** Category metadata for headers and subtle tints in the Act grid.
+ *  `tint`/`accent` colour the section header + icon badge; `titleClass`/
+ *  `descriptionClass` colour the body of each action card so a whole bucket
+ *  reads as one tonal family. All values are static literals so Tailwind JIT
+ *  can find them at build time. */
 export const URGE_CATEGORY_META: Record<
   UrgeAction['category'],
-  { label: string; subtitle: string; tint: string; accent: string }
+  {
+    label: string;
+    subtitle: string;
+    tint: string;
+    accent: string;
+    titleClass: string;
+    descriptionClass: string;
+  }
 > = {
   reset: {
     label: 'Reset',
     subtitle: 'Calm the body',
     tint: 'bg-emerald-100/60 border-emerald-200',
     accent: 'text-emerald-700',
+    titleClass: 'text-emerald-900',
+    descriptionClass: 'text-emerald-700/70',
   },
   ground: {
     label: 'Ground',
     subtitle: 'Come back to now',
     tint: 'bg-teal-100/60 border-teal-200',
     accent: 'text-teal-700',
+    titleClass: 'text-teal-900',
+    descriptionClass: 'text-teal-700/70',
   },
   protect: {
     label: 'Protect',
     subtitle: 'Change your environment',
     tint: 'bg-sky-100/60 border-sky-200',
     accent: 'text-sky-700',
+    titleClass: 'text-sky-900',
+    descriptionClass: 'text-sky-700/70',
   },
   reframe: {
     label: 'Reframe',
     subtitle: 'Shift the story',
     tint: 'bg-indigo-100/60 border-indigo-200',
     accent: 'text-indigo-700',
+    titleClass: 'text-indigo-900',
+    descriptionClass: 'text-indigo-700/70',
   },
 };


### PR DESCRIPTION
## Summary

Four follow-up polish items from #58 that came in after #59 merged. Item 4 (Coach tab navigation) remains deferred for a third pass.

Refs #58 (Item 4 still open).

## What changed

- **Help tab — Act card title + description now match the category color** (`webapp/data/urgeData.ts` + `webapp/components/urgeHelp/ActStage.tsx`). Two new static-literal fields on `URGE_CATEGORY_META` (`titleClass`, `descriptionClass`) so each bucket reads as one tonal family. `Best fit` badge and recommended-card border stay rose — they're a separate highlight layer that must pop over the category color.
- **Help tab — Locate modal sheet stops jumping height on first slider touch** (`webapp/components/urgeHelp/LocateStage.tsx`). The middle Mild/value/Crushing `<span>` was `text-[10px]` (`·` placeholder) until any value was set, then jumped to `text-base font-bold` — a ~12px line-height delta that grew the whole sheet. Always render at the larger size now; only the children swap.
- **Dashboard — `Urges Surfed` tile is an upsell button for free users** (`webapp/components/Dashboard.tsx`, `webapp/App.tsx`). New `hasUpsellAccess: boolean` prop plumbed from App. When `false`, the tile renders as `<button onClick={() => onChangeView(View.AI_COACH)}>` with `hover:bg-purple-200 transition-colors` — mirrors the sibling `I'm having an urge — help me` button pattern. When `true`, it stays as the existing static `<div>`. Counter wiring unchanged; localStorage-only urge log is naturally frozen for users without Help access.
- **Help tab — Locate modal sheet shades within rose palette by intensity** (`webapp/components/urgeHelp/LocateStage.tsx`). New `intensityTones()` helper uses inline HSL interpolation across 5 surfaces (inner card bg + border, slider `accent-color`, value number, drag-handle pill). `v=5` anchors reproduce today's Tailwind `rose-*` baseline so `intensity === null` renders identically to `intensity === 5` — no first-touch jump in either height (Item 8) or color (Item 10). Sheet outer chrome / Continue CTA / header text stay constant.
  - **Peer-review catch:** all hue anchors locked into the 345°–356° band. `interpolateHSL` does plain linear lerp (not shortest-arc), so a 0°↔355° anchor pair would visibly sweep through yellow → green → blue → purple before landing on rose at v=10. Docstring warns future editors.

## Commits

- `aff0ceb` style: cosmetic polish pass 2 — Help tab + Dashboard follow-ups (#58)

## Test plan

- [ ] Help → Act: each of the 4 category sections shows its own hue on the card title AND description (Reset → emerald, Ground → teal, Protect → sky, Reframe → indigo); `Best fit` cards still have rose badge + rose border
- [ ] Help → Locate: pick a feeling → sheet appears; first drag on the slider does NOT change the sheet height; the value number replaces the `·` placeholder at the same size
- [ ] Help → Locate: drag slider from 1 to 10 → inner card, slider, value number, and drag handle all smoothly shift through rose tones (no yellow/green/blue/purple flashes mid-range); transitions feel like a gradient, not a snap
- [ ] Dashboard (free user, `localStorage.removeItem('mc_has_upsell')` then reload): `Urges Surfed` tile shows hover state + cursor pointer; clicking opens Coach tab → renders ProGate
- [ ] Dashboard (paid user, `localStorage.setItem('mc_has_upsell', '1')` then reload): tile is static (no hover, no click)

Smoke test runs automatically on push via Claude Code hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)