### PR TITLE
feat: Coach auto-send urge context + fix scroll/input bug (#61)

### DIFF
--- a/.claude/plans/issue-61-coach-auto-send-urge.md
+++ b/.claude/plans/issue-61-coach-auto-send-urge.md
@@ -1,0 +1,86 @@
+# Issue #61: Coach modal auto-send + scroll/input bug fix
+
+**Overall Progress:** `0%`
+
+## TLDR
+
+Коли user тисне "I want to talk it through" на Reflect-стейджі, Coach modal
+зараз відкривається з generic welcome-повідомленням, не дає скролити чи
+писати, і змушує user самостійно формулювати запит у urge-state. Робимо:
+(1) auto-генеруємо і auto-send структуроване повідомлення з контекстом
+(feeling + intensity + actionsTried) у Coach, (2) фіксимо scroll/input bug
+у модалці.
+
+## Critical Decisions
+
+- **Divider як new `ChatMessage.role`** ('divider') — простіше за окремий
+  state-array; зберігається в DB; рендериться окремо; фільтрується перед
+  Anthropic API і coach-reset payload.
+- **Divider content = ISO timestamp** — рендеринг витягує `Date` із content,
+  формат `── New urge session · 2:34 PM ──` (повна дата якщо >24h).
+- **Одне auto-message замість N** — економить квоту, чистіший UI, urge-mode
+  prompt дає одну цілісну відповідь.
+- **`UrgeContextSeed.actionAttempted` → `actionsTried[]`** — і system prompt,
+  і auto-message бачать весь ланцюжок технік.
+- **Welcome скіпається тільки коли `messages.length === 1`** (порожній чат);
+  інакше divider + auto-message append'аться до існуючої історії.
+- **Auto-send fires одразу на mount** через `useEffect` з guard'ом проти
+  повторного спрацьовування.
+- **`urgeAutoMessage.ts` як shared module** — `buildUrgeAutoMessage()` і
+  `formatDividerLabel()` в одному місці.
+- **Scroll bug = `vh` → `dvh`** на mobile (гіпотеза, перевіримо при /execute).
+
+## Tasks
+
+- [ ] 🟥 **Step 1: Types & shared helpers**
+  - [ ] 🟥 Розширити `ChatMessage.role`: `'user' | 'assistant' | 'divider'` у `webapp/types.ts`
+  - [ ] 🟥 Замінити `UrgeContextSeed.actionAttempted: UrgeActionId | null` на `actionsTried: UrgeActionId[]`
+  - [ ] 🟥 Створити `webapp/lib/urgeAutoMessage.ts` з:
+    - `buildUrgeAutoMessage(feeling, intensity, actionsTried): string`
+    - `formatDividerLabel(isoTimestamp): string`
+    - `createDividerMessage(): ChatMessage` (content = ISO now)
+
+- [ ] 🟥 **Step 2: Update `UrgeHelp.tsx`**
+  - [ ] 🟥 `openCoach`: передати весь `actionsTried` у seed (заміна `actionsTried[actionsTried.length - 1] ?? null`)
+  - [ ] 🟥 Додати в seed prop `autoMessage: string` (згенерований через `buildUrgeAutoMessage`)
+  - [ ] 🟥 Прокинути `autoMessage` через `<CoachModal>` пропс
+
+- [ ] 🟥 **Step 3: Update `formatUrgeContext` в `AICoach.tsx`**
+  - [ ] 🟥 Рендерити весь `actionsTried[]` (joined `→`) замість одного `actionAttempted`
+  - [ ] 🟥 Оновити підпис системного промпта ("Most recent action they tried" → "Actions they've tried")
+
+- [ ] 🟥 **Step 4: Auto-send в `AICoach.tsx`**
+  - [ ] 🟥 Додати prop `autoMessage?: string` (опціональний, спрацьовує тільки в compact mode)
+  - [ ] 🟥 `useEffect` на mount: якщо `autoMessage` є → append divider (якщо чат не порожній) → append user message → виклик `getCoachResponse` → append response
+  - [ ] 🟥 Guard через `useRef` щоб не спрацьовувало двічі (StrictMode, re-mount)
+  - [ ] 🟥 Welcome message: НЕ показувати якщо `compact && autoMessage && messages.length === 1` (чистий старт у модалці)
+  - [ ] 🟥 Філтрувати `divider` із payload до `/api/coach`: `messagesRef.current.slice(1).filter(m => m.role !== 'divider').slice(-10)`
+  - [ ] 🟥 Не фільтрувати дивайдери у `toStore` upsert (зберігаються в DB)
+  - [ ] 🟥 `isEmpty` логіка: враховувати тільки `user`/`assistant` турни
+
+- [ ] 🟥 **Step 5: Render divider в `AICoach.tsx`**
+  - [ ] 🟥 У `messages.map` — якщо `role === 'divider'`, рендерити горизонтальний rule + label через `formatDividerLabel(content)`
+  - [ ] 🟥 Стиль: тонка лінія + центрований текст, purple-tinted, відрізняється від bubble
+
+- [ ] 🟥 **Step 6: Fix scroll/input bug в `CoachModal.tsx`**
+  - [ ] 🟥 Замінити `max-h-[90vh]` на `max-h-[90dvh]` (dynamic viewport — фіксить mobile keyboard)
+  - [ ] 🟥 Перевірити рендер на mobile (Safari iOS DevTools) з відкритою клавіатурою
+  - [ ] 🟥 Якщо `dvh` не вирішує — додати `overflow-y: auto` явно на wrapper AICoach
+
+- [ ] 🟥 **Step 7: Filter divider в `ResetChatModal.tsx`**
+  - [ ] 🟥 Перед `resetCoachChat(messagesToSave)` — `.filter(m => m.role !== 'divider')`
+  - [ ] 🟥 `disabled` check для "Save & start fresh": використати відфільтрований масив
+
+- [ ] 🟥 **Step 8: Manual testing**
+  - [ ] 🟥 Запустити webapp локально (`npm run dev` або per project script)
+  - [ ] 🟥 Сценарій A: порожній чат → Help → escalate → бачимо тільки auto-message + response (без welcome)
+  - [ ] 🟥 Сценарій B: чат з історією → Help → escalate → бачимо divider + auto-message + response after існуючої історії
+  - [ ] 🟥 Сценарій C: 2 actions → "Still here" → ще 1 action → escalate → auto-message містить всі 3 в порядку
+  - [ ] 🟥 Сценарій D: скрол у модалці працює, input видимий, можна дописати наступне повідомлення
+  - [ ] 🟥 Сценарій E: Reset chat ("Save") після auto-message не падає
+  - [ ] 🟥 Mobile viewport (Cmd+Opt+I → device toolbar): модалка не обрізається
+
+- [ ] 🟥 **Step 9: Build & smoke**
+  - [ ] 🟥 `npm run build` у `webapp/` — no errors
+  - [ ] 🟥 TypeScript: всі типи проходять
+  - [ ] 🟥 (Smoke test за README запустимо в /execute коли push)

--- a/webapp/components/AICoach.tsx
+++ b/webapp/components/AICoach.tsx
@@ -214,13 +214,13 @@ export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setM
     autoSentRef.current = true;
     // Count NON-welcome, NON-divider real turns. The chat starts with the
     // hardcoded welcome at index 0; everything past that is real history.
-    const realTurnCount = messagesRef.current
-      .slice(1)
-      .filter((m) => m.role !== 'divider').length;
+    const realTurnCount = withoutDividers(messagesRef.current.slice(1)).length;
     const divider = realTurnCount > 0 ? createDividerMessage() : undefined;
     handleSend(autoMessage, divider);
-    // handleSend is stable enough for this purpose and listing it as a dep
-    // would cause re-fires when checkInHistory / messages change mid-flight.
+    // handleSend isn't in deps on purpose: it's recreated every render, and
+    // adding it would re-fire this effect on every parent state change while
+    // the auto-send was still in flight. autoSentRef + the autoMessage gate
+    // are the real guards; the closure capture of handleSend is intentional.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoMessage]);
 

--- a/webapp/components/AICoach.tsx
+++ b/webapp/components/AICoach.tsx
@@ -7,6 +7,7 @@ import { supabase } from '../src/lib/supabase';
 import { CoachLighthouse } from './HeroVariants';
 import { ResetChatModal } from './ResetChatModal';
 import { COACH_WELCOME_MESSAGE, COACH_STARTER_PROMPTS, COACH_QUICK_REPLIES } from '../constants';
+import { createDividerMessage, formatDividerLabel } from '../src/lib/urgeAutoMessage';
 
 interface AICoachProps {
     checkInHistory: CheckIn[];
@@ -16,6 +17,11 @@ interface AICoachProps {
      *  We augment the system context with the live urge state so Claude's
      *  first response is targeted instead of generic. */
     currentUrgeContext?: UrgeContextSeed | null;
+    /** When set (Help-flow auto-send path), AICoach injects this as the first
+     *  user message on mount — preceded by a divider if the chat is non-empty.
+     *  Captured by reference once at mount; later prop changes do nothing.
+     *  See Issue #61. */
+    autoMessage?: string | null;
     /** When true, render in compact "embedded" mode (no edge-to-edge header
      *  image, less vertical chrome). Used by the Help-tab CoachModal. */
     compact?: boolean;
@@ -26,20 +32,30 @@ interface AICoachProps {
  *  so the existing recentHistory flow is unaffected for non-urge sessions. */
 function formatUrgeContext(seed: UrgeContextSeed | null | undefined): string {
     if (!seed) return '';
-    const action = seed.actionAttempted ? URGE_ACTION_BY_ID[seed.actionAttempted]?.title : null;
+    const actionTitles = seed.actionsTried
+        .map((id) => URGE_ACTION_BY_ID[id]?.title)
+        .filter(Boolean);
     const lines = [
         'ACTIVE URGE SESSION (user opened the Help tab and is currently mid-flow):',
         `- Stage: ${seed.stage}`,
         seed.feeling ? `- Named feeling: ${seed.feeling}` : '- Named feeling: (none yet)',
         seed.intensity != null ? `- Self-reported intensity: ${seed.intensity}/10` : null,
-        action ? `- Most recent action they tried: ${action}` : null,
+        actionTitles.length > 0
+            ? `- Actions tried this session (in order): ${actionTitles.join(' → ')}`
+            : null,
         `- Time on Help tab so far: ${seed.elapsedSec}s`,
         "Respond in urge mode: one grounding action + one reframe sentence. Don't suggest an action they've already tried.",
     ].filter(Boolean);
     return lines.join('\n');
 }
 
-export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setMessages, currentUrgeContext, compact = false }) => {
+/** Strip UI-only dividers before anything that goes to the Anthropic API or
+ *  to /api/coach-reset — both reject any role other than 'user'/'assistant'. */
+function withoutDividers(msgs: ChatMessage[]): ChatMessage[] {
+    return msgs.filter((m) => m.role !== 'divider');
+}
+
+export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setMessages, currentUrgeContext, autoMessage, compact = false }) => {
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [showResetModal, setShowResetModal] = useState(false);
@@ -56,6 +72,11 @@ export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setM
   // (Peer-review MEDIUM #1.)
   const chatGenRef = useRef(0);
 
+  // Auto-send guard. The "I want to talk it through" path mounts AICoach
+  // with an `autoMessage` prop — we fire it exactly once per mount so
+  // StrictMode double-effect or a parent re-render can't re-send.
+  const autoSentRef = useRef(false);
+
   // Auto-scroll to the latest message only when a NEW message arrives.
   // Skipping the initial mount keeps the hero header visible on first open.
   const prevMessagesLengthRef = useRef(messages.length);
@@ -66,15 +87,21 @@ export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setM
     prevMessagesLengthRef.current = messages.length;
   }, [messages]);
 
-  // Send a message, optionally pre-filled from a chip click. We accept the
-  // text as a parameter (instead of always reading from `input` state) so
-  // chip clicks can dispatch immediately without a render round-trip.
-  const handleSend = async (override?: string) => {
+  // Send a message, optionally pre-filled from a chip click or the urge
+  // auto-send effect. `prependedDivider` lets the auto-send path insert a
+  // session marker IN THE SAME state update as the user message — otherwise
+  // a second setMessages would race with messagesRef and persist a chat
+  // missing either the divider or the user message.
+  const handleSend = async (override?: string, prependedDivider?: ChatMessage) => {
     const userMsg = (override ?? input).trim();
     if (!userMsg || isLoading || quotaEndsAt) return;
 
     if (!override) setInput('');
-    setMessages(prev => [...prev, { role: 'user', content: userMsg }]);
+    setMessages(prev => [
+      ...prev,
+      ...(prependedDivider ? [prependedDivider] : []),
+      { role: 'user', content: userMsg },
+    ]);
     setIsLoading(true);
 
     // Capture identity at call time so racy state changes (chat reset, sign-
@@ -98,7 +125,9 @@ export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setM
 
     // Pass the last 10 chat messages so Claude has multi-turn memory.
     // Drop index 0 (hardcoded welcome message — never sent to the model).
-    const chatHistory = messagesRef.current.slice(1).slice(-10);
+    // Strip dividers BEFORE the slice so they don't occupy slots in the
+    // 10-message window (and the API would reject role='divider' anyway).
+    const chatHistory = withoutDividers(messagesRef.current.slice(1)).slice(-10);
 
     const result = await getCoachResponse(userMsg, recentHistory, chatHistory);
     setIsLoading(false);
@@ -122,9 +151,13 @@ export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setM
 
     // Persist to Supabase — fire-and-forget, never blocks UI.
     // Reconstruct the full conversation from the closure: messages (captured
-    // at handleSend call time, excludes userMsg) + userMsg + assistantMsg.
+    // at handleSend call time, excludes the divider + userMsg we just appended)
+    // + divider (if any) + userMsg + assistantMsg.
     // Slice off index 0 (hardcoded welcome message — never stored in DB).
     // Only persist real Claude responses; don't write fallback strings to DB.
+    //
+    // Divider IS persisted — it's part of the chat history so the user sees
+    // their past urge sessions when they reopen the Coach later.
     //
     // Two race-condition guards (peer review):
     //   1. chatGenRef bumped on reset — skip persist if the chat was reset
@@ -134,6 +167,7 @@ export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setM
     if (supabase && result.kind === 'text') {
       const toStore: ChatMessage[] = [
         ...messagesRef.current,
+        ...(prependedDivider ? [prependedDivider] : []),
         { role: 'user' as const, content: userMsg },
         assistantMsg,
       ].slice(1);
@@ -169,8 +203,36 @@ export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setM
     setMessages([COACH_WELCOME_MESSAGE]);
   };
 
+  // ── Urge auto-send (Issue #61) ────────────────────────────────────────
+  // When opened from "I want to talk it through", the parent passes the
+  // pre-built auto-message. We fire it exactly once per mount:
+  //   - skip the welcome (compact mode hides it via skipWelcome below)
+  //   - if chat is non-empty, insert a session divider before the user message
+  //   - then call handleSend, which handles loading, API, persist, fallback
+  useEffect(() => {
+    if (!autoMessage || autoSentRef.current) return;
+    autoSentRef.current = true;
+    // Count NON-welcome, NON-divider real turns. The chat starts with the
+    // hardcoded welcome at index 0; everything past that is real history.
+    const realTurnCount = messagesRef.current
+      .slice(1)
+      .filter((m) => m.role !== 'divider').length;
+    const divider = realTurnCount > 0 ? createDividerMessage() : undefined;
+    handleSend(autoMessage, divider);
+    // handleSend is stable enough for this purpose and listing it as a dep
+    // would cause re-fires when checkInHistory / messages change mid-flight.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoMessage]);
+
   // ── Derived UI flags ──────────────────────────────────────────────────
-  const isEmpty = messages.length === 1; // only the welcome message
+  // In the compact + autoMessage path, suppress the welcome bubble — the
+  // user came in from the Help flow and the very first thing they should
+  // see is their own context message + Coach's urge-mode reply.
+  const skipWelcome = compact && autoMessage != null;
+  // "Empty" = only the welcome turn present. Dividers are UI-only and never
+  // appear without a user/assistant pair around them, so we can ignore them
+  // here without an extra filter.
+  const isEmpty = !skipWelcome && messages.length === 1;
   const lastMessage = messages[messages.length - 1];
   const showQuickReplies =
     !isEmpty
@@ -219,22 +281,43 @@ export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setM
             </div>
           )}
 
-          {messages.map((m, i) => (
-            <div key={i} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
-              <div className={`flex gap-3 max-w-[85%] md:max-w-[75%] ${m.role === 'user' ? 'flex-row-reverse' : 'flex-row'}`}>
-                <div className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${m.role === 'user' ? 'bg-gray-200 text-gray-600' : 'bg-purple-600 text-white'}`}>
-                  {m.role === 'user' ? <UserIcon size={16} /> : <Brain size={16} />}
+          {messages.map((m, i) => {
+            // Hide the welcome bubble in the Help-modal auto-send flow so the
+            // user lands on their own context message, not a generic greeting.
+            if (skipWelcome && i === 0) return null;
+            if (m.role === 'divider') {
+              return (
+                <div
+                  key={i}
+                  role="separator"
+                  aria-label="New urge session"
+                  className="flex items-center gap-3 pt-2 pb-1 select-none"
+                >
+                  <div className="flex-1 h-px bg-purple-300/60" />
+                  <span className="text-[11px] font-semibold uppercase tracking-wider text-purple-700/70 whitespace-nowrap">
+                    {formatDividerLabel(m.content)}
+                  </span>
+                  <div className="flex-1 h-px bg-purple-300/60" />
                 </div>
-                <div className={`p-4 rounded-2xl text-sm leading-relaxed whitespace-pre-wrap ${
-                  m.role === 'user'
-                    ? 'bg-white border border-gray-200 text-gray-900 rounded-tr-none'
-                    : 'bg-purple-700 text-white rounded-tl-none shadow-sm'
-                }`}>
-                  {formatMessage(m.content)}
+              );
+            }
+            return (
+              <div key={i} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+                <div className={`flex gap-3 max-w-[85%] md:max-w-[75%] ${m.role === 'user' ? 'flex-row-reverse' : 'flex-row'}`}>
+                  <div className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${m.role === 'user' ? 'bg-gray-200 text-gray-600' : 'bg-purple-600 text-white'}`}>
+                    {m.role === 'user' ? <UserIcon size={16} /> : <Brain size={16} />}
+                  </div>
+                  <div className={`p-4 rounded-2xl text-sm leading-relaxed whitespace-pre-wrap ${
+                    m.role === 'user'
+                      ? 'bg-white border border-gray-200 text-gray-900 rounded-tr-none'
+                      : 'bg-purple-700 text-white rounded-tl-none shadow-sm'
+                  }`}>
+                    {formatMessage(m.content)}
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
 
           {isLoading && (
             <div className="flex justify-start">

--- a/webapp/components/AICoach.tsx
+++ b/webapp/components/AICoach.tsx
@@ -233,9 +233,16 @@ export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setM
   // appear without a user/assistant pair around them, so we can ignore them
   // here without an extra filter.
   const isEmpty = !skipWelcome && messages.length === 1;
+  // In the modal auto-send path, the useEffect fires after the first paint,
+  // so for one frame the chat is just [welcome] with the welcome hidden —
+  // "isEmpty" reads false (because skipWelcome inverts it) and Reset +
+  // QuickReplies would flash visible. Suppress them until handleSend has
+  // appended the user message.
+  const awaitingAutoSend = skipWelcome && messages.length === 1;
   const lastMessage = messages[messages.length - 1];
   const showQuickReplies =
     !isEmpty
+    && !awaitingAutoSend
     && !isLoading
     && !quotaEndsAt
     && lastMessage?.role === 'assistant'
@@ -263,8 +270,9 @@ export const AICoach: React.FC<AICoachProps> = ({ checkInHistory, messages, setM
         <div className={`px-4 space-y-4 max-w-4xl mx-auto ${compact ? 'pt-2' : ''}`}>
           {/* Reset chat button — small, right-aligned, above the messages.
               Visible in both Coach-tab and CoachModal modes; only shown
-              once there's at least one real message worth resetting. */}
-          {!isEmpty && (
+              once there's at least one real message worth resetting.
+              Suppressed during the brief auto-send-pending frame. */}
+          {!isEmpty && !awaitingAutoSend && (
             <div className="flex justify-center -mt-10 mb-2">
               <button
                 onClick={() => setShowResetModal(true)}

--- a/webapp/components/ResetChatModal.tsx
+++ b/webapp/components/ResetChatModal.tsx
@@ -35,10 +35,15 @@ export const ResetChatModal: React.FC<ResetChatModalProps> = ({
 
   if (!open) return null;
 
+  // UI-only dividers (Issue #61) must never reach the server — the
+  // summarizer round-trips messages through Anthropic, which rejects any
+  // role other than 'user'/'assistant'.
+  const sendable = messagesToSave.filter((m) => m.role !== 'divider');
+
   const handleReset = async (save: boolean) => {
     setError(null);
     setBusy(save ? 'save' : 'discard');
-    const result = await resetCoachChat(messagesToSave, save);
+    const result = await resetCoachChat(sendable, save);
     setBusy(null);
 
     if (result.kind === 'text') {
@@ -92,7 +97,7 @@ export const ResetChatModal: React.FC<ResetChatModalProps> = ({
 
           <button
             onClick={() => handleReset(true)}
-            disabled={busy !== null || messagesToSave.length === 0}
+            disabled={busy !== null || sendable.length === 0}
             className="w-full flex items-start gap-3 p-4 border border-purple-200 rounded-xl
                        hover:bg-purple-50 hover:border-purple-300 transition-colors
                        text-left disabled:opacity-50 disabled:cursor-not-allowed"

--- a/webapp/components/UrgeHelp.tsx
+++ b/webapp/components/UrgeHelp.tsx
@@ -9,6 +9,7 @@ import { SurfCelebration } from './urgeHelp/SurfCelebration';
 import { CoachModal } from './urgeHelp/CoachModal';
 import { URGE_ACTION_SCREENS } from './urgeActions';
 import { appendEntry, count as readUrgeCount } from '../src/lib/urgeLog';
+import { buildUrgeAutoMessage } from '../src/lib/urgeAutoMessage';
 
 interface UrgeHelpProps {
   // Coach state lifted from App so the modal session stays continuous with
@@ -48,6 +49,11 @@ export const UrgeHelp: React.FC<UrgeHelpProps> = ({
    *  context for its full lifetime, regardless of any background state
    *  changes in the orchestrator. */
   const [coachSeed, setCoachSeed] = useState<UrgeContextSeed | null>(null);
+  /** Auto-message text computed at openCoach time and sent into the Coach
+   *  the moment the modal mounts. Captured imperatively alongside the seed
+   *  so the message reflects exactly the state the user saw when they
+   *  pressed "I want to talk it through". */
+  const [coachAutoMessage, setCoachAutoMessage] = useState<string | null>(null);
   /** Number of completed surfs in the log. Read once per session reset so
    *  the Reflect copy ("Surf #N on your record") is accurate without
    *  re-reading localStorage on every keystroke. */
@@ -117,21 +123,25 @@ export const UrgeHelp: React.FC<UrgeHelpProps> = ({
 
   /** Open the Coach modal with a fresh snapshot of the current urge state.
    *  Captured imperatively at this single point so the modal's seed never
-   *  drifts while it's open, and we don't have to ignore exhaustive-deps. */
+   *  drifts while it's open, and we don't have to ignore exhaustive-deps.
+   *  Also builds the auto-message at the same moment so the visible chat
+   *  text matches the system-prompt context exactly. */
   const openCoach = useCallback(() => {
     setCoachSeed({
       stage,
       feeling,
       intensity,
-      actionAttempted: actionsTried[actionsTried.length - 1] ?? null,
+      actionsTried,
       elapsedSec: Math.floor((Date.now() - openedAtRef.current) / 1000),
     });
+    setCoachAutoMessage(buildUrgeAutoMessage(feeling, intensity, actionsTried));
     setCoachOpen(true);
   }, [stage, feeling, intensity, actionsTried]);
 
   const closeCoach = useCallback(() => {
     setCoachOpen(false);
     setCoachSeed(null);
+    setCoachAutoMessage(null);
   }, []);
 
   /** Reflect-stage handler. Logs only on terminal outcomes (`passed` /
@@ -237,6 +247,7 @@ export const UrgeHelp: React.FC<UrgeHelpProps> = ({
         open={coachOpen}
         onClose={closeCoach}
         seed={coachSeed}
+        autoMessage={coachAutoMessage}
         checkInHistory={checkInHistory}
         messages={chatHistory}
         setMessages={setChatHistory}

--- a/webapp/components/urgeHelp/CoachModal.tsx
+++ b/webapp/components/urgeHelp/CoachModal.tsx
@@ -7,8 +7,12 @@ interface CoachModalProps {
   open: boolean;
   onClose: () => void;
   /** Live urge state passed through to AICoach so the system prompt is
-   *  seeded with feeling/intensity/action/elapsed. */
+   *  seeded with feeling/intensity/actions/elapsed. */
   seed: UrgeContextSeed | null;
+  /** When set, AICoach auto-sends this message on mount so the user doesn't
+   *  have to type while in urge state. The text is built once at modal-open
+   *  time so it stays stable for the modal's lifetime. */
+  autoMessage: string | null;
   // Same coach state the App owns — keeps the modal session continuous
   // with the dedicated Coach view (no parallel conversations).
   checkInHistory: CheckIn[];
@@ -30,6 +34,7 @@ export const CoachModal: React.FC<CoachModalProps> = ({
   open,
   onClose,
   seed,
+  autoMessage,
   checkInHistory,
   messages,
   setMessages,
@@ -48,8 +53,11 @@ export const CoachModal: React.FC<CoachModalProps> = ({
       <div
         // Stop click propagation so taps inside the sheet don't dismiss it.
         onClick={(e) => e.stopPropagation()}
+        // dvh (dynamic viewport) instead of vh so mobile-keyboard open/close
+        // doesn't push the input area below the visible viewport. Also keeps
+        // min-h-0 on the AICoach wrapper so its inner flex column can size.
         className="bg-purple-50 w-full md:max-w-2xl md:rounded-2xl rounded-t-3xl
-                   max-h-[90vh] md:max-h-[85vh] flex flex-col overflow-hidden shadow-2xl
+                   max-h-[90dvh] md:max-h-[85dvh] flex flex-col overflow-hidden shadow-2xl
                    animate-in slide-in-from-bottom-8 md:zoom-in-95 duration-300"
       >
         {/* Compact header — matches the AICoach palette so it doesn't feel
@@ -81,6 +89,7 @@ export const CoachModal: React.FC<CoachModalProps> = ({
             messages={messages}
             setMessages={setMessages}
             currentUrgeContext={seed}
+            autoMessage={autoMessage}
             compact
           />
         </div>

--- a/webapp/src/lib/urgeAutoMessage.ts
+++ b/webapp/src/lib/urgeAutoMessage.ts
@@ -1,0 +1,72 @@
+// Shared formatting for the "I want to talk it through" auto-send flow.
+//
+// Single source of truth so the visible user-message in chat, the system-
+// prompt context block, and the urge-session divider all stay in sync.
+
+import type { ChatMessage, FeelingId, UrgeActionId } from '../../types';
+import { FEELINGS, URGE_ACTION_BY_ID } from '../../data/urgeData';
+
+const FEELING_LABEL_BY_ID: Record<FeelingId, string> = Object.fromEntries(
+  FEELINGS.map((f) => [f.id, f.label]),
+) as Record<FeelingId, string>;
+
+/** Format the auto-message sent to the Coach when the user picks
+ *  "I want to talk it through". Adapts to missing pieces so an empty
+ *  feeling/intensity/action set still produces a coherent message. */
+export function buildUrgeAutoMessage(
+  feeling: FeelingId | null,
+  intensity: number | null,
+  actionsTried: UrgeActionId[],
+): string {
+  const lines: string[] = ["I'm in the middle of an urge."];
+
+  if (feeling) {
+    const label = FEELING_LABEL_BY_ID[feeling].toLowerCase();
+    lines.push(
+      intensity != null ? `Feeling: ${label} (${intensity}/10).` : `Feeling: ${label}.`,
+    );
+  }
+
+  if (actionsTried.length > 0) {
+    const titles = actionsTried.map((id) => URGE_ACTION_BY_ID[id]?.title).filter(Boolean);
+    if (titles.length > 0) {
+      lines.push(`Tried: ${titles.join(' → ')}.`);
+    }
+  }
+
+  lines.push('Still here — I want to talk it through.');
+  return lines.join('\n');
+}
+
+/** Build the divider message inserted before an auto-send when prior chat
+ *  exists. Content holds an ISO timestamp so the renderer can choose how
+ *  to format it (relative time, absolute date for older sessions, etc.). */
+export function createDividerMessage(now: Date = new Date()): ChatMessage {
+  return { role: 'divider', content: now.toISOString() };
+}
+
+/** Render the label shown inside the divider rule. Uses `now` for the
+ *  "today vs older" decision so callers can pass a fixed reference in tests. */
+export function formatDividerLabel(isoTimestamp: string, now: Date = new Date()): string {
+  const then = new Date(isoTimestamp);
+  if (Number.isNaN(then.getTime())) return 'New urge session';
+
+  const HOUR = 60 * 60 * 1000;
+  const ageMs = now.getTime() - then.getTime();
+
+  // <24h: time only. Older: include short date so the user can see when
+  // the session happened without doing mental math.
+  if (ageMs < 24 * HOUR && now.toDateString() === then.toDateString()) {
+    return `New urge session · ${then.toLocaleTimeString(undefined, {
+      hour: 'numeric',
+      minute: '2-digit',
+    })}`;
+  }
+  return `New urge session · ${then.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  })}, ${then.toLocaleTimeString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+  })}`;
+}

--- a/webapp/src/lib/urgeAutoMessage.ts
+++ b/webapp/src/lib/urgeAutoMessage.ts
@@ -21,7 +21,9 @@ export function buildUrgeAutoMessage(
   const lines: string[] = ["I'm in the middle of an urge."];
 
   if (feeling) {
-    const label = FEELING_LABEL_BY_ID[feeling].toLowerCase();
+    // Fall back to the raw id if the FEELINGS array drifts out of sync with
+    // the FeelingId enum — better to surface "sexual_tension" than to throw.
+    const label = (FEELING_LABEL_BY_ID[feeling] ?? feeling).toLowerCase();
     lines.push(
       intensity != null ? `Feeling: ${label} (${intensity}/10).` : `Feeling: ${label}.`,
     );

--- a/webapp/types.ts
+++ b/webapp/types.ts
@@ -35,7 +35,11 @@ export interface User {
 }
 
 export interface ChatMessage {
-  role: 'user' | 'assistant';
+  /** 'divider' is a UI-only marker that breaks the chat into distinct urge
+   *  sessions. Content holds an ISO timestamp so the renderer can format
+   *  "── New urge session · 2:34 PM ──" (or include the date if >24h ago).
+   *  Filtered out of Anthropic API payloads and coach-reset summarization. */
+  role: 'user' | 'assistant' | 'divider';
   content: string;
 }
 
@@ -116,8 +120,10 @@ export interface UrgeContextSeed {
   stage: 'pause' | 'locate' | 'act' | 'reflect';
   feeling: FeelingId | null;
   intensity: number | null;
-  /** Most recent action the user opened (if any). */
-  actionAttempted: UrgeActionId | null;
+  /** Every action the user opened during this session, in click order (deduped).
+   *  Drives both the system-prompt context block and the auto-message template
+   *  so Claude sees the full coping chain instead of just the last try. */
+  actionsTried: UrgeActionId[];
   /** Seconds since the user landed on the Help tab. */
   elapsedSec: number;
 }


### PR DESCRIPTION
## Summary

При кліку "I want to talk it through" у Reflect-стейджі Coach modal тепер автоматично надсилає структуроване повідомлення в Coach з контекстом (feeling + intensity + actionsTried), а не змушує користувача друкувати в urge-state. Плюс пофікшено баг де модалку не можна було скролити/писати на mobile.

Closes #61

## What changed

- `feat`: auto-send urge context to Coach + fix scroll/input bug
- `refactor`: address self-review nits (withoutDividers reuse + FEELING label fallback)
- `fix`: suppress Reset + QuickReplies during auto-send-pending frame

## Key technical decisions

- Новий `ChatMessage.role: 'divider'` (UI-only marker, persisted to DB), фільтрується перед Anthropic API і coach-reset payload
- `UrgeContextSeed.actionAttempted` (last only) → `actionsTried[]` — system prompt і auto-message бачать весь ланцюжок технік
- Одне повідомлення замість N (по одному на техніку) — економить квоту $1/3міс
- Welcome скіпається у compact+autoMessage режимі; інакше append + `── New urge session · 2:34 PM ──` divider
- `max-h-[90vh]` → `max-h-[90dvh]` — dynamic viewport фіксить mobile-keyboard cropping

## Test plan

- [ ] Сценарій A: порожній чат → Help → escalate → бачимо тільки auto-message + Coach response (без welcome)
- [ ] Сценарій B: існуючий чат → Help → escalate → divider + auto-message + response after історії
- [ ] Сценарій C: 2 actions → "Still here" → ще 1 action → escalate → auto-message містить всі 3 в порядку
- [ ] Сценарій D: скрол у модалці працює, input видимий, можна дописати після Coach response
- [ ] Сценарій E: Reset chat ("Save & start fresh") після auto-message — divider'и не ламають summarize call
- [ ] Mobile viewport: модалка не обрізається, input видимий з відкритою клавіатурою

Smoke test runs automatically on push via Claude Code hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)