### PR TITLE
feat: Insights page — lifetime patterns & achievement cards (#73)

### DIFF
--- a/.claude/plans/issue-73-insights-patterns.md
+++ b/.claude/plans/issue-73-insights-patterns.md
@@ -1,0 +1,85 @@
+# Issue #73: Insights — patterns & achievements page (paid-only)
+
+**Overall Progress:** `89%` (manual scenarios — Step 9 — pending user smoke-test)
+
+## TLDR
+
+Нова `View.INSIGHTS` сторінка з 8 achievement-style картками: lifetime aggregations з `urge_log` + `check_ins`. Дві точки входу: кнопка `Insights` зліва від `New conversation` у Coach (paid → Insights, free → ProGate через `View.AI_COACH`); кнопка в правому верхньому куті Clean/Slip banner у day-detail modal (Dashboard). Усі візуалізації — inline SVG/CSS, без нових deps.
+
+## Critical Decisions
+
+- **No journal in MVP** — per #66 plan, journal буде compressed у coach_memory prose, не структуровано. Insights tap'ить тільки `urge_log` + `check_ins`.
+- **Inline SVG + CSS bars** замість chart library — consistent з рештою app, нуль нових deps. Бандл уже 920KB.
+- **Pure aggregation у `insightsCalc.ts`** окремо від UI — unit-testable, легше iterate на formulae.
+- **Coach Insights кнопка завжди видима** (не залежить від `isEmpty`). New conversation з'являється тільки при заповненому чаті — обидві кнопки сидять у спільному flex-row контейнері, який рендериться завжди.
+- **Free user entry route = `View.AI_COACH`** (НЕ окремий `View.INSIGHTS_PROGATE`). Pro tier включає Coach/Urge Help/Insights одним пакетом — апселл вже існує.
+- **Min sample threshold для "most effective"** = **3 tries** на action. Менше → action не показується у топ-3.
+- **Empty state threshold**: 0 urges → hero illustration + copy, NO empty cards. Partial data → показати тільки cards для яких є дані, решта замінити "Need at least N sessions" inline.
+- **Intensity trend** — monthly aggregation з `urge_log.endedAt`. Якщо <2 months даних — fallback на "Not enough data yet".
+- **Mobile responsive** — grid `grid-cols-1 md:grid-cols-2` для cards.
+
+## Tasks
+
+- [x] 🟩 **Step 1: Types & View enum**
+  - [x] 🟩 Додати `INSIGHTS = 'INSIGHTS'` до `View` enum у `webapp/types.ts`
+
+- [x] 🟩 **Step 2: Pure aggregation library `insightsCalc.ts`**
+  - [x] 🟩 Створити `webapp/src/lib/insightsCalc.ts`
+  - [x] 🟩 `topEffectiveActions(log, minTries=3, limit=3)` → `{ id, title, successRate, tries }[]`
+  - [x] 🟩 `actionEffectivenessAll(log, minTries=3)` → full ranked table
+  - [x] 🟩 `timeOfDayBuckets(log)` → `{ morning, afternoon, evening, lateNight }` counts (5-12 / 12-17 / 17-22 / 22-5)
+  - [x] 🟩 `outcomeBreakdown(log)` → `{ passed, stillHere, escalated, total }`
+  - [x] 🟩 `bestStreak(checkIns)` → number (longest consecutive CLEAN run)
+  - [x] 🟩 `topFeelings(log, limit=3)` → `{ id, label, count, pct }[]`
+  - [x] 🟩 `monthlyIntensityTrend(log)` → `{ month: 'YYYY-MM', avgIntensity, sampleSize }[]` (skip months with 0 samples)
+  - [x] 🟩 Усі функції pure + take `UrgeLogEntry[]` / `CheckIn[]` як input, return plain data (no React)
+
+- [x] 🟩 **Step 3: `Insights.tsx` page component (achievement cards)**
+  - [x] 🟩 Створити `webapp/components/Insights.tsx` (page-level)
+  - [x] 🟩 Props: `urgeLog: UrgeLogEntry[]`, `checkIns: CheckIn[]`
+  - [x] 🟩 Reuse `flex-1 overflow-y-auto pb-28 md:pb-8` layout pattern (як Dashboard)
+  - [x] 🟩 Hero блок з `CoachLighthouse` (або новий HeroVariant — поки використати existing)
+  - [x] 🟩 Grid `grid-cols-1 md:grid-cols-2 gap-4` для 8 cards
+  - [x] 🟩 Card subcomponent з consistent layout: Lucide icon + uppercase label + big metric + one-line context
+  - [x] 🟩 Card colors з `URGE_CATEGORY_META` (emerald/teal/sky/indigo тон per insight)
+  - [x] 🟩 `animate-in fade-in slide-in-from-bottom-2` на mount, stagger через `animationDelay`
+  - [x] 🟩 Empty state: `urgeLog.length === 0` → hero + motivational copy + return early
+  - [x] 🟩 Partial state: per-card "Need at least N sessions" коли дані недостатні
+
+- [x] 🟩 **Step 4: Inline SVG / CSS visualizations всередині cards**
+  - [x] 🟩 Time-of-day bar chart: 4 vertical bars з висотою proportional до count (pure CSS h-[...])
+  - [x] 🟩 Passed vs Escalated split bar: flex row з emerald + rose segments
+  - [x] 🟩 Intensity trend line: inline SVG polyline з points scaled до viewBox
+
+- [x] 🟩 **Step 5: Coach tab Insights button**
+  - [x] 🟩 Модифікувати `AICoach.tsx` — створити flex-row контейнер що завжди рендериться (не gated на `!isEmpty`)
+  - [x] 🟩 Insights кнопка зліва: Lucide `Sparkles` (або `BarChart3`) icon + "Insights" text
+  - [x] 🟩 Той же стиль `animate-coach-reset-pulse` + `bg-white border-2 hover:bg-purple-50`
+  - [x] 🟩 Click handler: `onChangeView(View.INSIGHTS)` (новий prop, plumbed від App)
+  - [x] 🟩 Додати `onChangeView` prop до `AICoachProps`
+
+- [x] 🟩 **Step 6: Dashboard day-detail modal Insights button**
+  - [x] 🟩 Модифікувати Clean/Slip banner у `Dashboard.tsx` — flex row з heading зліва + Insights button справа
+  - [x] 🟩 Кнопка висота = height "Clean Day"/"Slip Day" heading
+  - [x] 🟩 Той же `animate-coach-reset-pulse` стиль
+  - [x] 🟩 Click → `onChangeView(View.INSIGHTS)` (existing `onChangeView` prop)
+  - [x] 🟩 Закрити modal перед navigation (`setSelectedDate(null)` + changeView)
+
+- [x] 🟩 **Step 7: App.tsx wiring**
+  - [x] 🟩 Додати `{currentView === View.INSIGHTS && ...}` render block
+  - [x] 🟩 Paid: `<Insights urgeLog={urgeLogEntries} checkIns={checkIns} />`
+  - [x] 🟩 Free: `<ProGate featureName="Insights" featureDescription="..." userEmail={userEmail} onUnlocked={grantUpsellAccess} />`
+  - [x] 🟩 Прокинути `onChangeView={changeView}` до AICoach
+
+- [x] 🟩 **Step 8: Typecheck + build**
+  - [x] 🟩 `tsc --noEmit` clean
+  - [x] 🟩 `npm run build` clean (bandle warning баланс — accept ~5KB grow от cards/SVG)
+
+- [ ] 🟥 **Step 9: Manual scenarios** (user smoke-test on deploy)
+  - [ ] 🟥 Paid user no data → empty state hero + copy
+  - [ ] 🟥 Paid user з 1-2 urges → partial cards з "Need more" fallback
+  - [ ] 🟥 Paid user з достатніми даними → всі 8 cards рендеряться correctly
+  - [ ] 🟥 Free user click Insights з Coach → ProGate
+  - [ ] 🟥 Free user click Insights з day-modal → ProGate
+  - [ ] 🟥 Mobile viewport (375px) — cards stack vertically, кнопки fit
+  - [ ] 🟥 Lifetime stat verification: spot-check 2 cards проти hand-calc з urge_log

--- a/webapp/App.tsx
+++ b/webapp/App.tsx
@@ -661,7 +661,7 @@ export default function App() {
           ) : (
             <ProGate
               featureName="Insights"
-              featureDescription="See your patterns at a glance — your most effective techniques, when urges hit, what feelings trigger them, and how your streak is trending. All time-tested, drawn straight from your own sessions."
+              featureDescription="See your patterns at a glance — your most effective techniques, when urges hit, what feelings trigger them, and how your streak is trending. Drawn from your full history, lifetime stats updated with every session."
               userEmail={userEmail}
               onUnlocked={grantUpsellAccess}
             />

--- a/webapp/App.tsx
+++ b/webapp/App.tsx
@@ -6,6 +6,7 @@ import { DailyCheckIn } from './components/DailyCheckIn';
 import { Dashboard } from './components/Dashboard';
 import { AICoach } from './components/AICoach';
 import { UrgeHelp } from './components/UrgeHelp';
+import { Insights } from './components/Insights';
 import { isSameDay, subDays } from 'date-fns';
 import { Plan28 } from './components/Plan28';
 import { Settings } from './components/Settings';
@@ -642,11 +643,25 @@ export default function App() {
               currentUrgeContext={coachSeed}
               autoMessage={coachAutoMessage}
               onAutoMessageConsumed={consumeCoachAutoMessage}
+              onChangeView={changeView}
             />
           ) : (
             <ProGate
               featureName="AI Coach"
               featureDescription="Get personalized coaching from your AI companion. Analyze your patterns, reflect on triggers, and build lasting strategies — all tailored to your journey."
+              userEmail={userEmail}
+              onUnlocked={grantUpsellAccess}
+            />
+          )
+        )}
+
+        {currentView === View.INSIGHTS && (
+          hasUpsellAccess ? (
+            <Insights urgeLog={urgeLogEntries} checkIns={checkIns} />
+          ) : (
+            <ProGate
+              featureName="Insights"
+              featureDescription="See your patterns at a glance — your most effective techniques, when urges hit, what feelings trigger them, and how your streak is trending. All time-tested, drawn straight from your own sessions."
               userEmail={userEmail}
               onUnlocked={grantUpsellAccess}
             />

--- a/webapp/components/AICoach.tsx
+++ b/webapp/components/AICoach.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Brain, Send, User as UserIcon, RotateCcw } from 'lucide-react';
+import { Brain, Send, User as UserIcon, RotateCcw, BarChart3 } from 'lucide-react';
 import { getCoachResponse, FALLBACK_COPY } from '../services/claudeService';
-import { CheckIn, ChatMessage, UrgeContextSeed, UrgeLogEntry } from '../types';
+import { CheckIn, ChatMessage, UrgeContextSeed, UrgeLogEntry, View } from '../types';
 import { URGE_ACTION_BY_ID } from '../data/urgeData';
 import { supabase } from '../src/lib/supabase';
 import { CoachLighthouse } from './HeroVariants';
@@ -44,6 +44,10 @@ interface AICoachProps {
      *  this, navigating away from Coach and back would re-fire the same
      *  message on remount (fresh `autoSentRef`, same props). */
     onAutoMessageConsumed?: () => void;
+    /** App's `changeView` setter. Used by the `Insights` button (Issue #73)
+     *  to jump to the patterns page; passing it through avoids a separate
+     *  router or context for one button. */
+    onChangeView: (view: View) => void;
 }
 
 /** Format the urge context seed into a compact block the Claude system
@@ -85,6 +89,7 @@ export const AICoach: React.FC<AICoachProps> = ({
   currentUrgeContext,
   autoMessage,
   onAutoMessageConsumed,
+  onChangeView,
 }) => {
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -308,10 +313,21 @@ export const AICoach: React.FC<AICoachProps> = ({
         </div>
 
         <div className="px-4 space-y-4 max-w-4xl mx-auto">
-          {/* Reset chat button — small, centered, above the messages.
-              Only shown once there's at least one real message worth resetting. */}
-          {!isEmpty && (
-            <div className="flex justify-center -mt-10 mb-2">
+          {/* Action row — Insights (always visible, left) + New conversation
+              (only when chat has real turns to reset, right). Lifted into one
+              centered flex row so the buttons read as a pair under the hero. */}
+          <div className="flex justify-center items-center gap-2 -mt-10 mb-2">
+            <button
+              onClick={() => onChangeView(View.INSIGHTS)}
+              aria-label="View your patterns and insights"
+              className="animate-coach-reset-pulse flex items-center gap-2 text-sm font-semibold
+                         bg-white border-2 hover:bg-purple-50
+                         px-4 py-2 rounded-full shadow-sm"
+            >
+              <BarChart3 size={16} />
+              <span>Insights</span>
+            </button>
+            {!isEmpty && (
               <button
                 onClick={() => setShowResetModal(true)}
                 disabled={isLoading}
@@ -324,8 +340,8 @@ export const AICoach: React.FC<AICoachProps> = ({
                 <RotateCcw size={16} />
                 <span>New conversation</span>
               </button>
-            </div>
-          )}
+            )}
+          </div>
 
           {messages.map((m, i) => {
             if (m.role === 'divider') {

--- a/webapp/components/Dashboard.tsx
+++ b/webapp/components/Dashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useEffect, useRef } from 'react';
 import { CheckIn, CheckInStatus, View } from '../types';
-import { ChevronLeft, ChevronRight, X, Trophy, CircleCheck, Anchor, CalendarDays, Waves } from 'lucide-react';
+import { ChevronLeft, ChevronRight, X, Trophy, CircleCheck, Anchor, CalendarDays, Waves, BarChart3 } from 'lucide-react';
 import { format, isSameDay, startOfMonth, endOfMonth, eachDayOfInterval, getDay, addMonths, subMonths, isFuture } from 'date-fns';
 import { ProgressPeak } from './HeroVariants';
 
@@ -460,10 +460,30 @@ export const Dashboard: React.FC<DashboardProps> = ({ checkIns, streak, urgesCou
 
                         return (
                             <div className="space-y-6">
-                                {/* Overall Status Banner */}
-                                <div className={`p-4 rounded-xl border ${isDayClean ? 'bg-emerald-50 border-emerald-100 text-emerald-800' : 'bg-rose-50 border-rose-100 text-rose-800'}`}>
-                                    <span className="font-bold block text-lg mb-1">{isDayClean ? "Clean Day" : "Slip Day"}</span>
-                                    <span className="text-sm opacity-80">{isDayClean ? "A day of control." : "A learning day."}</span>
+                                {/* Overall Status Banner. Headline + body
+                                    column on the left; Insights button pinned
+                                    to the right edge, aligned to the heading's
+                                    optical centre. Click closes the modal and
+                                    routes to Insights (paid) / ProGate (free). */}
+                                <div className={`p-4 rounded-xl border flex items-start justify-between gap-3 ${isDayClean ? 'bg-emerald-50 border-emerald-100 text-emerald-800' : 'bg-rose-50 border-rose-100 text-rose-800'}`}>
+                                    <div className="min-w-0">
+                                        <span className="font-bold block text-lg mb-1">{isDayClean ? "Clean Day" : "Slip Day"}</span>
+                                        <span className="text-sm opacity-80">{isDayClean ? "A day of control." : "A learning day."}</span>
+                                    </div>
+                                    <button
+                                        type="button"
+                                        onClick={() => {
+                                            setSelectedDate(null);
+                                            onChangeView(View.INSIGHTS);
+                                        }}
+                                        aria-label="View your patterns and insights"
+                                        className="animate-coach-reset-pulse flex-shrink-0 flex items-center gap-1.5 text-xs font-semibold
+                                                   bg-white border-2 hover:bg-purple-50
+                                                   px-3 py-1.5 rounded-full shadow-sm self-center"
+                                    >
+                                        <BarChart3 size={14} />
+                                        <span>Insights</span>
+                                    </button>
                                 </div>
 
                                 <div className="space-y-4">

--- a/webapp/components/Insights.tsx
+++ b/webapp/components/Insights.tsx
@@ -12,7 +12,6 @@ import {
 import type { CheckIn, UrgeLogEntry } from '../types';
 import { ProgressPeak } from './HeroVariants';
 import {
-  topEffectiveActions,
   actionEffectivenessAll,
   timeOfDayBuckets,
   outcomeBreakdown,
@@ -44,19 +43,21 @@ export const Insights: React.FC<InsightsProps> = ({ urgeLog, checkIns }) => {
   // Memoise the full aggregation pass — the page rerenders on every parent
   // tick (App owns urgeLog + checkIns), but the underlying arrays change
   // rarely. Single useMemo over a stable object keeps all derived data
-  // in lockstep without juggling per-card useMemos.
-  const stats = useMemo(
-    () => ({
-      topActions: topEffectiveActions(urgeLog, MIN_TRIES, 3),
-      allActions: actionEffectivenessAll(urgeLog, MIN_TRIES),
+  // in lockstep without juggling per-card useMemos. We compute
+  // `allActions` once and `slice(0, 3)` for the top card, avoiding the
+  // double-pass that calling `topEffectiveActions` would introduce.
+  const stats = useMemo(() => {
+    const allActions = actionEffectivenessAll(urgeLog, MIN_TRIES);
+    return {
+      topActions: allActions.slice(0, 3),
+      allActions,
       buckets: timeOfDayBuckets(urgeLog),
       outcomes: outcomeBreakdown(urgeLog),
       streak: bestStreak(checkIns),
       feelings: topFeelings(urgeLog, 3),
       trend: monthlyIntensityTrend(urgeLog),
-    }),
-    [urgeLog, checkIns],
-  );
+    };
+  }, [urgeLog, checkIns]);
 
   // ── Empty state ─────────────────────────────────────────────────────────
   // First-day users see nothing useful from raw data, so we replace the
@@ -175,7 +176,7 @@ const NeedMore: React.FC<{ hint: string }> = ({ hint }) => (
 // ─── Card 1: Top 3 most-effective techniques ───────────────────────────────
 
 const TopTechniquesCard: React.FC<{
-  items: ReturnType<typeof topEffectiveActions>;
+  items: ReturnType<typeof actionEffectivenessAll>;
 }> = ({ items }) => (
   <CardShell
     index={0}

--- a/webapp/components/Insights.tsx
+++ b/webapp/components/Insights.tsx
@@ -1,0 +1,511 @@
+import React, { useMemo } from 'react';
+import {
+  Trophy,
+  Award,
+  Waves,
+  Clock,
+  Sparkles,
+  Heart,
+  TrendingUp,
+  ListOrdered,
+} from 'lucide-react';
+import type { CheckIn, UrgeLogEntry } from '../types';
+import { ProgressPeak } from './HeroVariants';
+import {
+  topEffectiveActions,
+  actionEffectivenessAll,
+  timeOfDayBuckets,
+  outcomeBreakdown,
+  bestStreak,
+  topFeelings,
+  monthlyIntensityTrend,
+} from '../src/lib/insightsCalc';
+
+/**
+ * Insights page (Issue #73) — lifetime aggregations over `urge_log` and
+ * `check_ins`. Achievement-style card grid; inline SVG / CSS for all
+ * visualisations so we don't pull in a chart library.
+ *
+ * All math lives in `insightsCalc.ts` so this file is pure layout. The
+ * page is paid-only — App.tsx routes free users to ProGate via the
+ * existing Coach/Urge Help gating pattern.
+ */
+interface InsightsProps {
+  urgeLog: UrgeLogEntry[];
+  checkIns: CheckIn[];
+}
+
+/** Sample-size floor for surfacing per-action stats. Mirrored from the
+ *  default in `insightsCalc.actionEffectivenessAll`; pinned here too so
+ *  empty-state copy can reference the exact threshold. */
+const MIN_TRIES = 3;
+
+export const Insights: React.FC<InsightsProps> = ({ urgeLog, checkIns }) => {
+  // Memoise the full aggregation pass — the page rerenders on every parent
+  // tick (App owns urgeLog + checkIns), but the underlying arrays change
+  // rarely. Single useMemo over a stable object keeps all derived data
+  // in lockstep without juggling per-card useMemos.
+  const stats = useMemo(
+    () => ({
+      topActions: topEffectiveActions(urgeLog, MIN_TRIES, 3),
+      allActions: actionEffectivenessAll(urgeLog, MIN_TRIES),
+      buckets: timeOfDayBuckets(urgeLog),
+      outcomes: outcomeBreakdown(urgeLog),
+      streak: bestStreak(checkIns),
+      feelings: topFeelings(urgeLog, 3),
+      trend: monthlyIntensityTrend(urgeLog),
+    }),
+    [urgeLog, checkIns],
+  );
+
+  // ── Empty state ─────────────────────────────────────────────────────────
+  // First-day users see nothing useful from raw data, so we replace the
+  // grid with a motivational hero instead of rendering eight "no data" boxes.
+  // Threshold is "no urge sessions yet" — check-ins alone aren't enough to
+  // make the patterns meaningful.
+  if (urgeLog.length === 0) {
+    return (
+      <div className="flex-1 h-full overflow-y-auto pb-28 md:pb-8">
+        <div className="w-full relative mb-4">
+          <ProgressPeak />
+          <div className="absolute top-[41px] md:top-[57px] left-4 md:left-8 pointer-events-none">
+            <span className="text-xs md:text-sm font-bold text-purple-700/80 uppercase tracking-wider">
+              Insights
+            </span>
+            <h2 className="text-3xl md:text-5xl font-extrabold text-purple-900 mt-1 drop-shadow-sm">
+              Your patterns
+            </h2>
+          </div>
+        </div>
+        <div className="max-w-2xl mx-auto px-4 md:px-8 -mt-4">
+          <div className="bg-white border border-purple-100 rounded-2xl p-6 md:p-8 text-center shadow-sm">
+            <Sparkles size={32} className="text-purple-400 mx-auto mb-3" />
+            <h3 className="text-lg md:text-xl font-bold text-purple-900 mb-2">
+              Your patterns will appear here
+            </h3>
+            <p className="text-sm md:text-base text-stone-600 leading-relaxed">
+              Open the Help tab the next time you feel an urge — even one
+              session is enough to start filling this page. The more you
+              practice, the more useful these stats become.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 h-full overflow-y-auto pb-28 md:pb-8">
+      {/* Hero reuses ProgressPeak — it already speaks "tracking" / "summit"
+          which fits an Insights surface, and avoids authoring a new SVG. */}
+      <div className="w-full relative mb-4">
+        <ProgressPeak />
+        <div className="absolute top-[41px] md:top-[57px] left-4 md:left-8 pointer-events-none">
+          <span className="text-xs md:text-sm font-bold text-purple-700/80 uppercase tracking-wider">
+            Insights
+          </span>
+          <h2 className="text-3xl md:text-5xl font-extrabold text-purple-900 mt-1 drop-shadow-sm">
+            Your patterns
+          </h2>
+        </div>
+      </div>
+
+      <div className="max-w-4xl mx-auto px-4 md:px-8 -mt-2">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <TopTechniquesCard items={stats.topActions} />
+          <TotalSurfsCard outcomes={stats.outcomes} />
+          <BestStreakCard streak={stats.streak} />
+          <OutcomeRatioCard outcomes={stats.outcomes} />
+          <TimeOfDayCard buckets={stats.buckets} />
+          <TopFeelingsCard items={stats.feelings} />
+          <IntensityTrendCard trend={stats.trend} />
+          {/* Full action ranking spans the full row on desktop — its body is
+              a list that needs the extra width to keep titles + bars readable. */}
+          <div className="md:col-span-2">
+            <ActionRankingCard items={stats.allActions} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ─── Shared card scaffold ──────────────────────────────────────────────────
+
+/** All eight insight cards share the same outer shell: rounded white box,
+ *  category-tinted icon badge, uppercase label, headline metric block at the
+ *  top, optional body (chart / list) below. Stagger the entrance animation
+ *  by `index` so the grid fades in row-by-row instead of as one flash. */
+interface CardShellProps {
+  index: number;
+  Icon: React.ComponentType<{ size?: number; className?: string }>;
+  label: string;
+  /** Tailwind class for the icon badge background (e.g. `bg-emerald-100`). */
+  tintBg: string;
+  /** Tailwind class for the icon colour (e.g. `text-emerald-700`). */
+  tintIcon: string;
+  children: React.ReactNode;
+}
+
+const CardShell: React.FC<CardShellProps> = ({ index, Icon, label, tintBg, tintIcon, children }) => (
+  <div
+    className="bg-white border border-purple-100 rounded-2xl p-5 md:p-6 shadow-sm
+               animate-in fade-in slide-in-from-bottom-2 duration-500"
+    style={{ animationDelay: `${index * 60}ms`, animationFillMode: 'backwards' }}
+  >
+    <div className="flex items-center gap-2 mb-4">
+      <div className={`${tintBg} ${tintIcon} p-1.5 rounded-lg`}>
+        <Icon size={16} />
+      </div>
+      <span className="text-[10px] font-semibold uppercase tracking-wider text-purple-700">
+        {label}
+      </span>
+    </div>
+    {children}
+  </div>
+);
+
+/** Inline "need more data" placeholder used by cards that need a minimum
+ *  sample size. Same typography as the surrounding metric so the empty
+ *  state doesn't feel like a different surface. */
+const NeedMore: React.FC<{ hint: string }> = ({ hint }) => (
+  <p className="text-sm text-stone-500 leading-relaxed">{hint}</p>
+);
+
+// ─── Card 1: Top 3 most-effective techniques ───────────────────────────────
+
+const TopTechniquesCard: React.FC<{
+  items: ReturnType<typeof topEffectiveActions>;
+}> = ({ items }) => (
+  <CardShell
+    index={0}
+    Icon={Trophy}
+    label="Top techniques"
+    tintBg="bg-emerald-100"
+    tintIcon="text-emerald-700"
+  >
+    {items.length === 0 ? (
+      <NeedMore hint={`Need at least ${MIN_TRIES} tries of any technique to surface a winner.`} />
+    ) : (
+      <ol className="space-y-3">
+        {items.map((a, i) => (
+          <li key={a.id} className="flex items-baseline justify-between gap-3">
+            <span className="flex items-baseline gap-2 min-w-0">
+              <span className="text-xs font-bold text-emerald-700 tabular-nums">{i + 1}.</span>
+              <span className="text-sm font-semibold text-emerald-900 truncate">{a.title}</span>
+            </span>
+            <span className="text-sm font-bold text-emerald-900 tabular-nums flex-shrink-0">
+              {Math.round(a.successRate * 100)}%
+            </span>
+          </li>
+        ))}
+      </ol>
+    )}
+  </CardShell>
+);
+
+// ─── Card 2: Total surfs ──────────────────────────────────────────────────
+
+const TotalSurfsCard: React.FC<{ outcomes: ReturnType<typeof outcomeBreakdown> }> = ({
+  outcomes,
+}) => (
+  <CardShell
+    index={1}
+    Icon={Waves}
+    label="Total surfs"
+    tintBg="bg-purple-100"
+    tintIcon="text-purple-700"
+  >
+    <div className="flex items-baseline gap-1.5 mb-2">
+      <span className="text-3xl md:text-4xl font-bold text-purple-900 tabular-nums">
+        {outcomes.total}
+      </span>
+      <span className="text-lg font-semibold text-purple-700">
+        {outcomes.total === 1 ? 'urge' : 'urges'}
+      </span>
+    </div>
+    <p className="text-xs text-stone-500">
+      {outcomes.passed} passed · {outcomes.stillHere} re-tried · {outcomes.escalated} escalated
+    </p>
+  </CardShell>
+);
+
+// ─── Card 3: Best streak ──────────────────────────────────────────────────
+
+const BestStreakCard: React.FC<{ streak: number }> = ({ streak }) => (
+  <CardShell
+    index={2}
+    Icon={Award}
+    label="Best streak"
+    tintBg="bg-purple-100"
+    tintIcon="text-purple-700"
+  >
+    <div className="flex items-baseline gap-1.5 mb-2">
+      <span className="text-3xl md:text-4xl font-bold text-purple-900 tabular-nums">
+        {streak}
+      </span>
+      <span className="text-lg font-semibold text-purple-700">
+        {streak === 1 ? 'day' : 'days'}
+      </span>
+    </div>
+    <p className="text-xs text-stone-500">Longest consecutive clean run on record.</p>
+  </CardShell>
+);
+
+// ─── Card 4: Passed vs Escalated ratio (split bar) ────────────────────────
+
+const OutcomeRatioCard: React.FC<{ outcomes: ReturnType<typeof outcomeBreakdown> }> = ({
+  outcomes,
+}) => {
+  // Only the two terminal outcomes are charted — `still_here` is mid-session
+  // and would skew the "did this resolve well?" question this card answers.
+  const total = outcomes.passed + outcomes.escalated;
+  const passedPct = total === 0 ? 0 : (outcomes.passed / total) * 100;
+  const escalatedPct = 100 - passedPct;
+  return (
+    <CardShell
+      index={3}
+      Icon={Sparkles}
+      label="Passed vs escalated"
+      tintBg="bg-indigo-100"
+      tintIcon="text-indigo-700"
+    >
+      {total === 0 ? (
+        <NeedMore hint="Resolve one urge session (passed or escalated) to see this ratio." />
+      ) : (
+        <>
+          <div className="flex items-baseline gap-1.5 mb-3">
+            <span className="text-3xl md:text-4xl font-bold text-indigo-900 tabular-nums">
+              {Math.round(passedPct)}%
+            </span>
+            <span className="text-sm font-semibold text-indigo-700">passed</span>
+          </div>
+          {/* CSS split bar. `min-w-[2px]` ensures a non-zero segment is still
+              visually present when its share rounds toward zero. */}
+          <div className="flex h-3 rounded-full overflow-hidden bg-stone-100" role="img"
+               aria-label={`${outcomes.passed} passed, ${outcomes.escalated} escalated`}>
+            <div className="bg-emerald-500 min-w-[2px]" style={{ width: `${passedPct}%` }} />
+            <div className="bg-rose-400 min-w-[2px]" style={{ width: `${escalatedPct}%` }} />
+          </div>
+          <p className="text-xs text-stone-500 mt-2">
+            {outcomes.passed} passed · {outcomes.escalated} escalated
+          </p>
+        </>
+      )}
+    </CardShell>
+  );
+};
+
+// ─── Card 5: Triggers by time of day (4-bucket bar chart) ─────────────────
+
+const TimeOfDayCard: React.FC<{ buckets: ReturnType<typeof timeOfDayBuckets> }> = ({
+  buckets,
+}) => {
+  // Render as four side-by-side vertical bars. Scale each bar's height to
+  // the max bucket so the tallest fills the chart area — comparing relative
+  // proportions is more useful than absolute counts here.
+  const entries = [
+    { key: 'morning', label: 'AM', long: 'Morning', count: buckets.morning },
+    { key: 'afternoon', label: 'Noon', long: 'Afternoon', count: buckets.afternoon },
+    { key: 'evening', label: 'Eve', long: 'Evening', count: buckets.evening },
+    { key: 'lateNight', label: 'Late', long: 'Late night', count: buckets.lateNight },
+  ] as const;
+  const max = Math.max(1, ...entries.map((e) => e.count));     // avoid /0
+  const total = entries.reduce((sum, e) => sum + e.count, 0);
+  return (
+    <CardShell
+      index={4}
+      Icon={Clock}
+      label="Triggers by time of day"
+      tintBg="bg-teal-100"
+      tintIcon="text-teal-700"
+    >
+      {total === 0 ? (
+        <NeedMore hint="No daypart data yet." />
+      ) : (
+        <div className="flex items-end justify-between gap-2 h-24" role="img"
+             aria-label="Urges by time-of-day bucket">
+          {entries.map((e) => {
+            const pct = (e.count / max) * 100;
+            return (
+              <div key={e.key} className="flex flex-col items-center flex-1 min-w-0 h-full">
+                <div className="flex-1 w-full flex items-end">
+                  <div
+                    className="w-full bg-teal-400 rounded-t-md transition-[height] min-h-[2px]"
+                    style={{ height: `${pct}%` }}
+                    title={`${e.long}: ${e.count}`}
+                  />
+                </div>
+                <span className="text-[10px] font-semibold uppercase tracking-wider text-teal-800/70 mt-1.5">
+                  {e.label}
+                </span>
+                <span className="text-[10px] font-bold text-teal-900 tabular-nums">{e.count}</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </CardShell>
+  );
+};
+
+// ─── Card 6: Top trigger feelings ─────────────────────────────────────────
+
+const TopFeelingsCard: React.FC<{ items: ReturnType<typeof topFeelings> }> = ({ items }) => (
+  <CardShell
+    index={5}
+    Icon={Heart}
+    label="Top trigger feelings"
+    tintBg="bg-sky-100"
+    tintIcon="text-sky-700"
+  >
+    {items.length === 0 ? (
+      <NeedMore hint="Name a feeling on the Locate stage to seed this card." />
+    ) : (
+      <ol className="space-y-2">
+        {items.map((f) => (
+          <li key={f.id}>
+            <div className="flex items-baseline justify-between gap-3 mb-1">
+              <span className="text-sm font-semibold text-sky-900 truncate">{f.label}</span>
+              <span className="text-xs font-bold text-sky-800 tabular-nums flex-shrink-0">
+                {Math.round(f.pct * 100)}%
+              </span>
+            </div>
+            {/* Horizontal proportion bar — width relative to "share of all
+                feelings named" (already normalised in topFeelings). */}
+            <div className="h-1.5 rounded-full bg-stone-100 overflow-hidden">
+              <div
+                className="h-full bg-sky-400 rounded-full"
+                style={{ width: `${Math.max(2, f.pct * 100)}%` }}
+              />
+            </div>
+          </li>
+        ))}
+      </ol>
+    )}
+  </CardShell>
+);
+
+// ─── Card 7: Average intensity trend (inline SVG line) ────────────────────
+
+const IntensityTrendCard: React.FC<{
+  trend: ReturnType<typeof monthlyIntensityTrend>;
+}> = ({ trend }) => {
+  // <2 months of data is too thin to read as a "trend" — fall back to a
+  // copy state rather than render a single dot pretending to be a line.
+  if (trend.length < 2) {
+    return (
+      <CardShell
+        index={6}
+        Icon={TrendingUp}
+        label="Intensity trend"
+        tintBg="bg-indigo-100"
+        tintIcon="text-indigo-700"
+      >
+        <NeedMore hint="Need urges across at least 2 months to draw a trend line." />
+      </CardShell>
+    );
+  }
+  // Scale points into a fixed-aspect SVG viewBox so layout maths happens
+  // once and the chart is resolution-independent.
+  const VIEW_W = 280;
+  const VIEW_H = 80;
+  const PAD = 6;
+  const xStep = (VIEW_W - PAD * 2) / Math.max(1, trend.length - 1);
+  const points = trend
+    .map((m, i) => {
+      const x = PAD + i * xStep;
+      // Intensity is 1–10 from the slider; invert so higher intensity sits
+      // higher on the chart, with PAD margins top and bottom.
+      const y = VIEW_H - PAD - ((m.avgIntensity - 1) / 9) * (VIEW_H - PAD * 2);
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(' ');
+  const latest = trend[trend.length - 1];
+  return (
+    <CardShell
+      index={6}
+      Icon={TrendingUp}
+      label="Intensity trend"
+      tintBg="bg-indigo-100"
+      tintIcon="text-indigo-700"
+    >
+      <div className="flex items-baseline gap-1.5 mb-2">
+        <span className="text-3xl md:text-4xl font-bold text-indigo-900 tabular-nums">
+          {latest.avgIntensity.toFixed(1)}
+        </span>
+        <span className="text-sm font-semibold text-indigo-700">/ 10 latest month</span>
+      </div>
+      <svg
+        viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+        className="w-full h-20"
+        role="img"
+        aria-label="Average urge intensity per month"
+      >
+        <polyline
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinejoin="round"
+          strokeLinecap="round"
+          points={points}
+          className="text-indigo-500"
+        />
+        {trend.map((m, i) => {
+          const x = PAD + i * xStep;
+          const y = VIEW_H - PAD - ((m.avgIntensity - 1) / 9) * (VIEW_H - PAD * 2);
+          return (
+            <circle
+              key={m.month}
+              cx={x}
+              cy={y}
+              r={2.5}
+              className="fill-indigo-600"
+            />
+          );
+        })}
+      </svg>
+      <p className="text-xs text-stone-500 mt-1">{trend.length} months of data.</p>
+    </CardShell>
+  );
+};
+
+// ─── Card 8: Full action effectiveness ranking ────────────────────────────
+
+const ActionRankingCard: React.FC<{
+  items: ReturnType<typeof actionEffectivenessAll>;
+}> = ({ items }) => (
+  <CardShell
+    index={7}
+    Icon={ListOrdered}
+    label="All techniques ranked"
+    tintBg="bg-emerald-100"
+    tintIcon="text-emerald-700"
+  >
+    {items.length === 0 ? (
+      <NeedMore hint={`Each technique needs at least ${MIN_TRIES} tries before it appears here.`} />
+    ) : (
+      <ul className="space-y-2.5">
+        {items.map((a) => {
+          const pct = Math.round(a.successRate * 100);
+          return (
+            <li key={a.id}>
+              <div className="flex items-baseline justify-between gap-3 mb-1">
+                <span className="text-sm font-semibold text-emerald-900 truncate">{a.title}</span>
+                <span className="text-xs text-emerald-700 tabular-nums flex-shrink-0">
+                  {a.successes}/{a.tries} · {pct}%
+                </span>
+              </div>
+              <div className="h-1.5 rounded-full bg-stone-100 overflow-hidden">
+                <div
+                  className="h-full bg-emerald-400 rounded-full"
+                  style={{ width: `${Math.max(2, pct)}%` }}
+                />
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    )}
+  </CardShell>
+);

--- a/webapp/src/lib/insightsCalc.ts
+++ b/webapp/src/lib/insightsCalc.ts
@@ -1,0 +1,243 @@
+// Pure aggregation functions for the Insights page (Issue #73).
+//
+// Everything here takes plain UrgeLogEntry[] / CheckIn[] inputs and returns
+// plain data structures — no React, no side effects, no logging. That makes
+// each function trivially unit-testable and keeps the visualisation layer
+// (`Insights.tsx`) focused on rendering.
+//
+// Why "lifetime" not "rolling window": the user explicitly asked for
+// all-time aggregations rather than last-N-days, so the patterns shown here
+// reflect the long-horizon picture (#73 acceptance criteria).
+
+import type { CheckIn, UrgeLogEntry, FeelingId, UrgeActionId } from '../../types';
+import { CheckInStatus } from '../../types';
+import { FEELINGS, URGE_ACTION_BY_ID } from '../../data/urgeData';
+
+const FEELING_LABEL_BY_ID: Record<FeelingId, string> = Object.fromEntries(
+  FEELINGS.map((f) => [f.id, f.label]),
+) as Record<FeelingId, string>;
+
+// ─── Action effectiveness ──────────────────────────────────────────────────
+
+export interface ActionEffectiveness {
+  id: UrgeActionId;
+  title: string;
+  /** Successful sessions where this action was tried, over total sessions
+   *  where it was tried. 0–1 range. */
+  successRate: number;
+  /** Total sessions in which the user opened this action — drives the
+   *  `minTries` cutoff for statistical significance. */
+  tries: number;
+  /** Absolute count of `passed` outcomes among those tries — surfaced in
+   *  the UI as "12 of 18 worked" rather than just a percentage. */
+  successes: number;
+}
+
+/** Walk the urge log once and return per-action effectiveness, ranked by
+ *  success rate desc. Actions tried fewer than `minTries` times are excluded
+ *  so a single 100%-success record can't dominate the top of the list. */
+export function actionEffectivenessAll(
+  log: UrgeLogEntry[],
+  minTries = 3,
+): ActionEffectiveness[] {
+  // Walk the log once accumulating per-action (tries, successes).
+  const stats = new Map<UrgeActionId, { tries: number; successes: number }>();
+  for (const entry of log) {
+    const isSuccess = entry.outcome === 'passed';
+    for (const actionId of entry.actionsTried) {
+      const prev = stats.get(actionId) ?? { tries: 0, successes: 0 };
+      prev.tries += 1;
+      if (isSuccess) prev.successes += 1;
+      stats.set(actionId, prev);
+    }
+  }
+  // Materialise into the ranked array, filtered by sample-size floor.
+  const ranked: ActionEffectiveness[] = [];
+  for (const [id, { tries, successes }] of stats) {
+    if (tries < minTries) continue;
+    const title = URGE_ACTION_BY_ID[id]?.title ?? id;
+    ranked.push({ id, title, successRate: successes / tries, tries, successes });
+  }
+  // Highest success-rate first; ties broken by larger sample (more confident).
+  ranked.sort((a, b) => b.successRate - a.successRate || b.tries - a.tries);
+  return ranked;
+}
+
+/** Convenience: top N from the full ranking. Same `minTries` semantics. */
+export function topEffectiveActions(
+  log: UrgeLogEntry[],
+  minTries = 3,
+  limit = 3,
+): ActionEffectiveness[] {
+  return actionEffectivenessAll(log, minTries).slice(0, limit);
+}
+
+// ─── Time-of-day buckets ──────────────────────────────────────────────────
+
+export interface TimeOfDayBuckets {
+  morning: number;     // 05:00–11:59
+  afternoon: number;   // 12:00–16:59
+  evening: number;     // 17:00–21:59
+  lateNight: number;   // 22:00–04:59
+}
+
+/** Counts urges per 4 daypart bucket. Boundaries mirror the existing
+ *  `TIME_OF_DAY` constant in `constants.ts` so the language stays consistent
+ *  with the check-in form. */
+export function timeOfDayBuckets(log: UrgeLogEntry[]): TimeOfDayBuckets {
+  const buckets: TimeOfDayBuckets = {
+    morning: 0,
+    afternoon: 0,
+    evening: 0,
+    lateNight: 0,
+  };
+  for (const entry of log) {
+    const ts = new Date(entry.endedAt);
+    if (Number.isNaN(ts.getTime())) continue;
+    const h = ts.getHours();
+    if (h >= 5 && h < 12) buckets.morning += 1;
+    else if (h >= 12 && h < 17) buckets.afternoon += 1;
+    else if (h >= 17 && h < 22) buckets.evening += 1;
+    else buckets.lateNight += 1;
+  }
+  return buckets;
+}
+
+// ─── Outcome breakdown ─────────────────────────────────────────────────────
+
+export interface OutcomeBreakdown {
+  passed: number;
+  stillHere: number;
+  escalated: number;
+  total: number;
+}
+
+/** Sum of outcomes across the log. `total` is the array length — exposed so
+ *  callers don't have to recompute it for the "total surfs" card. */
+export function outcomeBreakdown(log: UrgeLogEntry[]): OutcomeBreakdown {
+  const out: OutcomeBreakdown = { passed: 0, stillHere: 0, escalated: 0, total: log.length };
+  for (const entry of log) {
+    if (entry.outcome === 'passed') out.passed += 1;
+    else if (entry.outcome === 'still_here') out.stillHere += 1;
+    else if (entry.outcome === 'escalated') out.escalated += 1;
+  }
+  return out;
+}
+
+// ─── Best streak ───────────────────────────────────────────────────────────
+
+/** Longest consecutive run of CLEAN days. A day with NO check-in breaks the
+ *  streak (matches the rule used by `App.streak` so the two numbers tell a
+ *  consistent story). SLIP also breaks. SKIPPED is treated as "no check-in"
+ *  and breaks the streak as well — feature, not bug. */
+export function bestStreak(checkIns: CheckIn[]): number {
+  if (checkIns.length === 0) return 0;
+  // Reduce to one status per local-date so multi-check-in days don't
+  // over-count — and so a SLIP entry on the same day as CLEAN still kills
+  // the streak.
+  const dayStatus = new Map<string, CheckInStatus>();
+  for (const c of checkIns) {
+    const key = new Date(c.date).toDateString();
+    const prev = dayStatus.get(key);
+    if (prev === CheckInStatus.SLIP) continue;             // SLIP wins
+    if (c.status === CheckInStatus.SLIP) {
+      dayStatus.set(key, CheckInStatus.SLIP);
+    } else if (c.status === CheckInStatus.CLEAN) {
+      if (!prev) dayStatus.set(key, CheckInStatus.CLEAN);
+    } else {
+      if (!prev) dayStatus.set(key, c.status);
+    }
+  }
+  // Iterate chronologically, counting consecutive CLEAN days. We walk by
+  // calendar day (not by entry) so a gap in check-ins also breaks the run.
+  const sortedKeys = Array.from(dayStatus.keys())
+    .map((k) => new Date(k))
+    .sort((a, b) => a.getTime() - b.getTime());
+  if (sortedKeys.length === 0) return 0;
+
+  let best = 0;
+  let current = 0;
+  let prev: Date | null = null;
+  const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+  for (const date of sortedKeys) {
+    const key = date.toDateString();
+    const status = dayStatus.get(key);
+    const isContinuous =
+      prev !== null && Math.round((date.getTime() - prev.getTime()) / MS_PER_DAY) === 1;
+    if (status === CheckInStatus.CLEAN) {
+      current = isContinuous ? current + 1 : 1;
+      if (current > best) best = current;
+    } else {
+      current = 0;
+    }
+    prev = date;
+  }
+  return best;
+}
+
+// ─── Most-common trigger feelings ──────────────────────────────────────────
+
+export interface FeelingFrequency {
+  id: FeelingId;
+  label: string;
+  count: number;
+  /** Share of urges with a named feeling that fall in this bucket (0–1).
+   *  Sessions with `feeling === null` are excluded from both numerator
+   *  and denominator so the percentages add up to 100% across the bars. */
+  pct: number;
+}
+
+export function topFeelings(log: UrgeLogEntry[], limit = 3): FeelingFrequency[] {
+  const counts = new Map<FeelingId, number>();
+  let totalWithFeeling = 0;
+  for (const entry of log) {
+    if (!entry.feeling) continue;
+    counts.set(entry.feeling, (counts.get(entry.feeling) ?? 0) + 1);
+    totalWithFeeling += 1;
+  }
+  if (totalWithFeeling === 0) return [];
+  const arr: FeelingFrequency[] = [];
+  for (const [id, count] of counts) {
+    arr.push({
+      id,
+      label: FEELING_LABEL_BY_ID[id] ?? id,
+      count,
+      pct: count / totalWithFeeling,
+    });
+  }
+  arr.sort((a, b) => b.count - a.count);
+  return arr.slice(0, limit);
+}
+
+// ─── Monthly intensity trend ──────────────────────────────────────────────
+
+export interface MonthlyIntensity {
+  /** YYYY-MM in local time — used as a stable map key + chart x-axis label. */
+  month: string;
+  avgIntensity: number;
+  sampleSize: number;
+}
+
+/** Group urges by local-time month and average their intensity. Months with
+ *  zero samples are omitted so the chart doesn't render misleading zero-points
+ *  in the gap (a missing month means "no data", not "intensity dropped to 0"). */
+export function monthlyIntensityTrend(log: UrgeLogEntry[]): MonthlyIntensity[] {
+  const totals = new Map<string, { sum: number; n: number }>();
+  for (const entry of log) {
+    if (entry.intensity == null) continue;
+    const ts = new Date(entry.endedAt);
+    if (Number.isNaN(ts.getTime())) continue;
+    const month = `${ts.getFullYear()}-${String(ts.getMonth() + 1).padStart(2, '0')}`;
+    const prev = totals.get(month) ?? { sum: 0, n: 0 };
+    prev.sum += entry.intensity;
+    prev.n += 1;
+    totals.set(month, prev);
+  }
+  const out: MonthlyIntensity[] = [];
+  for (const [month, { sum, n }] of totals) {
+    out.push({ month, avgIntensity: sum / n, sampleSize: n });
+  }
+  out.sort((a, b) => a.month.localeCompare(b.month));
+  return out;
+}

--- a/webapp/types.ts
+++ b/webapp/types.ts
@@ -5,6 +5,9 @@ export enum View {
   PLAN_21 = 'PLAN_21',
   AI_COACH = 'AI_COACH',
   URGE_HELP = 'URGE_HELP',
+  /** Lifetime aggregations over urge_log + check_ins. Paid-only; free users
+   *  hitting this view get the same ProGate as Coach / Urge Help. Issue #73. */
+  INSIGHTS = 'INSIGHTS',
   FUTURE = 'FUTURE',
   SETTINGS = 'SETTINGS',
 }


### PR DESCRIPTION
## Summary

Paid-only Insights page з 8 achievement-style картками: lifetime aggregations над `urge_log` + `check_ins`. Два entry points (Coach hero + Dashboard day-detail modal). Free users → ProGate (same Pro tier як Coach / Urge Help).

Closes #73

## What changed

- `feat`: 8 lifetime insight cards (top techniques, time of day, passed/escalated ratio, best streak, total surfs, top feelings, intensity trend, full action ranking)
- `refactor`: peer-review fixes (single-pass `actionEffectivenessAll` + copy nit)

## Architecture

- **`webapp/src/lib/insightsCalc.ts`** — 7 pure aggregation функцій. Нуль React/I/O — easy unit-test. `MIN_TRIES = 3` floor на action stats запобігає 100%-success domination від single-record action.
- **`webapp/components/Insights.tsx`** — page-level component, single `CardShell` scaffold reused для 8 cards. Inline SVG / CSS bars для всіх візуалізацій — **нуль нових deps**.
- **`View.INSIGHTS`** enum value + App-level routing з ProGate fallback для free users.
- **Achievement-style cards**: Lucide icon badge + uppercase label + headline metric + optional body chart. `animate-in fade-in slide-in-from-bottom-2` staggered by `animationDelay: index * 60ms` для row-by-row reveal.

## Entry points

- **Coach hero**: `Insights` button **завжди видима** (зліва від `New conversation` коли той теж видимий). Той самий `animate-coach-reset-pulse` стиль для visual consistency.
- **Dashboard day-detail modal**: button у правому куті Clean / Slip banner. Closes modal перед navigation.

## Empty / partial states

- `urgeLog.length === 0` → hero + motivational copy (NO empty cards)
- Per-card "Need at least N sessions" placeholder коли data inadequate
- `IntensityTrendCard` requires >=2 months
- `TopTechniques` / `ActionRanking` require >=3 tries per action

## What was excluded

- **Journal entries**. Issue #66 plans to compress journal into `coach_memory` prose, не давати окрему таблицю. Insights tap'ить тільки structured data (urge_log + check_ins).

## Test plan

- [ ] Paid user without urges → hero + motivational copy, без empty cards
- [ ] Paid user з 1-2 urges → partial cards rendering correctly з "Need more" placeholders
- [ ] Paid user з достатніми даними → всі 8 cards: метрики + візуалізації
- [ ] Coach Insights button завжди видима, навіть у порожньому чаті
- [ ] Day-modal Insights button у правому куті Clean/Slip banner; click closes modal + navigates
- [ ] Free user click Insights (з Coach) → ProGate з Insights-specific copy
- [ ] Free user click Insights (з day-modal) → ProGate з Insights-specific copy
- [ ] Mobile viewport (375px): cards stack vertically, buttons fit
- [ ] Spot-check: hand-calculate 2 metrics (best streak, action success rate) проти Insights output

Smoke test runs automatically on push via Claude Code hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)