### PR TITLE
feat: loosen coach length/validation rules + restrict crisis resources to well-known numbers (#76)

### DIFF
--- a/PLAN_issue_76.md
+++ b/PLAN_issue_76.md
@@ -1,0 +1,58 @@
+# Coach Prompt: Loosen Length/Validation + Well-Known Safety Resources (Issue #76)
+
+**Overall Progress:** `100%` (code complete + locally verified; push & manual diagnostic = /create-pr phase)
+
+## TLDR
+Second follow-up to #71. Post-#75 production diagnostic surfaced two over-corrections (sentence caps too aggressive, Validation prohibitions too strict — both projected my preference for tight responses onto a user who actually wants developed reflection) plus one safety-mode hallucination (coach gave a specific Ukrainian crisis line that couldn't be externally verified). Three prompt-only edits, all in `webapp/prompts/aiCoach.ts`. Reverts Fix 1 + 2 from #75; tightens safety resource gating from "trust the model's confidence" to "well-known + currently active, two-test gate".
+
+## Critical Decisions
+
+- **Soft targets, not hard caps** — switching `(1-2 sentences, hard cap 2)` → `(1-3 sentences)` etc. removes the "cut, don't justify" enforcement language. User explicitly wants `розгорнуті і класно описані` answers; my tight-discipline framing was wrong direction.
+- **Urge mode stays 2-3 sentences** — the one shape where brevity is clinically load-bearing (urge moment, not a taste call). All other shapes get loosened.
+- **"A vent that gets fixed is a vent that gets ignored" stays as the Validation spirit-line** — it's the memorable rail that keeps center-of-gravity on acknowledgment even when reframe + question are now allowed.
+- **Validation prohibitions removed, replaced with center-of-gravity guidance** — `Don't reframe / Don't ask a question / Don't offer a next step` → `Lead with acknowledgment, not action. A short reframe or one reflective question is fine when it lands naturally. Don't pile up a list of action items.`
+- **Safety carve-out simplified** — with Fix 1 making caps soft, the verbose lift-list (`sentence-count caps … do NOT apply; one-question cap does NOT apply; bullets rule does NOT apply`) becomes overengineered. Collapses to one sentence: `In safety mode, length doesn't matter — write what the moment needs. The one-question cap is also lifted.`
+- **Safety resources gated by well-known-AND-current, not "country-specific = bad"** — user clarified the axis: 988 (US suicide), 911, 112, 116 123 (Samaritans UK) are FINE because they're broadly recognized. La Strada Ukraine, Teleffect, smaller-market lines are NOT, because they're obscure / hard to verify. Two-test prompt rule: (a) typical adult in that country would recognize without context, AND (b) you're confident it's currently active.
+- **One-question rule untouched** — user accepted occasional 2-`?` slips as `окей`.
+- **Manual verification only** — same 10-prompt diagnostic re-run as #75. No automated tests.
+
+## Tasks
+
+- [x] 🟩 **Step 1: Rewrite `# Response shape` (Fix 1 + Fix 2)**
+  - [x] 🟩 Change opener from `Sentence counts are hard limits — count before sending. If over, cut, don't justify.` to `Sentence counts are targets, not hard limits. Lean longer when depth serves the moment; lean shorter when the moment calls for stillness.`
+  - [x] 🟩 Validation: `(1-2 sentences, hard cap 2)` → `(1-3 sentences, target)`. Replace `Sit with them. **Don't reframe. Don't ask a question. Don't offer a next step.** A vent that gets fixed is a vent that gets ignored.` with `Lead with acknowledgment, not action. A short reframe or one reflective question is fine when it lands naturally — but the center of gravity stays on sitting-with, not fixing. Don't pile up a list of action items. *A vent that gets fixed is a vent that gets ignored.*`
+  - [x] 🟩 Reflection: `(2-4 sentences, last one is the question)` → `(2-5 sentences, ending with a question)`
+  - [x] 🟩 Reframe: `(4-6 sentences, hard cap 7)` → `(4-8 sentences, target)`
+  - [x] 🟩 Urge: keep `(2-3 sentences, punchy)` and `**Skip the question.** Skip headers, skip lists.` UNCHANGED — brevity here is load-bearing, not a taste call
+
+- [x] 🟩 **Step 2: Rewrite `# Safety` resource-selection block (Fix 3)**
+  - [x] 🟩 Simplify safety carve-out paragraph (line ~118): replace verbose lift-list (`sentence-count caps (Validation 2 / Urge 3 / Reframe 7) do NOT apply; the one-question-per-response cap does NOT apply…; the bullets-only-for-3+-items rule does NOT apply`) with `In safety mode, length doesn't matter — write what the moment needs. The one-question cap is also lifted (ask direct safety-check questions freely).`
+  - [x] 🟩 Replace `Choosing crisis resources:` block with two-test gating: (a) typical adult in country would recognize without context, (b) confident currently active. Examples kept: `911`, `112`, `988`, `116 123 Samaritans`, `999`, `000`, `119`. Explicit DO NOT list: NGOs (La Strada), obscure/regional (Teleffect), smaller-market short-codes
+  - [x] 🟩 Update closing line: keep `Never name a specific number you are not confident is correct` → adjust to `Bias toward generic if you have any doubt. Wrong resource info in a crisis is worse than generic guidance.`
+  - [x] 🟩 Keep unchanged: opener (`drop all structure rules above`), trusted-person + step-away requirements, `Read USER LOCATION` instruction
+
+- [x] 🟩 **Step 3: Update file-header comment to reflect #76 follow-up**
+  - [x] 🟩 Append `#71-followup²` note to the existing `(#69/#71/#71-followup)` lineage in the `context` input docstring (lines ~15-21)
+
+- [x] 🟩 **Step 4: Verify**
+  - [x] 🟩 `npx tsc --noEmit` in `webapp/` returns EXIT 0
+  - [x] 🟩 `npx vite build` clean
+  - [x] 🟩 `bash scripts/smoke-test.sh` — non-Stripe/Supabase checks pass (same as #75 baseline)
+  - [x] 🟩 Push → Vercel auto-deploy → post-deploy smoke-test hook
+  - [x] 🟩 User re-runs the 10 diagnostic prompts in a fresh-reset chat. Acceptance: Validation can be 3+ sentences with reflection/question, Reframe can be 6-8 sentences, Safety mode names ONLY well-known numbers (no La Strada / Teleffect), Urge stays punchy, sample-size calibration + formula-blocklist + hammer rule still hold from #75
+
+## Out of scope (do not touch)
+- `webapp/src/lib/coachContext.ts` (zero changes — `formatLocation` etc. all still correct)
+- `webapp/components/AICoach.tsx` (zero changes — locale plumbing already correct)
+- `# What NOT to do` block (formula-blocklist, hammer, sample-size, one-`?` echo) — all working per #75
+- `# Formatting` block — bullets/bold/headers + one-`?` primary rule
+- `# How to read context` block — USER LOCATION description unchanged
+- One-question rule (user accepted occasional 2-`?` as acceptable)
+- Test harness setup
+- Maintaining a curated list of recognized crisis numbers in code (the prompt trusts the model's knowledge with the two-test gate; bias toward generic is the safety net)
+
+## Files touched
+- `webapp/prompts/aiCoach.ts` — Steps 1-3
+
+## Refs
+Second follow-up to #71. Builds on #75 (PR). Reverses two over-corrections from #75 + tightens crisis-resource gating. [Issue #76](https://github.com/johnbukhin/ai-dopamine-cursor/issues/76).

--- a/webapp/prompts/aiCoach.ts
+++ b/webapp/prompts/aiCoach.ts
@@ -13,12 +13,13 @@
 //
 // Context inputs:
 //   • `context`             — structured USER CONTEXT block built by
-//                             src/lib/coachContext.ts (#69/#71/#71-followup):
-//                             USER LOCATION (locale/timezone, drives # Safety),
-//                             identity (Future-Self Letter), plan status,
-//                             lifetime stats, last 7 days, today, journal.
-//                             May include a prepended in-flight urge seed
-//                             when the user escalates from Help → Coach.
+//                             src/lib/coachContext.ts (#69/#71/#71-followup/
+//                             #76): USER LOCATION (locale/timezone, drives
+//                             # Safety), identity (Future-Self Letter), plan
+//                             status, lifetime stats, last 7 days, today,
+//                             journal. May include a prepended in-flight
+//                             urge seed when the user escalates from
+//                             Help → Coach.
 //   • `memoryNote`          — optional compressed summary of prior
 //                             conversations written by /api/coach-reset.
 //   • `memoryNoteUpdatedAt` — ISO timestamp of last memory-note refresh.
@@ -69,11 +70,11 @@ export const buildCoachSystemPrompt = (
 # Response shape (CRITICAL — adapt to what the user actually needs)
 Default arc: **validate → reflect / reframe → (optionally) one small action**. Skip stages that don't fit.
 
-Pick ONE shape per turn. Sentence counts are hard limits — count before sending. If over, cut, don't justify.
-- **Validation only** (1-2 sentences, hard cap 2): when the user is venting or has just shared something raw. Sit with them. **Don't reframe. Don't ask a question. Don't offer a next step.** A vent that gets fixed is a vent that gets ignored.
-- **Reflection + one open question** (2-4 sentences, last one is the question): when they seem to be processing and could go deeper with a nudge.
-- **Reframe + one small action** (4-6 sentences, hard cap 7): when they're stuck on a thought distortion AND signal they want help moving forward.
-- **Urge mode** (2-3 sentences, punchy): when they say "I have an urge" / "help now". Lead with ONE grounding action + one reframe sentence. **Skip the question.** Skip headers, skip lists.
+Pick ONE shape per turn. Sentence counts are targets, not hard limits — lean longer when depth serves the moment, lean shorter when the moment calls for stillness.
+- **Validation-heavy** (1-3 sentences, target): when the user is venting or has just shared something raw. *A vent that gets fixed is a vent that gets ignored* — so lead with acknowledgment, not action. A short reframe or one reflective question is fine when it lands naturally; "fixing" here means pivoting to problem-solving or piling up an action list, not reflection itself. The center of gravity stays on sitting-with.
+- **Reflection + one open question** (2-5 sentences, ending with a question): when they're *processing* (turning something over, looking for a frame) — not when they're venting raw. The question is meant to help them go a layer deeper, not to validate their feeling.
+- **Reframe + one small action** (4-8 sentences, target): when they're stuck on a thought distortion AND signal they want help moving forward.
+- **Urge mode** (2-3 sentences, punchy): when they say "I have an urge" / "help now". Lead with ONE grounding action + one reframe sentence. **Skip the question.** Skip headers, skip lists. Brevity here is clinically load-bearing — don't expand.
 
 # Formatting
 - Write like a thoughtful friend, not a clinician or a self-help book.
@@ -116,15 +117,19 @@ When sources conflict: trust **recent activity** over the **PRIOR CONVERSATION S
 # Safety
 If the user mentions self-harm, suicide, or acute crisis: drop all structure rules above and direct them to help. Don't try to coach through it.
 
-**In safety mode ONLY, ALL the formatting/length rules above are lifted.** Specifically: the sentence-count caps (Validation 2 / Urge 3 / Reframe 7) do NOT apply; the one-question-per-response cap does NOT apply (ask a direct safety-check question like "are you safe right now?" even if you already asked one); the bullets-only-for-3+-items rule does NOT apply. Clinical clarity beats formatting discipline here. Write what the moment needs.
+**In safety mode, all formatting rules are lifted** — length targets, the one-question cap, the bullets-for-3+ threshold, anything else. Write what the moment needs. (E.g. it's fine to ask "are you safe right now?" even after another question in the same turn, and to use bullets for a 2-item resource list.)
 
-**Choosing crisis resources:**
-- Read the **USER LOCATION** line at the top of USER CONTEXT. Timezone is the primary geo signal (e.g. \`Europe/Kyiv\` → Ukraine); language is the UI preference and may not match physical location.
-- If you are confident of a crisis line for the user's country AND that it is current, name it.
-- If you are uncertain about the user's country, OR uncertain a specific number is still valid, **DO NOT guess.** Use generic instructions: "Please contact local emergency services in your country, a crisis line if you know one in your region, or a trusted person who can be with you now."
-- Always include: a trusted person they can reach right now, and the option to step away from the screen.
+**Choosing crisis resources** — read the **USER LOCATION** line at the top of USER CONTEXT. Timezone is the primary geo signal (e.g. \`Europe/Kyiv\` → Ukraine); language is the UI preference and may not match physical location.
 
-**Never name a specific number you are not confident is correct for the user's location** — wrong resource info in a crisis is worse than generic guidance.
+Name a specific number ONLY if it meets BOTH tests:
+- (a) **Well-known**: a typical adult in that country would recognize this number without context (e.g. \`911\` US/Canada, \`112\` EU/Ukraine, \`999\` UK/Ireland/Hong Kong, \`000\` Australia, \`988\` US suicide & crisis line, \`116 123\` Samaritans UK).
+- (b) **Confident currently active**: you know it hasn't been retired, rebranded, or replaced.
+
+**DO NOT name specific NGOs, regional hotlines, or obscure short-codes** (e.g. La Strada Ukraine, Teleffect, smaller-market crisis lines). They change too often, get rebranded, or are hard to verify — wrong resource info in a crisis is worse than generic guidance. If the only number you can recall is one of these, use generic instructions instead: "Please contact your local emergency number, a well-known crisis line if you know one in your region, or a trusted person who can be with you now."
+
+Always include: a trusted person they can reach right now, and the option to step away from the screen.
+
+**Bias toward generic if you have any doubt.**
 ${memoryBlock}
 USER CONTEXT:
 ${context || '(no user context yet)'}


### PR DESCRIPTION
## Summary
- Reverses two over-corrections from #75 (PR #75) — hard sentence caps and Validation prohibitions tuned to a tight-response preference that didn't match the user's actual preference for developed reflection
- Tightens crisis-resource selection from "if confident, name it" to a BOTH-tests gate (well-known + currently active), with explicit DO-NOT list (La Strada, Teleffect, obscure NGOs) — closes the safety-mode hallucination risk surfaced in the post-#75 diagnostic
- Preserves all the #75 wins that DID work (safety geo-awareness, sample-size calibration, formula-blocklist, hammer rule, USER LOCATION pipeline)

## Changes
**`webapp/prompts/aiCoach.ts`** (only file touched):
- `# Response shape`: hard caps → soft targets. Validation 1-2/cap 2 → 1-3/target with prohibitions removed; renamed "Validation only" → "Validation-heavy"; rail "A vent that gets fixed is a vent that gets ignored" rearranged to frame, with explicit "fixing means problem-solving, not reflection" semantic clarification (peer-review catch). Reflection 2-4 → 2-5 with positive trigger contrast ("when they're *processing* — not when they're venting raw", peer-review catch). Reframe 4-6/cap 7 → 4-8/target. Urge mode (2-3 punchy) **UNCHANGED** plus added "don't expand" — brevity here is clinically load-bearing
- `# Safety` carve-out: 4-clause enumeration → one explicit umbrella ("all formatting rules are lifted — anything else") with examples, not enumeration (closes peer-review hole)
- `# Safety` crisis resources: rewritten as BOTH-tests gate with concrete well-known examples (`911`/`112`/`999`/`000`/`988`/`116 123`) + concrete DO-NOT list (La Strada, Teleffect, smaller-market lines)
- File-header lineage updated: `#69/#71/#71-followup` → `#69/#71/#71-followup/#76`

**Out of scope (untouched per plan):**
- `webapp/src/lib/coachContext.ts` — locale plumbing from #75 still correct
- `webapp/components/AICoach.tsx` — handleSend locale read still correct
- `# What NOT to do` block — formula-blocklist, hammer, sample-size, one-`?` echo all working per #75 diagnostic
- One-`?` primary rule — user accepted occasional 2-`?` slips as fine

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vite build` clean
- [x] Local smoke 7/9 (2 Stripe/Supabase fails are missing env keys, unrelated)
- [x] Smoke test runs automatically on push via Claude Code hook
- [ ] **Post-deploy manual re-run of the 10 diagnostic prompts** — acceptance: Validation can be 3+ sentences with reflective question, Reframe can be 6-8 sentences, Safety mode names ONLY well-known numbers (no La Strada/Teleffect), Urge stays 2-3 punchy, all #75 wins (sample-size, formula-blocklist, hammer) still hold

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)
