### PR TITLE
fix: pass upsell signal via URL hash so AI Companion unlocks immediately on first load (#79)

### DIFF
--- a/funnel/engine/app.js
+++ b/funnel/engine/app.js
@@ -5045,9 +5045,14 @@ const Events = {
                     // Supabase session cross-origin (localStorage is scoped per origin and
                     // cannot be read by a different domain).
                     // The webapp reads, consumes, and strips the hash on mount.
+                    // Include upsell flag when the user purchased the AI Companion
+                    // add-on during this funnel session. The webapp reads &upsell=1
+                    // from the hash and writes mc_has_upsell to its own localStorage
+                    // so features are unlocked immediately on first load.
                     const hash = result.access_token && result.refresh_token
                         ? '#access_token=' + encodeURIComponent(result.access_token) +
-                          '&refresh_token=' + encodeURIComponent(result.refresh_token)
+                          '&refresh_token=' + encodeURIComponent(result.refresh_token) +
+                          (State.data.hasUpsell ? '&upsell=1' : '')
                         : '';
                     window.location.href = CONFIG.webappUrl + hash;
                     return;

--- a/webapp/App.tsx
+++ b/webapp/App.tsx
@@ -404,6 +404,11 @@ export default function App() {
   const handleLogin = () => {
     setIsAuthenticated(true);
     setCurrentView(View.PLAN_28);
+    // Re-sync upsell access from localStorage. The lazy useState init ran at
+    // mount before Login.tsx wrote mc_has_upsell (cross-origin funnel redirect
+    // path), so we must explicitly re-read the flag here. The loadUserData
+    // Supabase check remains the authoritative validation fallback.
+    if (localStorage.getItem('mc_has_upsell') === '1') setHasUpsellAccess(true);
   };
 
   const handleLogout = async () => {

--- a/webapp/components/Login.tsx
+++ b/webapp/components/Login.tsx
@@ -57,6 +57,11 @@ export const Login: React.FC<LoginProps> = ({ onLogin }) => {
         const params = new URLSearchParams(hash);
         const hashAccessToken = params.get('access_token');
         const hashRefreshToken = params.get('refresh_token');
+        // Upsell flag — set by the funnel when the user purchased the AI Companion
+        // add-on. Written to localStorage here (webapp origin) so App.tsx can
+        // read mc_has_upsell synchronously in handleLogin before loadUserData
+        // completes its async Supabase check.
+        const hashHasUpsell = params.get('upsell') === '1';
 
         // Strip hash from URL immediately — tokens must not linger in browser history.
         // Preserve query params (utm/deep-link context).
@@ -73,6 +78,7 @@ export const Login: React.FC<LoginProps> = ({ onLogin }) => {
             });
 
             if (!sessionError) {
+              if (hashHasUpsell) localStorage.setItem('mc_has_upsell', '1');
               onLogin();
               return;
             }


### PR DESCRIPTION
Fixes a bug where users who purchased the AI Companion upsell in the funnel arrived at the webapp with features locked.

Closes #79

## What changed

The funnel already tracked `State.data.hasUpsell = true` after a successful upsell purchase, but that signal was never forwarded to the webapp at redirect time. Since both domains are different origins, localStorage can't be shared — the only channel is the URL hash.

- **`funnel/engine/app.js`** — appends `&upsell=1` to the cross-origin redirect hash when `State.data.hasUpsell === true`
- **`webapp/components/Login.tsx`** — reads `upsell=1` from the hash and writes `mc_has_upsell` to localStorage (webapp origin) before calling `onLogin()`
- **`webapp/App.tsx`** — in `handleLogin()`, re-reads `mc_has_upsell` from localStorage and calls `setHasUpsellAccess(true)` if set (the lazy `useState` init ran at mount before the flag was written)

The existing `subscriptions` Supabase check + 8-second retry in `loadUserData` remain as validation fallback.

Smoke test runs automatically on push via Claude Code hook.