### PR TITLE
feat: add Meta Pixel tracking to funnel

### DIFF
--- a/funnel/engine/app.js
+++ b/funnel/engine/app.js
@@ -33,6 +33,47 @@ const log = {
 };
 
 // ========================================
+// Meta Pixel Event Tracker
+// ========================================
+const MetaPixel = {
+    // Intro prices per tier in USD — used to populate Purchase event value.
+    // Keep in sync with CURRENCY_DISPLAY in api/create-checkout.js.
+    _introPrices: { '7_day': 6.99, '1_month': 14.99, '3_month': 29.99 },
+
+    track(event, params) {
+        if (typeof fbq === 'function') fbq('track', event, params);
+    },
+
+    viewContent() {
+        this.track('ViewContent', { content_name: 'Paywall', content_type: 'product' });
+    },
+
+    lead(email) {
+        this.track('Lead', email ? { em: email } : undefined);
+    },
+
+    initiateCheckout(tierId, currency) {
+        const value = this._introPrices[tierId] || 14.99;
+        this.track('InitiateCheckout', {
+            value,
+            currency: (currency || 'USD').toUpperCase(),
+            content_ids: [tierId],
+            num_items: 1,
+        });
+    },
+
+    purchase(tierId, currency) {
+        const value = this._introPrices[tierId] || 14.99;
+        this.track('Purchase', {
+            value,
+            currency: (currency || 'USD').toUpperCase(),
+            content_ids: [tierId],
+            content_type: 'product',
+        });
+    },
+};
+
+// ========================================
 // Security Utilities
 // ========================================
 const Security = {
@@ -4776,6 +4817,9 @@ const Events = {
             const formInput = document.querySelector('.form-capture__input');
             if (formInput && formInput.value.trim()) {
                 State.recordAnswer(screenId, formInput.value.trim());
+                if (screenData.screenType === 'email_gate') {
+                    MetaPixel.lead(formInput.value.trim());
+                }
             } else {
                 log.warn(`[Events] Continue clicked but form input empty for ${screenId}`);
                 return;
@@ -5480,6 +5524,7 @@ const App = {
                     // Payment succeeded — store currency so the upsell screen can charge
                     // in the same currency without re-detecting.
                     State.set('checkoutCurrency', currency);
+                    MetaPixel.purchase(State.data.selectedTier, currency);
                     log.info('[Checkout] Payment confirmed — provisioning Supabase account');
 
                     // Fire-and-forget provision: create the auth user + profile immediately
@@ -5927,6 +5972,13 @@ const App = {
         // Bootstrap Stripe Payment Element after DOM is ready for checkout screen
         if ((screenData.screenType || screenData.type) === 'checkout') {
             this.initStripe(screenData);
+            MetaPixel.initiateCheckout(State.data.selectedTier, Currency.detect());
+        }
+
+        // Meta Pixel: fire ViewContent + AddToCart when the paywall first renders
+        if ((screenData.screenType || screenData.type) === 'payment') {
+            MetaPixel.viewContent();
+            MetaPixel.track('AddToCart', { content_type: 'product' });
         }
 
         // Attach direct listeners on upsell buttons — position:fixed elements on

--- a/funnel/funnel-v2/index.html
+++ b/funnel/funnel-v2/index.html
@@ -6,6 +6,23 @@
     <title>Mind Compass</title>
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="../engine/styles.css">
+    <!-- Meta Pixel -->
+    <script>
+    !function(f,b,e,v,n,t,s)
+    {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+    n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+    if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+    n.queue=[];t=b.createElement(e);t.async=!0;
+    t.src=v;s=b.getElementsByTagName(e)[0];
+    s.parentNode.insertBefore(t,s)}(window, document,'script',
+    'https://connect.facebook.net/en_US/fbevents.js');
+    fbq('init', '1530402652053089');
+    fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+    src="https://www.facebook.com/tr?id=1530402652053089&ev=PageView&noscript=1"
+    /></noscript>
+    <!-- End Meta Pixel -->
     <!-- High priority: landing screen gender cards -->
     <link rel="preload" as="image" href="../assets/good_mood_man.png?v=2026-05-04-resized" fetchpriority="high">
     <link rel="preload" as="image" href="../assets/good_mood_woman.png?v=2026-05-04-resized" fetchpriority="high">


### PR DESCRIPTION
Adds Meta Pixel (ID: 1530402652053089) browser-side tracking to the funnel with all key conversion events.

## Changes

- **`funnel-v2/index.html`** — base pixel code in `<head>` + noscript fallback, following Meta's placement guide
- **`engine/app.js`** — `MetaPixel` helper module with guarded `fbq()` calls:

| Event | When fired |
|-------|------------|
| `PageView` | Every page load (automatic via base code) |
| `ViewContent` | Paywall renders (user sees pricing) |
| `AddToCart` | Same — paywall render (plan selection intent) |
| `Lead` | Email gate form submitted |
| `InitiateCheckout` | Checkout screen renders (with tier + currency) |
| `Purchase` | After `stripe.confirmPayment()` succeeds (with value + currency) |

Smoke test runs automatically on push via Claude Code hook.