### PR TITLE
feat: deduplicate browser + CAPI Purchase events

### DIFF
--- a/funnel/api/webhook.js
+++ b/funnel/api/webhook.js
@@ -37,7 +37,7 @@ const PRICE_LABEL_MAP = {
 // event within seconds). Only fires on initial subscription purchases, not
 // renewals, to avoid inflating Meta's purchase count.
 // ---------------------------------------------------------------------------
-async function fireCapiPurchase({ email, amountCents, currency, contentId }) {
+async function fireCapiPurchase({ email, amountCents, currency, contentId, eventId }) {
     const pixelId = process.env.META_PIXEL_ID;
     const token   = process.env.META_CAPI_TOKEN;
     if (!pixelId || !token) return;
@@ -50,6 +50,9 @@ async function fireCapiPurchase({ email, amountCents, currency, contentId }) {
         data: [{
             event_name:       'Purchase',
             event_time:       Math.floor(Date.now() / 1000),
+            // event_id lets Meta deduplicate this server event against the
+            // matching browser pixel Purchase (same event_name + event_id).
+            ...(eventId && { event_id: eventId }),
             action_source:    'website',
             event_source_url: 'https://ai-dopamine-addict.vercel.app/funnel-v2/',
             user_data: {
@@ -196,6 +199,8 @@ export default async function handler(req, res) {
             amountCents: invoice.amount_paid,
             currency:    invoice.currency,
             contentId:   planLabel || priceId || 'subscription',
+            // Must match the browser eventID: `purchase_${subscriptionId}` (app.js).
+            eventId:     `purchase_${subscriptionId}`,
         });
     }
 
@@ -234,11 +239,14 @@ async function handleUpsellPayment(pi, res) {
         console.error('[webhook] Unexpected error in handleUpsellPayment:', err.message);
     }
 
+    // Upsell fires only server-side (no browser Purchase), so a unique
+    // event_id is enough to prevent double-counting on webhook retries.
     await fireCapiPurchase({
         email:       pi.metadata?.user_email,
         amountCents: pi.amount,
         currency:    pi.currency,
         contentId:   'ai_companion',
+        eventId:     `purchase_${pi.id}`,
     });
 
     return res.status(200).json({ received: true });

--- a/funnel/engine/app.js
+++ b/funnel/engine/app.js
@@ -46,8 +46,12 @@ const MetaPixel = {
         return parseFloat(raw.replace(/[^0-9.]/g, '')) || 14.99;
     },
 
-    track(event, params) {
-        if (typeof fbq === 'function') fbq('track', event, params);
+    // eventId (optional) sets fbq's eventID so this browser event can be
+    // deduplicated against the matching server-side CAPI event.
+    track(event, params, eventId) {
+        if (typeof fbq !== 'function') return;
+        if (eventId) fbq('track', event, params, { eventID: eventId });
+        else fbq('track', event, params);
     },
 
     viewContent() {
@@ -67,13 +71,16 @@ const MetaPixel = {
         });
     },
 
-    purchase(tierId, currency) {
+    // subscriptionId, when provided, produces a deterministic eventID shared
+    // with the server-side CAPI Purchase (webhook.js) so Meta dedupes the two.
+    purchase(tierId, currency, subscriptionId) {
+        const eventId = subscriptionId ? `purchase_${subscriptionId}` : undefined;
         this.track('Purchase', {
             value:        this._getValue(tierId, currency),
             currency:     (currency || 'USD').toUpperCase(),
             content_ids:  [tierId],
             content_type: 'product',
-        });
+        }, eventId);
     },
 };
 
@@ -5618,7 +5625,9 @@ const App = {
                     // Payment succeeded — store currency so the upsell screen can charge
                     // in the same currency without re-detecting.
                     State.set('checkoutCurrency', currency);
-                    MetaPixel.purchase(State.data.selectedTier, currency);
+                    // Pass subscriptionId so the browser Purchase shares an eventID
+                    // with the server CAPI Purchase (webhook.js) for deduplication.
+                    MetaPixel.purchase(State.data.selectedTier, currency, data.subscriptionId);
                     log.info('[Checkout] Payment confirmed — provisioning Supabase account');
 
                     // Fire-and-forget provision: create the auth user + profile immediately


### PR DESCRIPTION
## Why
Purchase fires from **both** the browser pixel and the server-side CAPI. With no shared `event_id`, Meta could only dedupe heuristically — likely inflating purchase counts once ads run. This adds a deterministic shared ID so Meta collapses the pair into one conversion.

## How dedup works
Meta dedupes two events when they share `event_name` **and** `event_id` (`eventID` on the browser, `event_id` on CAPI).

| Flow | Browser eventID | Server event_id | Shared? |
|------|-----------------|-----------------|---------|
| Subscription | `purchase_{subscriptionId}` | `purchase_{subscriptionId}` | ✅ dedupes |
| Upsell | *(no browser event)* | `purchase_{pi.id}` | server-only, guards webhook retries |

The subscription ID is the one key both sides reliably hold — browser gets it from the `create-checkout` response, server resolves it on `invoice.payment_succeeded`.

## Changes
- `MetaPixel.track()` — optional `eventId` → sets fbq `eventID`
- `MetaPixel.purchase(tierId, currency, subscriptionId)` — builds the deterministic id
- Checkout call site passes `data.subscriptionId`
- `fireCapiPurchase()` — optional `eventId` → sets `event_id` on the CAPI payload
- Both webhook handlers pass matching ids

## Safety
- If `subscriptionId` is missing browser-side, `eventID` is simply omitted (no regression).
- Server already returns early when it cannot resolve `subscriptionId`, so it never fires a mismatched event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)