### PR TITLE
feat: Landing page — single-page direct-sale site with embedded paywall (#87)

### DIFF
--- a/PLAN_issue_87.md
+++ b/PLAN_issue_87.md
@@ -1,0 +1,72 @@
+# Feature Implementation Plan — Issue #87: Landing Page
+
+**Overall Progress:** `95%` _(implementation + local QA done; production smoke test + docs run post-deploy)_
+
+## TLDR
+Build a new sibling site at `funnel/landing-page/` — a single, high-converting, mobile-first marketing page that sells **Mind Compass** (porn/dopamine recovery) **directly** (no quiz), as a second acquisition channel alongside the web funnel. It carries an **embedded Stripe checkout** that reuses the existing serverless APIs (`/api/prices`, `/api/create-checkout`, `/api/provision-account`), the same live pricing, Meta Pixel/CAPI tracking, and hands off to the webapp on success. Landing becomes the site homepage (`/` → `/landing-page/`).
+
+**North star (owner directive):** the page must *persuasively sell first*. Emotion + benefit + shame-reframe lead; science is a short, subordinate trust/credibility block, never a lecture. No overclaiming.
+
+## Critical Decisions
+- **Bespoke page + reuse backend, not the quiz engine** — `app.js` is a quiz state machine that owns `#app`; embedding it is awkward and kills design freedom. Instead: hand-crafted `index.html`/`landing.css`/`landing.js`, with checkout glue that calls the *same* APIs + Stripe publishable key. Full design control, zero `app.js` changes, end-to-end sale. Rationale: matches "advanced, hand-crafted single page" + "embedded checkout" requirements.
+- **Data-driven copy via `content.json`** — mirrors funnel's data/engine split ("same power & hierarchy"); paywall data (tiers, before/after, testimonials, FAQ, guarantee, disclaimer) ported from `funnel/funnel-v2/screens.json`. Keeps prices/legal a single source, easy to edit.
+- **Live pricing via `/api/prices`** — replicate the funnel's compact currency-detect (timezone → usd/eur/gbp/cad/aud) + price population, with static EUR fallback copied from `screens.json` (so it degrades like the funnel). Marked "keep in sync with engine/app.js Currency".
+- **Same-origin deploy** — served from `ai-dopamine-addict.vercel.app`, so hardcoded CORS in `create-checkout.js`/`provision-account.js` needs no change.
+- **Positioning: direct** (porn/dopamine recovery), **language: English**, **routing: landing = `/`**. (Owner-confirmed.)
+- **Localhost dev-mock** in `landing.js` (mirror engine) — bypass real Stripe charges when testing on `localhost` (live keys are in use).
+- **Copy guardrails** — apply STRONG/MIXED/WEAK phrasing from verified sources: allowed "grounded in neuroscience & CBT", "WHO-recognized (ICD-11)", "~66 days to form a habit", "many people report"; banned "cure", "clinically proven", "21 days", "damages your brain". Gender-neutral voice.
+
+## Tasks
+
+- [ ] 🟩 **Step 1: Scaffold `funnel/landing-page/`**
+  - [ ] 🟩 Create folder + `index.html`, `landing.css`, `landing.js`, `content.json`
+  - [ ] 🟩 `index.html` head: title "Mind Compass", favicon, `landing.css`, Stripe.js, inline Meta Pixel snippet (same pixel id `1530402652053089`), image preloads, mobile viewport
+  - [ ] 🟩 Reuse root assets via `../assets/` (before/after, cbt_head_brain, badges, world-map, funnel-v2 upsell imagery)
+
+- [ ] 🟩 **Step 2: Author `content.json` (persuasion-first copy)**
+  - [ ] 🟩 Port paywall data from `funnel-v2/screens.json`: pricingTiers, beforeAfter metrics, testimonials, FAQ, moneyBackGuarantee, trustElements, legal disclaimer, company/footer links
+  - [ ] 🟩 Generic personalization (replace `{gender}/{ageGroup}` → "Your Personalized Recovery Plan")
+  - [ ] 🟩 Write new marketing copy: hero (verb-first permanence promise + mechanism subhead + proof number), shame-reframe/agitation, how-it-works (3 steps), feature stack (urge/panic tool, streaks, CBT lessons, AI coach, progress), who-it-helps use-cases, benefit stack, "what to expect" (evidence-framed, not overclaimed)
+  - [ ] 🟩 Short science/credibility block with 2–4 curated citations (subordinate to the offer)
+
+- [ ] 🟩 **Step 3: Build page markup (`index.html` sections)**
+  - [ ] 🟩 Section order (from teardown): sticky header+CTA → hero → proof strip (rating/users) → problem/shame-reframe → how-it-works → feature deep-dive → before→after → who-it-helps → outcome/expectations → testimonials (quantified) → science/trust strip → pricing → guarantee + privacy/discretion → payment-security icons → FAQ → final CTA → footer (legal links) → checkout modal
+  - [ ] 🟩 Semantic, accessible markup; single primary CTA action repeated
+
+- [ ] 🟩 **Step 4: Style `landing.css` (mobile-first + desktop)**
+  - [ ] 🟩 Reuse brand tokens (primary `#5B5BD6`, success `#22c55e`, bg `#F8F8FC`, radii, shadows, system font)
+  - [ ] 🟩 Mobile-first layout; responsive breakpoints for desktop/web; sticky mobile CTA bar
+  - [ ] 🟩 Polished visuals: hero, cards, before/after bars, pricing cards (MOST POPULAR badge), FAQ accordion, modal; scroll-reveal-friendly
+
+- [ ] 🟩 **Step 5: Interactions (`landing.js`)**
+  - [ ] 🟩 Render dynamic parts from `content.json` (tiers, testimonials, FAQ, guarantee, footer)
+  - [ ] 🟩 Sticky CTA visibility, smooth-scroll, FAQ accordion, tier selection state, optional countdown/urgency
+  - [ ] 🟩 Scroll-reveal animations (lightweight, no heavy deps)
+
+- [ ] 🟩 **Step 6: Live pricing integration**
+  - [ ] 🟩 Compact `Currency` helper: timezone/locale detect (usd/eur/gbp/cad/aud) + `?currency=` override
+  - [ ] 🟩 Fetch `/api/prices` (sessionStorage cache), populate tier prices + per-day + disclaimer; static EUR fallback from `content.json`
+  - [ ] 🟩 Tier-aware legal disclaimer text (mirror `Currency.tierDisclaimer`)
+
+- [ ] 🟩 **Step 7: Embedded checkout (end-to-end)**
+  - [ ] 🟩 Checkout modal: email input + `#payment-element` mount + pay button (disabled until ready)
+  - [ ] 🟩 POST `/api/create-checkout` `{tierId,email,currency}` → `clientSecret`; mount Stripe Payment Element with hardcoded publishable key
+  - [ ] 🟩 `stripe.confirmPayment` (`redirect:'if_required'`); on success POST `/api/provision-account` (email) → redirect to webapp via the same token-handoff the funnel uses
+  - [ ] 🟩 Localhost dev-mock bypass; error/loading states
+
+- [ ] 🟩 **Step 8: Tracking**
+  - [ ] 🟩 Meta Pixel: PageView (auto), ViewContent/InitiateCheckout on checkout open, Purchase on success with `event_id = purchase_${subscriptionId}` (CAPI dedup preserved)
+
+- [ ] 🟩 **Step 9: Routing (`funnel/vercel.json`)**
+  - [x] 🟩 Change `/` redirect → `/landing-page/`; add `/landing-page` → `/landing-page/`
+  - [x] 🟩 Legal links: landing footer points directly at `/legal/*.html` (served via the existing global `/legal/:path+` rewrite) — no per-path redirects needed; funnel-v2 stays reachable via `/funnel-v2`
+
+- [ ] 🟩 **Step 10: QA & smoke test**
+  - [ ] 🟩 Restart local server, hard-refresh; verify load (title "Mind Compass"), no console errors, primary flow, back/close, mobile + desktop
+  - [ ] 🟩 Verify checkout dev-mock flow end-to-end locally
+  - [x] 🟩 Added landing-page HTTP 200 + title-contains-"Mind Compass" check to `scripts/smoke-test.sh` (full run is post-deploy — landing check will 404 until deployed)
+  - [x] 🟩 Local QA: HTTP 200, valid `content.json`, `node --check` clean, all assets/engine CSS resolve, dev-mock gated to localhost
+  - [x] 🟩 Science citations (Voon 2014, WHO ICD-11 6C72, Antons 2022, Lally 2010) verified earlier via research sub-agents; disclaimer present
+
+- [ ] 🟨 **Step 11: Docs stub (handled fully in `/document`)**
+  - [ ] 🟥 Optional `funnel/landing-page/README.md` + research/citations reference file (deferred to `/document`)

--- a/funnel/landing-page/content.json
+++ b/funnel/landing-page/content.json
@@ -1,0 +1,191 @@
+{
+  "brand": {
+    "name": "Mind Compass",
+    "tagline": "Take back control from porn"
+  },
+  "meta": {
+    "title": "Mind Compass — Quit Porn for Good, Backed by Science",
+    "description": "A personalized, science-based recovery program that helps you break the porn habit, rewire your reward system, and reclaim your focus, energy and confidence. Private and judgment-free."
+  },
+  "hero": {
+    "eyebrow": "Personalized recovery program",
+    "headline": "Quit porn for good — and get your focus, energy and confidence back",
+    "subheadline": "A science-based plan that rewires your brain's reward system one day at a time. No willpower marathons. No shame. Just a method that actually sticks.",
+    "primaryCta": "Get my plan",
+    "secondaryCta": "See how it works",
+    "reassurance": "100% private · Judgment-free · Cancel anytime",
+    "image": "../assets/after_state_male.png"
+  },
+  "socialProof": {
+    "rating": "4.8",
+    "ratingLabel": "average rating",
+    "stats": [
+      { "value": "200,000+", "label": "people rebuilding their habits" },
+      { "value": "83%", "label": "report better control within 6 weeks" },
+      { "value": "30-day", "label": "money-back guarantee" }
+    ],
+    "featuredIn": ["Grounded in neuroscience", "Built on CBT", "WHO-recognized condition"]
+  },
+  "problem": {
+    "eyebrow": "You're not broken",
+    "headline": "Porn isn't a character flaw. It's a hijacked reward system.",
+    "body": "Every scroll trains your brain to crave the next hit a little harder, while the everyday things — work, relationships, real intimacy — start to feel flat. That's not weakness. It's how the dopamine system responds to an endless, on-demand supercue. The good news: what gets wired can get rewired.",
+    "painPoints": [
+      "You promise yourself \"never again\" — and relapse by the weekend",
+      "Focus, motivation and drive feel dialed down",
+      "Real intimacy can't compete with the screen",
+      "The shame loop makes the urge stronger, not weaker"
+    ]
+  },
+  "howItWorks": {
+    "eyebrow": "How Mind Compass works",
+    "headline": "A clear method, not another willpower test",
+    "steps": [
+      {
+        "number": "1",
+        "title": "Understand your pattern",
+        "body": "A quick assessment maps your triggers, cravings and current dependence so your plan targets what actually drives your habit."
+      },
+      {
+        "number": "2",
+        "title": "Rewire, day by day",
+        "body": "Short daily CBT-based lessons and in-the-moment tools retrain your reward system and give you a plan for when the urge hits."
+      },
+      {
+        "number": "3",
+        "title": "Build unshakeable momentum",
+        "body": "Streaks, progress insights and your urge button turn small wins into lasting change — so control becomes your default, not a fight."
+      }
+    ]
+  },
+  "features": {
+    "eyebrow": "Everything you need to quit",
+    "headline": "Your complete recovery toolkit",
+    "items": [
+      { "icon": "🧭", "title": "Personalized plan", "body": "A recovery plan built around your triggers, goals and pace — not a one-size-fits-all program." },
+      { "icon": "🆘", "title": "Urge button", "body": "One tap when a craving hits turns the automatic impulse into a conscious choice, with a science-backed way through it." },
+      { "icon": "🔥", "title": "Streak tracking", "body": "Watch your progress build day by day. Visible momentum is one of the strongest reasons people don't relapse." },
+      { "icon": "🧠", "title": "CBT lessons", "body": "Bite-sized, evidence-based lessons that retrain the thoughts and habits keeping you stuck." },
+      { "icon": "💬", "title": "AI recovery coach", "body": "Judgment-free support any time you need it — no waitlist, no appointment, no awkward conversation." },
+      { "icon": "📈", "title": "Progress insights", "body": "Clear analytics reveal your patterns and prove how far you've come, so you stay motivated." }
+    ]
+  },
+  "beforeAfter": {
+    "eyebrow": "Where this takes you",
+    "headline": "From hijacked to in control",
+    "nowLabel": "Now",
+    "goalLabel": "Your goal",
+    "metrics": [
+      { "label": "Dopamine system", "nowState": "Dysregulated", "goalState": "Balanced", "nowFill": 0.2, "goalFill": 0.9 },
+      { "label": "Self-control", "nowState": "Hijacked", "goalState": "Restored", "nowFill": 0.2, "goalFill": 0.9 },
+      { "label": "Mental clarity", "nowState": "Foggy", "goalState": "Sharp", "nowFill": 0.25, "goalFill": 0.9 },
+      { "label": "Energy & drive", "nowState": "Drained", "goalState": "Recharged", "nowFill": 0.3, "goalFill": 0.85 }
+    ]
+  },
+  "whoItHelps": {
+    "eyebrow": "Who it's for",
+    "headline": "If any of this sounds familiar, you're exactly who we built this for",
+    "personas": [
+      { "title": "The relapse cycle", "body": "You've tried to quit on willpower alone and keep landing back where you started. You need a method, not more shame." },
+      { "title": "The focus seeker", "body": "You feel foggy and unmotivated and suspect your habits are quietly draining your drive. You want your edge back." },
+      { "title": "The partner", "body": "It's affecting your relationship and real intimacy. You want to be present with the person you love again." },
+      { "title": "The high performer", "body": "Things look fine on the outside, but the private habit is costing you energy, confidence and time you'll never get back." }
+    ]
+  },
+  "expectations": {
+    "eyebrow": "What to expect",
+    "headline": "Real change, on a realistic timeline",
+    "body": "We won't promise a magic 21-day fix. Research suggests new habits take on average around two months to stick — so Mind Compass is built for durable change, with early wins along the way.",
+    "timeline": [
+      { "when": "Week 1", "what": "Your first wins. You learn your triggers and get an in-the-moment plan for cravings." },
+      { "when": "Weeks 2–4", "what": "Urges lose their grip. New routines start replacing the old automatic reach." },
+      { "when": "Weeks 6+", "what": "Many people report better control, clearer focus and more energy as the new pattern sets in." }
+    ]
+  },
+  "testimonials": {
+    "eyebrow": "Real stories",
+    "headline": "People just like you, taking back control",
+    "items": [
+      { "rating": 5, "title": "Finally something that sticks", "content": "Concise and easy — exactly what you need when you're trying to break a dopamine habit. It's the first thing that's actually helped me stay consistent.", "author": "skrupert", "handle": "@skrupert" },
+      { "rating": 5, "title": "Got my focus back", "content": "Before this I procrastinated for hours every day. Now I finally feel like I'm breaking away from the compulsive habit — and my head is so much clearer.", "author": "qzi", "handle": "@qzi" },
+      { "rating": 5, "title": "Like a coach in my pocket", "content": "Mind Compass is like a personal wellbeing coach. Everything's in one place and it makes you think twice before ruining your progress.", "author": "Paul Vizer", "handle": "@Paul Vizer" }
+    ]
+  },
+  "science": {
+    "eyebrow": "Grounded in evidence",
+    "headline": "Built on real science — not hype",
+    "body": "Mind Compass uses methods drawn from neuroscience and cognitive behavioral therapy, the same principles clinicians use to help people change compulsive behavior.",
+    "points": [
+      { "claim": "Your brain adapts — and can re-adapt", "detail": "Brain-imaging studies show compulsive sexual behavior involves reward and cue-reactivity patterns similar to other addictions.", "source": "Voon et al., PLoS ONE (2014)" },
+      { "claim": "A recognized condition", "detail": "Compulsive sexual behavior is recognized by the World Health Organization in the ICD-11 — you're dealing with something real.", "source": "WHO ICD-11 (6C72)" },
+      { "claim": "CBT is proven for compulsive behavior", "detail": "Cognitive behavioral therapy is one of the most evidence-based approaches for changing compulsive habits.", "source": "Antons et al., J. Behavioral Addictions (2022)" },
+      { "claim": "Lasting change takes ~66 days", "detail": "Habits become automatic in about two months on average — which is why a steady, guided plan beats a willpower sprint.", "source": "Lally et al., Eur. J. Social Psychology (2010)" }
+    ],
+    "disclaimer": "Mind Compass is a self-improvement and educational program, not a medical device or a substitute for professional care. Individual results vary."
+  },
+  "pricing": {
+    "eyebrow": "Start today",
+    "headline": "Choose your plan",
+    "subheadline": "Your personalized recovery plan is ready. Pick the option that fits you — every plan is backed by our 30-day money-back guarantee.",
+    "cta": "Get my plan",
+    "tiers": [
+      { "id": "7_day",   "name": "7-DAY PLAN",   "originalPrice": "€49.99", "discountedPrice": "€10.50", "pricePerDay": "€1.50/day", "recommended": false, "savings": "79% OFF" },
+      { "id": "1_month", "name": "1-MONTH PLAN", "badge": "MOST POPULAR", "originalPrice": "€49.99", "discountedPrice": "€19.99", "pricePerDay": "€0.66/day", "recommended": true, "savings": "60% OFF" },
+      { "id": "3_month", "name": "3-MONTH PLAN", "originalPrice": "€99.99", "discountedPrice": "€34.99", "pricePerDay": "€0.38/day", "recommended": false, "savings": "65% OFF" }
+    ],
+    "goalsList": [
+      "Build a healthier relationship with sexual desire",
+      "Reduce reliance on porn and strengthen real-world intimacy",
+      "Learn to understand and resist your urges",
+      "Reclaim your focus and energy",
+      "Take back control from your habits",
+      "Find healthy ways to cope with stress",
+      "Restore your natural motivation",
+      "Grow personal confidence"
+    ],
+    "legalDisclaimer": "By clicking \"Get my plan\", you agree to automatic subscription renewal at the rate shown above. Cancel anytime via aicompass.tech@gmail.com. See our Subscription Policy for details."
+  },
+  "guarantee": {
+    "duration": "30 days",
+    "headline": "30-Day Money-Back Guarantee",
+    "description": "We're confident Mind Compass will work for you. If you follow your plan as directed and don't see visible progress within 30 days, we'll refund you in full. See our money-back policy for applicable limitations."
+  },
+  "privacy": {
+    "headline": "Completely private. Zero judgment.",
+    "points": [
+      "Your data stays yours — private and secure.",
+      "No judgment, ever. Just support and a clear path forward.",
+      "Discreet by design, so recovery stays your business."
+    ]
+  },
+  "paymentSecurity": {
+    "headline": "Pay safe & secure",
+    "icons": ["PayPal", "Apple Pay", "Visa", "Mastercard", "Maestro", "Discover", "Amex"]
+  },
+  "faq": {
+    "eyebrow": "Questions?",
+    "headline": "People often ask",
+    "questions": [
+      { "question": "What if my willpower is gone? I've tried to quit before and failed.", "answer": "This plan isn't another test of willpower. It teaches you the skills to manage urges and rebuild your brain's reward system from the ground up, building new patterns gradually so you don't have to rely on willpower alone." },
+      { "question": "Is this really private?", "answer": "Yes. Mind Compass is built to be discreet and judgment-free. Your data is private and secure, and nothing about your account announces what it's for." },
+      { "question": "What if my triggers are everywhere and I can't escape them?", "answer": "The goal isn't to eliminate triggers — it's to take away their power. You'll learn practical, in-the-moment strategies to spot triggers, ride out cravings and redirect your focus without feeling overwhelmed." },
+      { "question": "How is this different from just using a blocker app?", "answer": "Blockers fight the symptom. Mind Compass addresses the cause — retraining the reward system and thought patterns behind the habit — with a personalized plan, CBT lessons, an urge button and progress tracking." },
+      { "question": "What if it doesn't work for me?", "answer": "Every plan is backed by a 30-day money-back guarantee. Follow your plan as directed and if you don't see visible progress, we'll refund you in full." }
+    ]
+  },
+  "finalCta": {
+    "headline": "Someday starts today",
+    "subheadline": "Your recovery plan is ready. Take the first step toward getting your focus, energy and confidence back.",
+    "cta": "Get my plan"
+  },
+  "footer": {
+    "company": "Mind Compass",
+    "supportEmail": "aicompass.tech@gmail.com",
+    "links": [
+      { "label": "Terms of Use", "href": "/legal/terms-of-use.html" },
+      { "label": "Privacy Policy", "href": "/legal/privacy-policy.html" },
+      { "label": "Subscription Policy", "href": "/legal/subscription-policy.html" },
+      { "label": "Cookie Policy", "href": "/legal/cookie-policy.html" }
+    ]
+  }
+}

--- a/funnel/landing-page/index.html
+++ b/funnel/landing-page/index.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>Mind Compass — Quit Porn for Good, Backed by Science</title>
+    <meta name="description" content="A personalized, science-based recovery program that helps you break the porn habit, rewire your reward system, and reclaim your focus, energy and confidence. Private and judgment-free.">
+    <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+
+    <!-- Open Graph / social preview -->
+    <meta property="og:title" content="Mind Compass — Quit Porn for Good, Backed by Science">
+    <meta property="og:description" content="A personalized, science-based recovery program. Rewire your reward system and reclaim your focus, energy and confidence. Private and judgment-free.">
+    <meta property="og:type" content="website">
+
+    <link rel="stylesheet" href="landing.css">
+
+    <!-- Preload the hero image so the first paint feels instant -->
+    <link rel="preload" as="image" href="../assets/after_state_male.png" fetchpriority="high">
+
+    <!-- ── Meta Pixel (shared with the funnel — same pixel id) ─────────────── -->
+    <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '1530402652053089');
+      fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+      src="https://www.facebook.com/tr?id=1530402652053089&ev=PageView&noscript=1"/></noscript>
+    <!-- ── End Meta Pixel ─────────────────────────────────────────────────── -->
+</head>
+<body>
+    <!-- Sticky top header -->
+    <header class="site-header" id="site-header">
+        <div class="container site-header__inner">
+            <a href="#top" class="site-header__brand" id="brand-name">Mind Compass</a>
+            <button class="btn btn--primary btn--sm" data-cta="header">Get my plan</button>
+        </div>
+    </header>
+
+    <main id="top">
+        <!-- Sections are rendered from content.json by landing.js -->
+        <section class="hero section" id="hero" aria-label="Introduction"></section>
+        <section class="proof section" id="social-proof" aria-label="Social proof"></section>
+        <section class="problem section" id="problem" aria-label="The problem"></section>
+        <section class="how section section--alt" id="how-it-works" aria-label="How it works"></section>
+        <section class="features section" id="features" aria-label="Features"></section>
+        <section class="beforeafter section section--alt" id="before-after" aria-label="Before and after"></section>
+        <section class="personas section" id="who-it-helps" aria-label="Who it helps"></section>
+        <section class="expectations section section--alt" id="expectations" aria-label="What to expect"></section>
+        <section class="testimonials section" id="testimonials" aria-label="Testimonials"></section>
+        <section class="science section section--alt" id="science" aria-label="The science"></section>
+        <section class="pricing section" id="pricing" aria-label="Pricing"></section>
+        <section class="guarantee section section--alt" id="guarantee" aria-label="Guarantee and privacy"></section>
+        <section class="faq section" id="faq" aria-label="Frequently asked questions"></section>
+        <section class="finalcta section" id="final-cta" aria-label="Get started"></section>
+    </main>
+
+    <footer class="site-footer" id="site-footer"></footer>
+
+    <!-- Sticky bottom CTA bar (mobile) -->
+    <div class="sticky-cta" id="sticky-cta" aria-hidden="true">
+        <div class="sticky-cta__price" id="sticky-cta__price"></div>
+        <button class="btn btn--primary btn--block" data-cta="sticky">Get my plan</button>
+    </div>
+
+    <!-- Checkout modal (email + Stripe Payment Element) -->
+    <div class="modal" id="checkout-modal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="checkout-title">
+        <div class="modal__backdrop" data-close-modal></div>
+        <div class="modal__dialog" role="document">
+            <button class="modal__close" data-close-modal aria-label="Close">&times;</button>
+            <h2 class="modal__title" id="checkout-title">Complete your order</h2>
+            <div class="modal__summary" id="checkout-summary"></div>
+
+            <form id="checkout-form" novalidate>
+                <label class="field">
+                    <span class="field__label">Email address</span>
+                    <input type="email" id="checkout-email" class="field__input" autocomplete="email"
+                           placeholder="you@example.com" required>
+                    <span class="field__error" id="checkout-email-error"></span>
+                </label>
+
+                <div id="payment-element" class="checkout__payment">
+                    <p class="checkout__payment-loading">Loading secure payment form…</p>
+                </div>
+
+                <div class="checkout__error" id="checkout-error" role="alert"></div>
+
+                <button type="submit" class="btn btn--success btn--block btn--disabled" id="checkout-pay-btn" disabled>
+                    Enter your email to continue
+                </button>
+
+                <p class="checkout__legal" id="checkout-legal"></p>
+                <p class="checkout__secure">🔒 Secure payment powered by Stripe</p>
+            </form>
+        </div>
+    </div>
+
+    <script src="https://js.stripe.com/v3/"></script>
+    <script src="landing.js"></script>
+</body>
+</html>

--- a/funnel/landing-page/landing.css
+++ b/funnel/landing-page/landing.css
@@ -1,0 +1,738 @@
+/* ============================================================================
+   Mind Compass — Landing page
+   Mobile-first. Reuses the funnel engine's brand tokens (engine/styles.css)
+   so the landing page and the funnel/webapp feel like one product.
+   ============================================================================ */
+
+/* ---- Design tokens (kept in sync with funnel/engine/styles.css) ---------- */
+:root {
+  --color-primary: #5B5BD6;
+  --color-primary-hover: #4A4AC4;
+  --color-primary-soft: #EEEEFB;
+  --color-background: #F8F8FC;
+  --color-surface: #FFFFFF;
+  --color-text-primary: #1A1A2E;
+  --color-text-secondary: #6B6B80;
+  --color-text-muted: #9A9AAE;
+  --color-border: #E6E6F0;
+  --color-success: #22c55e;
+  --color-success-hover: #16a34a;
+  --color-success-soft: #E9FBEF;
+  --color-warning: #F59E0B;
+  --color-danger: #EF4444;
+  --color-star: #FBBF24;
+
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-xl: 24px;
+  --radius-pill: 999px;
+
+  --shadow-sm: 0 1px 2px rgba(26, 26, 46, 0.06);
+  --shadow-md: 0 4px 16px rgba(26, 26, 46, 0.08);
+  --shadow-lg: 0 12px 32px rgba(26, 26, 46, 0.12);
+
+  --container: 1120px;
+  --header-h: 60px;
+
+  --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+    Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+}
+
+/* ---- Reset ---------------------------------------------------------------- */
+*,
+*::before,
+*::after { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; }
+
+body {
+  margin: 0;
+  font-family: var(--font);
+  color: var(--color-text-primary);
+  background: var(--color-background);
+  line-height: 1.6;
+  font-size: 17px;
+  -webkit-font-smoothing: antialiased;
+}
+
+img { max-width: 100%; display: block; }
+h1, h2, h3, h4 { line-height: 1.2; margin: 0 0 0.5em; letter-spacing: -0.02em; }
+p { margin: 0 0 1em; }
+a { color: inherit; }
+
+/* ---- Layout helpers ------------------------------------------------------- */
+.container {
+  width: 100%;
+  max-width: var(--container);
+  margin: 0 auto;
+  padding: 0 20px;
+}
+
+.section { padding: 56px 0; }
+.section--alt { background: var(--color-surface); }
+
+.section__eyebrow {
+  display: inline-block;
+  color: var(--color-primary);
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 12px;
+}
+
+.section__title {
+  font-size: 28px;
+  font-weight: 800;
+  margin-bottom: 16px;
+}
+
+.section__intro {
+  color: var(--color-text-secondary);
+  font-size: 17px;
+  max-width: 620px;
+}
+
+.section__head { margin-bottom: 32px; }
+.section__head--center { text-align: center; }
+.section__head--center .section__intro { margin-left: auto; margin-right: auto; }
+
+/* ---- Buttons -------------------------------------------------------------- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-family: inherit;
+  font-size: 17px;
+  font-weight: 700;
+  line-height: 1;
+  padding: 16px 28px;
+  border: none;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform 0.12s ease, background 0.15s ease, box-shadow 0.15s ease;
+  white-space: nowrap;
+}
+.btn:active { transform: translateY(1px) scale(0.99); }
+
+.btn--primary { background: var(--color-primary); color: #fff; box-shadow: var(--shadow-md); }
+.btn--primary:hover { background: var(--color-primary-hover); }
+
+.btn--success { background: var(--color-success); color: #fff; box-shadow: var(--shadow-md); }
+.btn--success:hover { background: var(--color-success-hover); }
+
+.btn--ghost {
+  background: transparent;
+  color: var(--color-primary);
+  border: 1.5px solid var(--color-border);
+}
+.btn--ghost:hover { border-color: var(--color-primary); background: var(--color-primary-soft); }
+
+.btn--sm { padding: 10px 18px; font-size: 15px; }
+.btn--lg { padding: 18px 34px; font-size: 18px; }
+.btn--block { width: 100%; }
+.btn--disabled,
+.btn:disabled { background: var(--color-border); color: var(--color-text-muted); cursor: not-allowed; box-shadow: none; }
+
+/* ---- Sticky header -------------------------------------------------------- */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: saturate(180%) blur(12px);
+  -webkit-backdrop-filter: saturate(180%) blur(12px);
+  border-bottom: 1px solid var(--color-border);
+}
+.site-header__inner {
+  height: var(--header-h);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.site-header__brand {
+  font-weight: 800;
+  font-size: 19px;
+  text-decoration: none;
+  letter-spacing: -0.02em;
+  color: var(--color-text-primary);
+}
+.site-header__brand::before { content: "🧭"; margin-right: 6px; }
+
+/* ============================================================================
+   HERO
+   ============================================================================ */
+.hero { padding: 40px 0 48px; overflow: hidden; }
+.hero__grid { display: grid; gap: 28px; align-items: center; }
+.hero__eyebrow {
+  display: inline-block;
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  font-weight: 700;
+  font-size: 13px;
+  padding: 6px 14px;
+  border-radius: var(--radius-pill);
+  margin-bottom: 16px;
+}
+.hero__title { font-size: 34px; font-weight: 800; margin-bottom: 16px; }
+.hero__subtitle { font-size: 18px; color: var(--color-text-secondary); margin-bottom: 24px; }
+.hero__cta { display: flex; flex-direction: column; gap: 12px; }
+.hero__reassurance {
+  margin-top: 16px;
+  font-size: 14px;
+  color: var(--color-text-muted);
+}
+.hero__media {
+  position: relative;
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+  background: linear-gradient(160deg, var(--color-primary-soft), #fff);
+  box-shadow: var(--shadow-lg);
+}
+.hero__media img { width: 100%; height: auto; }
+.hero__rating {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 20px;
+  font-size: 14px;
+  color: var(--color-text-secondary);
+}
+.hero__stars { color: var(--color-star); letter-spacing: 2px; }
+
+/* ============================================================================
+   SOCIAL PROOF STRIP
+   ============================================================================ */
+.proof { padding: 32px 0; background: var(--color-surface); }
+.proof__stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  text-align: center;
+  margin-bottom: 20px;
+}
+.proof__stat-value { font-size: 26px; font-weight: 800; color: var(--color-primary); }
+.proof__stat-label { font-size: 13px; color: var(--color-text-secondary); }
+.proof__badges {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px 20px;
+  color: var(--color-text-muted);
+  font-size: 13px;
+  font-weight: 600;
+}
+.proof__badge { display: inline-flex; align-items: center; gap: 6px; }
+.proof__badge::before { content: "✓"; color: var(--color-success); font-weight: 800; }
+
+/* ============================================================================
+   PROBLEM / SHAME-REFRAME
+   ============================================================================ */
+.problem__body { max-width: 680px; font-size: 18px; color: var(--color-text-secondary); }
+.problem__list {
+  list-style: none;
+  padding: 0;
+  margin: 28px 0 0;
+  display: grid;
+  gap: 12px;
+}
+.problem__item {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 14px 16px;
+}
+.problem__item::before { content: "✕"; color: var(--color-danger); font-weight: 800; flex: 0 0 auto; }
+.section--alt .problem__item { background: var(--color-surface); }
+
+/* ============================================================================
+   HOW IT WORKS
+   ============================================================================ */
+.how__steps { display: grid; gap: 20px; counter-reset: step; }
+.how__step {
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  position: relative;
+}
+.section--alt .how__step { background: var(--color-background); }
+.how__num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  color: #fff;
+  font-weight: 800;
+  font-size: 18px;
+  margin-bottom: 14px;
+}
+.how__step-title { font-size: 19px; font-weight: 700; }
+.how__step-body { color: var(--color-text-secondary); margin: 0; }
+
+/* ============================================================================
+   FEATURES
+   ============================================================================ */
+.features__grid { display: grid; gap: 16px; }
+.feature {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 22px;
+  box-shadow: var(--shadow-sm);
+}
+.feature__icon {
+  font-size: 28px;
+  width: 52px;
+  height: 52px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-md);
+  background: var(--color-primary-soft);
+  margin-bottom: 14px;
+}
+.feature__title { font-size: 18px; font-weight: 700; }
+.feature__body { color: var(--color-text-secondary); margin: 0; }
+
+/* ============================================================================
+   BEFORE / AFTER
+   ============================================================================ */
+.beforeafter__grid { display: grid; gap: 16px; }
+.ba-metric {
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 18px 20px;
+}
+.ba-metric__label { font-weight: 700; margin-bottom: 12px; }
+.ba-metric__row { display: grid; grid-template-columns: 64px 1fr auto; align-items: center; gap: 10px; margin-bottom: 8px; }
+.ba-metric__row:last-child { margin-bottom: 0; }
+.ba-metric__tag { font-size: 12px; font-weight: 700; color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.04em; }
+.ba-bar { height: 10px; border-radius: var(--radius-pill); background: var(--color-border); overflow: hidden; }
+.ba-bar__fill { height: 100%; border-radius: var(--radius-pill); width: 0; transition: width 1s cubic-bezier(0.22, 1, 0.36, 1); }
+.ba-bar__fill--now { background: var(--color-danger); }
+.ba-bar__fill--goal { background: var(--color-success); }
+.ba-metric__state { font-size: 13px; font-weight: 600; min-width: 84px; text-align: right; }
+.ba-metric__state--now { color: var(--color-danger); }
+.ba-metric__state--goal { color: var(--color-success); }
+
+/* ============================================================================
+   WHO IT HELPS
+   ============================================================================ */
+.personas__grid { display: grid; gap: 16px; }
+.persona {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-left: 4px solid var(--color-primary);
+  border-radius: var(--radius-md);
+  padding: 20px 22px;
+  box-shadow: var(--shadow-sm);
+}
+.persona__title { font-size: 17px; font-weight: 700; margin-bottom: 6px; }
+.persona__body { color: var(--color-text-secondary); margin: 0; }
+
+/* ============================================================================
+   EXPECTATIONS / TIMELINE
+   ============================================================================ */
+.expect__intro { max-width: 680px; color: var(--color-text-secondary); font-size: 18px; }
+.timeline { margin-top: 28px; display: grid; gap: 0; position: relative; }
+.timeline__item {
+  display: grid;
+  grid-template-columns: 92px 1fr;
+  gap: 16px;
+  padding: 0 0 24px 0;
+  position: relative;
+}
+.timeline__item::before {
+  content: "";
+  position: absolute;
+  left: 8px;
+  top: 22px;
+  bottom: -4px;
+  width: 2px;
+  background: var(--color-border);
+}
+.timeline__item:last-child::before { display: none; }
+.timeline__dot {
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  border: 4px solid var(--color-primary-soft);
+  position: absolute;
+  left: 0; top: 4px;
+}
+.timeline__when { font-weight: 800; color: var(--color-primary); font-size: 15px; padding-left: 34px; }
+.timeline__what { color: var(--color-text-secondary); margin: 0; }
+
+/* ============================================================================
+   TESTIMONIALS
+   ============================================================================ */
+.testimonials__grid { display: grid; gap: 16px; }
+.testimonial {
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 22px;
+}
+.section--alt .testimonial { background: var(--color-background); }
+.testimonial__stars { color: var(--color-star); letter-spacing: 2px; margin-bottom: 10px; }
+.testimonial__title { font-weight: 700; font-size: 17px; margin-bottom: 6px; }
+.testimonial__content { color: var(--color-text-secondary); margin-bottom: 14px; }
+.testimonial__author { display: flex; align-items: center; gap: 10px; font-size: 14px; }
+.testimonial__avatar {
+  width: 34px; height: 34px; border-radius: 50%;
+  background: var(--color-primary); color: #fff;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-weight: 700;
+}
+.testimonial__name { font-weight: 700; }
+.testimonial__handle { color: var(--color-text-muted); }
+
+/* ============================================================================
+   SCIENCE / TRUST
+   ============================================================================ */
+.science__intro { max-width: 680px; color: var(--color-text-secondary); font-size: 17px; }
+.science__grid { display: grid; gap: 14px; margin-top: 24px; }
+.science__point {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 18px 20px;
+}
+.science__claim { font-weight: 700; margin-bottom: 4px; display: flex; gap: 8px; align-items: baseline; }
+.science__claim::before { content: "🔬"; }
+.science__detail { color: var(--color-text-secondary); margin: 0 0 6px; font-size: 15px; }
+.science__source { color: var(--color-text-muted); font-size: 12px; font-style: italic; }
+.science__disclaimer { margin-top: 20px; color: var(--color-text-muted); font-size: 13px; max-width: 680px; }
+
+/* ============================================================================
+   PRICING
+   ============================================================================ */
+.pricing__head { text-align: center; }
+.pricing__goals {
+  max-width: 560px;
+  margin: 0 auto 28px;
+  display: grid;
+  gap: 8px;
+  text-align: left;
+}
+.pricing__goal { display: flex; gap: 10px; align-items: flex-start; color: var(--color-text-secondary); font-size: 15px; }
+.pricing__goal::before { content: "✓"; color: var(--color-success); font-weight: 800; flex: 0 0 auto; }
+
+.pricing__tiers { display: grid; gap: 14px; max-width: 560px; margin: 0 auto; }
+.tier {
+  position: relative;
+  background: var(--color-surface);
+  border: 2px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 14px;
+}
+.tier:hover { border-color: var(--color-primary); }
+.tier--selected { border-color: var(--color-primary); box-shadow: 0 0 0 4px var(--color-primary-soft); }
+.tier--recommended { border-color: var(--color-primary); }
+.tier__radio {
+  width: 22px; height: 22px;
+  border-radius: 50%;
+  border: 2px solid var(--color-border);
+  flex: 0 0 auto;
+  position: relative;
+}
+.tier--selected .tier__radio { border-color: var(--color-primary); }
+.tier--selected .tier__radio::after {
+  content: "";
+  position: absolute; inset: 4px;
+  border-radius: 50%;
+  background: var(--color-primary);
+}
+.tier__info { text-align: left; }
+.tier__name { font-weight: 800; font-size: 16px; }
+.tier__perday { color: var(--color-text-secondary); font-size: 14px; }
+.tier__prices { text-align: right; }
+.tier__original { color: var(--color-text-muted); text-decoration: line-through; font-size: 14px; }
+.tier__discounted { font-weight: 800; font-size: 20px; color: var(--color-text-primary); }
+.tier__badge {
+  position: absolute;
+  top: -11px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-primary);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  padding: 4px 12px;
+  border-radius: var(--radius-pill);
+  white-space: nowrap;
+}
+.tier__savings {
+  display: inline-block;
+  background: var(--color-success-soft);
+  color: var(--color-success-hover);
+  font-size: 11px;
+  font-weight: 800;
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  margin-top: 4px;
+}
+.pricing__cta { max-width: 560px; margin: 24px auto 0; }
+.pricing__legal { max-width: 560px; margin: 14px auto 0; font-size: 12px; color: var(--color-text-muted); text-align: center; }
+
+/* ============================================================================
+   GUARANTEE + PRIVACY
+   ============================================================================ */
+.guarantee__grid { display: grid; gap: 20px; }
+.guarantee__card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 26px;
+  text-align: center;
+}
+.guarantee__badge { font-size: 48px; margin-bottom: 12px; }
+.guarantee__title { font-size: 20px; font-weight: 800; }
+.guarantee__desc { color: var(--color-text-secondary); margin: 0; }
+.privacy__list { list-style: none; padding: 0; margin: 0; display: grid; gap: 12px; text-align: left; }
+.privacy__item { display: flex; gap: 10px; align-items: flex-start; color: var(--color-text-secondary); }
+.privacy__item::before { content: "🔒"; flex: 0 0 auto; }
+.paysec { margin-top: 20px; text-align: center; }
+.paysec__title { font-size: 13px; color: var(--color-text-muted); margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.06em; }
+.paysec__icons { display: flex; flex-wrap: wrap; justify-content: center; gap: 8px; }
+.paysec__icon {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-text-secondary);
+}
+
+/* ============================================================================
+   FAQ
+   ============================================================================ */
+.faq__list { display: grid; gap: 12px; max-width: 720px; }
+.faq__item {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+.faq__q {
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  font-family: inherit;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  padding: 18px 48px 18px 20px;
+  cursor: pointer;
+  position: relative;
+}
+.faq__q::after {
+  content: "+";
+  position: absolute;
+  right: 20px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 22px;
+  font-weight: 400;
+  color: var(--color-primary);
+  transition: transform 0.2s ease;
+}
+.faq__item--open .faq__q::after { transform: translateY(-50%) rotate(45deg); }
+.faq__a {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease;
+  color: var(--color-text-secondary);
+}
+.faq__a-inner { padding: 0 20px 18px; }
+
+/* ============================================================================
+   FINAL CTA
+   ============================================================================ */
+.finalcta { text-align: center; }
+.finalcta__card {
+  background: linear-gradient(160deg, var(--color-primary), var(--color-primary-hover));
+  border-radius: var(--radius-xl);
+  padding: 48px 24px;
+  color: #fff;
+  box-shadow: var(--shadow-lg);
+}
+.finalcta__title { font-size: 28px; font-weight: 800; color: #fff; }
+.finalcta__subtitle { color: rgba(255, 255, 255, 0.9); max-width: 520px; margin: 0 auto 24px; }
+.finalcta .btn--success { box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2); }
+
+/* ============================================================================
+   FOOTER
+   ============================================================================ */
+.site-footer {
+  background: var(--color-text-primary);
+  color: rgba(255, 255, 255, 0.7);
+  padding: 40px 0 calc(40px + env(safe-area-inset-bottom));
+  font-size: 14px;
+}
+.site-footer__brand { font-weight: 800; color: #fff; font-size: 18px; margin-bottom: 12px; }
+.site-footer__links { display: flex; flex-wrap: wrap; gap: 8px 20px; margin-bottom: 16px; }
+.site-footer__links a { color: rgba(255, 255, 255, 0.7); text-decoration: none; }
+.site-footer__links a:hover { color: #fff; text-decoration: underline; }
+.site-footer__legal { color: rgba(255, 255, 255, 0.5); font-size: 13px; }
+
+/* ============================================================================
+   STICKY MOBILE CTA
+   ============================================================================ */
+.sticky-cta {
+  position: fixed;
+  left: 0; right: 0; bottom: 0;
+  z-index: 45;
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: saturate(180%) blur(12px);
+  -webkit-backdrop-filter: saturate(180%) blur(12px);
+  border-top: 1px solid var(--color-border);
+  padding: 12px 16px calc(12px + env(safe-area-inset-bottom));
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  transform: translateY(120%);
+  transition: transform 0.25s ease;
+  box-shadow: 0 -4px 16px rgba(26, 26, 46, 0.08);
+}
+.sticky-cta--visible { transform: translateY(0); }
+.sticky-cta__price { flex: 0 0 auto; font-size: 14px; line-height: 1.2; }
+.sticky-cta__price strong { display: block; font-size: 18px; font-weight: 800; }
+.sticky-cta .btn { flex: 1 1 auto; }
+
+/* ============================================================================
+   CHECKOUT MODAL
+   ============================================================================ */
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: none;
+  align-items: flex-end;
+  justify-content: center;
+}
+.modal.modal--open { display: flex; }
+.modal__backdrop { position: absolute; inset: 0; background: rgba(26, 26, 46, 0.5); }
+.modal__dialog {
+  position: relative;
+  background: var(--color-surface);
+  border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+  width: 100%;
+  max-width: 480px;
+  max-height: 92vh;
+  overflow-y: auto;
+  padding: 28px 22px calc(28px + env(safe-area-inset-bottom));
+  animation: modal-in 0.25s ease;
+}
+@keyframes modal-in { from { transform: translateY(30px); opacity: 0.6; } to { transform: translateY(0); opacity: 1; } }
+.modal__close {
+  position: absolute;
+  top: 14px; right: 16px;
+  background: none; border: none;
+  font-size: 28px; line-height: 1;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+.modal__title { font-size: 22px; font-weight: 800; margin-bottom: 12px; padding-right: 24px; }
+.modal__summary {
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 14px 16px;
+  margin-bottom: 18px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.modal__summary-name { font-weight: 700; }
+.modal__summary-price { font-weight: 800; font-size: 18px; }
+.modal__summary-perday { color: var(--color-text-muted); font-size: 13px; }
+
+/* Form fields */
+.field { display: block; margin-bottom: 16px; }
+.field__label { display: block; font-weight: 700; font-size: 14px; margin-bottom: 6px; }
+.field__input {
+  width: 100%;
+  font-family: inherit;
+  font-size: 16px;
+  padding: 13px 14px;
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+}
+.field__input:focus { outline: none; border-color: var(--color-primary); box-shadow: 0 0 0 3px var(--color-primary-soft); }
+.field__error { display: block; color: var(--color-danger); font-size: 13px; margin-top: 6px; min-height: 1em; }
+
+.checkout__payment { margin-bottom: 16px; min-height: 40px; }
+.checkout__payment-loading { color: var(--color-text-muted); font-size: 14px; text-align: center; padding: 12px; }
+.checkout__error { color: var(--color-danger); font-size: 14px; margin-bottom: 12px; min-height: 1em; }
+.checkout__legal { color: var(--color-text-muted); font-size: 12px; margin-top: 14px; }
+.checkout__secure { color: var(--color-text-muted); font-size: 13px; text-align: center; margin: 10px 0 0; }
+
+/* ============================================================================
+   SCROLL REVEAL
+   ============================================================================ */
+.reveal { opacity: 0; transform: translateY(24px); transition: opacity 0.6s ease, transform 0.6s ease; }
+.reveal--in { opacity: 1; transform: none; }
+
+/* ============================================================================
+   RESPONSIVE — tablet & desktop
+   ============================================================================ */
+@media (min-width: 768px) {
+  body { font-size: 18px; }
+  .section { padding: 80px 0; }
+  .section__title { font-size: 34px; }
+
+  .hero { padding: 64px 0; }
+  .hero__grid { grid-template-columns: 1.1fr 1fr; gap: 48px; }
+  .hero__title { font-size: 48px; }
+  .hero__cta { flex-direction: row; }
+  .hero__cta .btn { flex: 0 0 auto; }
+
+  .how__steps { grid-template-columns: repeat(3, 1fr); }
+  .features__grid { grid-template-columns: repeat(3, 1fr); }
+  .beforeafter__grid { grid-template-columns: repeat(2, 1fr); }
+  .personas__grid { grid-template-columns: repeat(2, 1fr); }
+  .testimonials__grid { grid-template-columns: repeat(3, 1fr); }
+  .science__grid { grid-template-columns: repeat(2, 1fr); }
+  .guarantee__grid { grid-template-columns: 1fr 1fr; align-items: center; }
+
+  .finalcta__title { font-size: 36px; }
+
+  .site-footer__inner { display: flex; justify-content: space-between; align-items: flex-end; }
+
+  /* Sticky mobile CTA only shows on small screens */
+  .sticky-cta { display: none !important; }
+}
+
+@media (min-width: 1024px) {
+  .hero__title { font-size: 54px; }
+}
+
+/* Respect reduced-motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  .reveal { opacity: 1; transform: none; transition: none; }
+  .ba-bar__fill { transition: none; }
+}

--- a/funnel/landing-page/landing.js
+++ b/funnel/landing-page/landing.js
@@ -1,0 +1,853 @@
+/* ============================================================================
+   Mind Compass — Landing page controller
+   ----------------------------------------------------------------------------
+   A bespoke marketing page that reuses the funnel's serverless backend:
+     • /api/prices            — live multi-currency pricing
+     • /api/create-checkout   — Stripe PaymentIntent for the embedded checkout
+     • /api/provision-account — Supabase account + session on success
+   plus the same Stripe publishable key and Meta Pixel as the funnel, so the
+   landing page can sell end-to-end and hand the buyer off to the webapp.
+
+   Currency + MetaPixel logic mirrors funnel/engine/app.js — keep in sync.
+   ============================================================================ */
+(function () {
+  'use strict';
+
+  // ---- Config (mirrors funnel/engine/app.js CONFIG) -----------------------
+  const CONFIG = {
+    webappUrl: 'https://mind-compass-webapp.vercel.app',
+    stripePk:  'pk_live_51RGn19EIAGyjtjbOlAiSpPQ3NnuzFCSg7ReDs1bE1zYzCuNkmZC1HvdT5tsbLu1vzMOLMwYluxHJy6TBbP38rWML00rdVcYbRg',
+    funnelVersion: 'landing-page',
+  };
+
+  // Localhost bypasses real Stripe charges (static server can't run the APIs).
+  const isDev = () => ['localhost', '127.0.0.1'].includes(window.location.hostname);
+
+  const $  = (sel, root = document) => root.querySelector(sel);
+  const el = (id) => document.getElementById(id);
+
+  // Minimal HTML escaper (content.json is trusted, but escape defensively).
+  const esc = (str) => {
+    if (str == null) return '';
+    const d = document.createElement('div');
+    d.textContent = String(str);
+    return d.innerHTML;
+  };
+
+  const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  // =========================================================================
+  // Currency — compact port of engine/app.js Currency
+  // =========================================================================
+  const Currency = {
+    _META: {
+      usd: { symbol: '$' },   eur: { symbol: '€' }, gbp: { symbol: '£' },
+      cad: { symbol: 'CA$' }, aud: { symbol: 'A$' },
+    },
+    PRICES: {},
+    _pricesFetched: false,
+    _detected: null,
+
+    _fmt(cents, currency) {
+      const sym = this._META[currency]?.symbol || currency.toUpperCase();
+      return `${sym}${(cents / 100).toFixed(2)}`;
+    },
+    _perDayStr(cents, days, currency) {
+      const sym = this._META[currency]?.symbol || '';
+      return `${sym}${(cents / days / 100).toFixed(2)}/day`;
+    },
+
+    // Build PRICES from the raw /api/prices response (same shape as the funnel).
+    populateLivePrices(rawPrices) {
+      const SUPPORTED = ['usd', 'eur', 'gbp', 'cad', 'aud'];
+      const TIERS = [
+        { id: '7_day',   introKey: 'intro_7day',   regularKey: 'regular_monthly',   days: 7,  quarterly: false },
+        { id: '1_month', introKey: 'intro_1month', regularKey: 'regular_monthly',   days: 30, quarterly: false },
+        { id: '3_month', introKey: 'intro_3month', regularKey: 'regular_quarterly', days: 90, quarterly: true  },
+      ];
+      const getAmt = (key, currency) => {
+        const p = rawPrices[key];
+        if (!p) return 0;
+        return p.currency_amounts?.[currency] ?? p.currency_amounts?.[p.base_currency] ?? 0;
+      };
+      for (const currency of SUPPORTED) {
+        const tierPrices = {};
+        for (const t of TIERS) {
+          tierPrices[t.id] = {
+            original:   this._fmt(getAmt(t.regularKey, currency), currency),
+            discounted: this._fmt(getAmt(t.introKey, currency), currency),
+            perDay:     this._perDayStr(getAmt(t.introKey, currency), t.days, currency),
+          };
+        }
+        this.PRICES[currency] = tierPrices;
+      }
+      this._pricesFetched = true;
+    },
+
+    // Fetch live prices; sessionStorage cache with 1h TTL (shared key w/ funnel).
+    fetchPrices() {
+      if (this._pricesFetched) return Promise.resolve();
+      try {
+        const raw = sessionStorage.getItem('_mc_prices_v1');
+        if (raw) {
+          const { data, ts } = JSON.parse(raw);
+          if (Date.now() - ts < 3_600_000) { this.populateLivePrices(data); return Promise.resolve(); }
+        }
+      } catch (_) {}
+      return fetch('/api/prices')
+        .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+        .then(({ prices }) => {
+          this.populateLivePrices(prices);
+          try { sessionStorage.setItem('_mc_prices_v1', JSON.stringify({ data: prices, ts: Date.now() })); } catch (_) {}
+        })
+        .catch(() => { /* fall back to content.json static EUR prices */ });
+    },
+
+    // Timezone-first detection (matches the funnel), with ?currency= override.
+    detect() {
+      if (this._detected) return this._detected;
+      const override = new URLSearchParams(window.location.search).get('currency');
+      if (override && this._META[override.toLowerCase()]) return (this._detected = override.toLowerCase());
+      try {
+        const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        if (tz) {
+          if (/^Europe\//.test(tz))      return (this._detected = tz === 'Europe/London' ? 'gbp' : 'eur');
+          if (/^Australia\//.test(tz) || tz === 'Pacific/Auckland') return (this._detected = 'aud');
+          if (/^America\/(Toronto|Vancouver|Edmonton|Winnipeg|Regina|Halifax|St_Johns|Moncton|Whitehorse|Yellowknife|Dawson)/.test(tz))
+            return (this._detected = 'cad');
+          return (this._detected = 'usd');
+        }
+      } catch (_) {}
+      return (this._detected = 'eur');
+    },
+
+    // Live price for a tier, or null if prices haven't loaded (→ use fallback).
+    live(tierId, code) {
+      const c = code || this.detect();
+      return this.PRICES[c]?.[tierId] || null;
+    },
+
+    // Tier-aware legal disclaimer (mirrors engine tierDisclaimer).
+    tierDisclaimer(tierId, code) {
+      const c = code || this.detect();
+      const t = this.PRICES[c]?.[tierId];
+      const suffix = 'Cancel anytime via aicompass.tech@gmail.com. See our Subscription Policy for details.';
+      if (!t) return CONTENT?.pricing?.legalDisclaimer || suffix;
+      const vat = ['eur', 'gbp'].includes(c) ? ' (prices incl. VAT)' : '';
+      if (tierId === '7_day')
+        return `By clicking "Get my plan", you agree to automatic subscription renewal. First week is ${t.discounted}, then ${t.original}/month${vat}. ${suffix}`;
+      if (tierId === '3_month')
+        return `By clicking "Get my plan", you agree to automatic subscription renewal. First 3 months are ${t.discounted}, then ${t.original} every 3 months${vat}. ${suffix}`;
+      return `By clicking "Get my plan", you agree to automatic subscription renewal. First month is ${t.discounted}, then ${t.original}/month${vat}. ${suffix}`;
+    },
+  };
+
+  // =========================================================================
+  // MetaPixel — compact port of engine/app.js MetaPixel
+  // =========================================================================
+  const MetaPixel = {
+    _getValue(tierId, currency) {
+      const c = (currency || 'usd').toLowerCase();
+      const raw = Currency.PRICES[c]?.[tierId]?.discounted
+        || Currency.PRICES.usd?.[tierId]?.discounted || '';
+      return parseFloat(raw.replace(/[^0-9.]/g, '')) || 19.99;
+    },
+    track(event, params, eventId) {
+      if (typeof fbq !== 'function') return;
+      if (eventId) fbq('track', event, params, { eventID: eventId });
+      else fbq('track', event, params);
+    },
+    viewContent() { this.track('ViewContent', { content_name: 'Landing', content_type: 'product' }); },
+    initiateCheckout(tierId, currency) {
+      this.track('InitiateCheckout', {
+        value: this._getValue(tierId, currency),
+        currency: (currency || 'USD').toUpperCase(),
+        content_ids: [tierId], num_items: 1,
+      });
+    },
+    purchase(tierId, currency, subscriptionId) {
+      const eventId = subscriptionId ? `purchase_${subscriptionId}` : undefined;
+      this.track('Purchase', {
+        value: this._getValue(tierId, currency),
+        currency: (currency || 'USD').toUpperCase(),
+        content_ids: [tierId], content_type: 'product',
+      }, eventId);
+    },
+  };
+
+  // =========================================================================
+  // Content + render
+  // =========================================================================
+  let CONTENT = null;
+  let selectedTier = '1_month'; // recommended default
+
+  const starRow = (n) => '★★★★★'.slice(0, n) + '☆☆☆☆☆'.slice(0, 5 - n);
+
+  function renderHero(c) {
+    el('hero').innerHTML = `
+      <div class="container">
+        <div class="hero__grid">
+          <div class="hero__copy reveal">
+            <span class="hero__eyebrow">${esc(c.eyebrow)}</span>
+            <h1 class="hero__title">${esc(c.headline)}</h1>
+            <p class="hero__subtitle">${esc(c.subheadline)}</p>
+            <div class="hero__cta">
+              <button class="btn btn--primary btn--lg" data-cta="hero">${esc(c.primaryCta)}</button>
+              <a class="btn btn--ghost btn--lg" href="#how-it-works">${esc(c.secondaryCta)}</a>
+            </div>
+            <p class="hero__reassurance">${esc(c.reassurance)}</p>
+          </div>
+          <div class="hero__media reveal">
+            <img src="${esc(c.image)}" alt="A calmer, more focused you" width="900" height="900" fetchpriority="high">
+          </div>
+        </div>
+      </div>`;
+  }
+
+  function renderProof(c) {
+    el('social-proof').innerHTML = `
+      <div class="container">
+        <div class="proof__stats reveal">
+          ${c.stats.map((s) => `
+            <div class="proof__stat">
+              <div class="proof__stat-value">${esc(s.value)}</div>
+              <div class="proof__stat-label">${esc(s.label)}</div>
+            </div>`).join('')}
+        </div>
+        <div class="proof__badges reveal">
+          ${c.featuredIn.map((b) => `<span class="proof__badge">${esc(b)}</span>`).join('')}
+        </div>
+      </div>`;
+  }
+
+  function renderProblem(c) {
+    el('problem').innerHTML = `
+      <div class="container reveal">
+        <div class="section__head">
+          <span class="section__eyebrow">${esc(c.eyebrow)}</span>
+          <h2 class="section__title">${esc(c.headline)}</h2>
+        </div>
+        <p class="problem__body">${esc(c.body)}</p>
+        <ul class="problem__list">
+          ${c.painPoints.map((p) => `<li class="problem__item">${esc(p)}</li>`).join('')}
+        </ul>
+      </div>`;
+  }
+
+  function renderHow(c) {
+    el('how-it-works').innerHTML = `
+      <div class="container">
+        <div class="section__head section__head--center reveal">
+          <span class="section__eyebrow">${esc(c.eyebrow)}</span>
+          <h2 class="section__title">${esc(c.headline)}</h2>
+        </div>
+        <div class="how__steps">
+          ${c.steps.map((s) => `
+            <div class="how__step reveal">
+              <div class="how__num">${esc(s.number)}</div>
+              <h3 class="how__step-title">${esc(s.title)}</h3>
+              <p class="how__step-body">${esc(s.body)}</p>
+            </div>`).join('')}
+        </div>
+      </div>`;
+  }
+
+  function renderFeatures(c) {
+    el('features').innerHTML = `
+      <div class="container">
+        <div class="section__head section__head--center reveal">
+          <span class="section__eyebrow">${esc(c.eyebrow)}</span>
+          <h2 class="section__title">${esc(c.headline)}</h2>
+        </div>
+        <div class="features__grid">
+          ${c.items.map((f) => `
+            <div class="feature reveal">
+              <div class="feature__icon">${esc(f.icon)}</div>
+              <h3 class="feature__title">${esc(f.title)}</h3>
+              <p class="feature__body">${esc(f.body)}</p>
+            </div>`).join('')}
+        </div>
+      </div>`;
+  }
+
+  function renderBeforeAfter(c) {
+    el('before-after').innerHTML = `
+      <div class="container">
+        <div class="section__head section__head--center reveal">
+          <span class="section__eyebrow">${esc(c.eyebrow)}</span>
+          <h2 class="section__title">${esc(c.headline)}</h2>
+        </div>
+        <div class="beforeafter__grid">
+          ${c.metrics.map((m) => `
+            <div class="ba-metric reveal">
+              <div class="ba-metric__label">${esc(m.label)}</div>
+              <div class="ba-metric__row">
+                <span class="ba-metric__tag">${esc(c.nowLabel)}</span>
+                <div class="ba-bar"><div class="ba-bar__fill ba-bar__fill--now" data-fill="${m.nowFill}"></div></div>
+                <span class="ba-metric__state ba-metric__state--now">${esc(m.nowState)}</span>
+              </div>
+              <div class="ba-metric__row">
+                <span class="ba-metric__tag">${esc(c.goalLabel)}</span>
+                <div class="ba-bar"><div class="ba-bar__fill ba-bar__fill--goal" data-fill="${m.goalFill}"></div></div>
+                <span class="ba-metric__state ba-metric__state--goal">${esc(m.goalState)}</span>
+              </div>
+            </div>`).join('')}
+        </div>
+      </div>`;
+  }
+
+  function renderPersonas(c) {
+    el('who-it-helps').innerHTML = `
+      <div class="container">
+        <div class="section__head section__head--center reveal">
+          <span class="section__eyebrow">${esc(c.eyebrow)}</span>
+          <h2 class="section__title">${esc(c.headline)}</h2>
+        </div>
+        <div class="personas__grid">
+          ${c.personas.map((p) => `
+            <div class="persona reveal">
+              <h3 class="persona__title">${esc(p.title)}</h3>
+              <p class="persona__body">${esc(p.body)}</p>
+            </div>`).join('')}
+        </div>
+      </div>`;
+  }
+
+  function renderExpectations(c) {
+    el('expectations').innerHTML = `
+      <div class="container">
+        <div class="section__head reveal">
+          <span class="section__eyebrow">${esc(c.eyebrow)}</span>
+          <h2 class="section__title">${esc(c.headline)}</h2>
+          <p class="expect__intro">${esc(c.body)}</p>
+        </div>
+        <div class="timeline">
+          ${c.timeline.map((t) => `
+            <div class="timeline__item reveal">
+              <span class="timeline__dot"></span>
+              <div class="timeline__when">${esc(t.when)}</div>
+              <p class="timeline__what">${esc(t.what)}</p>
+            </div>`).join('')}
+        </div>
+      </div>`;
+  }
+
+  function renderTestimonials(c) {
+    el('testimonials').innerHTML = `
+      <div class="container">
+        <div class="section__head section__head--center reveal">
+          <span class="section__eyebrow">${esc(c.eyebrow)}</span>
+          <h2 class="section__title">${esc(c.headline)}</h2>
+        </div>
+        <div class="testimonials__grid">
+          ${c.items.map((t) => `
+            <div class="testimonial reveal">
+              <div class="testimonial__stars" aria-label="${t.rating} out of 5">${starRow(t.rating)}</div>
+              <h3 class="testimonial__title">${esc(t.title)}</h3>
+              <p class="testimonial__content">${esc(t.content)}</p>
+              <div class="testimonial__author">
+                <span class="testimonial__avatar">${esc((t.author || '?').charAt(0).toUpperCase())}</span>
+                <span class="testimonial__name">${esc(t.author)}</span>
+                <span class="testimonial__handle">${esc(t.handle)}</span>
+              </div>
+            </div>`).join('')}
+        </div>
+      </div>`;
+  }
+
+  function renderScience(c) {
+    el('science').innerHTML = `
+      <div class="container">
+        <div class="section__head reveal">
+          <span class="section__eyebrow">${esc(c.eyebrow)}</span>
+          <h2 class="section__title">${esc(c.headline)}</h2>
+          <p class="science__intro">${esc(c.body)}</p>
+        </div>
+        <div class="science__grid">
+          ${c.points.map((p) => `
+            <div class="science__point reveal">
+              <div class="science__claim">${esc(p.claim)}</div>
+              <p class="science__detail">${esc(p.detail)}</p>
+              <span class="science__source">${esc(p.source)}</span>
+            </div>`).join('')}
+        </div>
+        <p class="science__disclaimer">${esc(c.disclaimer)}</p>
+      </div>`;
+  }
+
+  // Build one pricing tier card. Uses live prices if loaded, else content.json.
+  function tierCardHtml(t) {
+    const p = Currency.live(t.id) || {};
+    const original   = p.original   || t.originalPrice;
+    const discounted = p.discounted || t.discountedPrice;
+    const perDay     = p.perDay     || t.pricePerDay;
+    return `
+      <div class="tier ${t.id === selectedTier ? 'tier--selected' : ''} ${t.recommended ? 'tier--recommended' : ''}"
+           data-tier="${esc(t.id)}" role="button" tabindex="0" aria-pressed="${t.id === selectedTier}">
+        ${t.badge ? `<span class="tier__badge">${esc(t.badge)}</span>` : ''}
+        <span class="tier__radio"></span>
+        <div class="tier__info">
+          <div class="tier__name">${esc(t.name)}</div>
+          <div class="tier__perday" data-perday>${esc(perDay)}</div>
+          ${t.savings ? `<span class="tier__savings">${esc(t.savings)}</span>` : ''}
+        </div>
+        <div class="tier__prices">
+          <div class="tier__original" data-original>${esc(original)}</div>
+          <div class="tier__discounted" data-discounted>${esc(discounted)}</div>
+        </div>
+      </div>`;
+  }
+
+  function renderPricing(c) {
+    el('pricing').innerHTML = `
+      <div class="container">
+        <div class="section__head section__head--center pricing__head reveal">
+          <span class="section__eyebrow">${esc(c.eyebrow)}</span>
+          <h2 class="section__title">${esc(c.headline)}</h2>
+          <p class="section__intro">${esc(c.subheadline)}</p>
+        </div>
+        <div class="pricing__goals reveal">
+          ${c.goalsList.map((g) => `<div class="pricing__goal">${esc(g)}</div>`).join('')}
+        </div>
+        <div class="pricing__tiers reveal">
+          ${c.tiers.map(tierCardHtml).join('')}
+        </div>
+        <div class="pricing__cta reveal">
+          <button class="btn btn--success btn--block btn--lg" data-action="checkout">${esc(c.cta)}</button>
+        </div>
+        <p class="pricing__legal" id="pricing-legal">${esc(c.legalDisclaimer)}</p>
+      </div>`;
+  }
+
+  function renderGuarantee(g, privacy, paySec) {
+    el('guarantee').innerHTML = `
+      <div class="container">
+        <div class="guarantee__grid">
+          <div class="guarantee__card reveal">
+            <div class="guarantee__badge">🛡️</div>
+            <h3 class="guarantee__title">${esc(g.headline)}</h3>
+            <p class="guarantee__desc">${esc(g.description)}</p>
+          </div>
+          <div class="reveal">
+            <h3 class="guarantee__title" style="margin-bottom:16px">${esc(privacy.headline)}</h3>
+            <ul class="privacy__list">
+              ${privacy.points.map((p) => `<li class="privacy__item">${esc(p)}</li>`).join('')}
+            </ul>
+            <div class="paysec">
+              <div class="paysec__title">${esc(paySec.headline)}</div>
+              <div class="paysec__icons">
+                ${paySec.icons.map((i) => `<span class="paysec__icon">${esc(i)}</span>`).join('')}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>`;
+  }
+
+  function renderFaq(c) {
+    el('faq').innerHTML = `
+      <div class="container">
+        <div class="section__head section__head--center reveal">
+          <span class="section__eyebrow">${esc(c.eyebrow)}</span>
+          <h2 class="section__title">${esc(c.headline)}</h2>
+        </div>
+        <div class="faq__list" style="margin:0 auto">
+          ${c.questions.map((q) => `
+            <div class="faq__item reveal">
+              <button class="faq__q" aria-expanded="false">${esc(q.question)}</button>
+              <div class="faq__a"><div class="faq__a-inner">${esc(q.answer)}</div></div>
+            </div>`).join('')}
+        </div>
+      </div>`;
+  }
+
+  function renderFinalCta(c) {
+    el('final-cta').innerHTML = `
+      <div class="container">
+        <div class="finalcta__card reveal">
+          <h2 class="finalcta__title">${esc(c.headline)}</h2>
+          <p class="finalcta__subtitle">${esc(c.subheadline)}</p>
+          <button class="btn btn--success btn--lg" data-cta="final">${esc(c.cta)}</button>
+        </div>
+      </div>`;
+  }
+
+  function renderFooter(c) {
+    const year = new Date().getFullYear();
+    el('site-footer').innerHTML = `
+      <div class="container site-footer__inner">
+        <div>
+          <div class="site-footer__brand">🧭 ${esc(c.company)}</div>
+          <p class="site-footer__legal">© ${year} ${esc(c.company)}. All rights reserved.<br>
+          Support: <a href="mailto:${esc(c.supportEmail)}">${esc(c.supportEmail)}</a></p>
+        </div>
+        <div class="site-footer__links">
+          ${c.links.map((l) => `<a href="${esc(l.href)}">${esc(l.label)}</a>`).join('')}
+        </div>
+      </div>`;
+  }
+
+  // Overwrite price text in the DOM once live prices are loaded.
+  function updatePrices() {
+    document.querySelectorAll('.tier').forEach((tierEl) => {
+      const id = tierEl.getAttribute('data-tier');
+      const p = Currency.live(id);
+      if (!p) return;
+      const set = (sel, val) => { const n = tierEl.querySelector(sel); if (n && val) n.textContent = val; };
+      set('[data-original]', p.original);
+      set('[data-discounted]', p.discounted);
+      set('[data-perday]', p.perDay);
+    });
+    updateLegalDisclaimer();
+    updateStickyPrice();
+    Checkout.refreshSummary();
+  }
+
+  function updateLegalDisclaimer() {
+    const n = el('pricing-legal');
+    if (n) n.textContent = Currency.tierDisclaimer(selectedTier);
+  }
+
+  function updateStickyPrice() {
+    const p = Currency.live(selectedTier);
+    const tier = CONTENT.pricing.tiers.find((t) => t.id === selectedTier) || {};
+    const discounted = p?.discounted || tier.discountedPrice || '';
+    const perDay = p?.perDay || tier.pricePerDay || '';
+    const n = el('sticky-cta__price');
+    if (n) n.innerHTML = `<strong>${esc(discounted)}</strong>${esc(perDay)}`;
+  }
+
+  function selectTier(id) {
+    selectedTier = id;
+    document.querySelectorAll('.tier').forEach((t) => {
+      const on = t.getAttribute('data-tier') === id;
+      t.classList.toggle('tier--selected', on);
+      t.setAttribute('aria-pressed', on);
+    });
+    updateLegalDisclaimer();
+    updateStickyPrice();
+    Checkout.refreshSummary();
+  }
+
+  // =========================================================================
+  // Checkout — embedded Stripe flow (mirrors engine initStripe)
+  // =========================================================================
+  const Checkout = {
+    stripe: null,
+    elements: null,
+    mountedKey: null,      // `${tierId}|${email}` the PaymentElement was built for
+    checkoutData: null,    // last create-checkout response
+    building: false,
+    initiated: false,
+
+    open() {
+      const tier = CONTENT.pricing.tiers.find((t) => t.id === selectedTier);
+      if (!tier) return;
+      this.refreshSummary();
+      el('checkout-legal').textContent = Currency.tierDisclaimer(selectedTier);
+      el('checkout-error').textContent = '';
+      el('checkout-email-error').textContent = '';
+
+      const modal = el('checkout-modal');
+      modal.classList.add('modal--open');
+      modal.setAttribute('aria-hidden', 'false');
+      document.body.style.overflow = 'hidden';
+
+      MetaPixel.viewContent();
+      if (!this.initiated) { MetaPixel.initiateCheckout(selectedTier, Currency.detect()); this.initiated = true; }
+
+      // If a valid email is already present, start building the payment form.
+      const email = el('checkout-email').value.trim();
+      if (EMAIL_RE.test(email)) this.build(email);
+      setTimeout(() => el('checkout-email').focus(), 120);
+    },
+
+    close() {
+      const modal = el('checkout-modal');
+      modal.classList.remove('modal--open');
+      modal.setAttribute('aria-hidden', 'true');
+      document.body.style.overflow = '';
+    },
+
+    refreshSummary() {
+      const tier = CONTENT.pricing.tiers.find((t) => t.id === selectedTier);
+      if (!tier) return;
+      const p = Currency.live(selectedTier);
+      const discounted = p?.discounted || tier.discountedPrice;
+      const perDay = p?.perDay || tier.pricePerDay;
+      const summary = el('checkout-summary');
+      if (summary) {
+        summary.innerHTML = `
+          <div>
+            <div class="modal__summary-name">${esc(tier.name)}</div>
+            <div class="modal__summary-perday">${esc(perDay)}</div>
+          </div>
+          <div class="modal__summary-price">${esc(discounted)}</div>`;
+      }
+      const legal = el('checkout-legal');
+      if (legal) legal.textContent = Currency.tierDisclaimer(selectedTier);
+    },
+
+    onEmailInput() {
+      const email = el('checkout-email').value.trim();
+      const errEl = el('checkout-email-error');
+      const key = `${selectedTier}|${email}`;
+      if (!EMAIL_RE.test(email)) { errEl.textContent = ''; return; }
+      errEl.textContent = '';
+      if (key !== this.mountedKey && !this.building) this.build(email);
+    },
+
+    setPayBtn(disabled, text) {
+      const btn = el('checkout-pay-btn');
+      if (!btn) return;
+      btn.disabled = disabled;
+      btn.classList.toggle('btn--disabled', disabled);
+      if (text) btn.textContent = text;
+    },
+
+    showError(msg) { el('checkout-error').textContent = msg || ''; },
+
+    // Build the Stripe Payment Element for the current tier + email.
+    async build(email) {
+      this.building = true;
+      const tierId = selectedTier;
+      const currency = Currency.detect();
+      const mountEl = el('payment-element');
+      this.showError('');
+      this.setPayBtn(true, 'Preparing secure checkout…');
+      mountEl.innerHTML = '<p class="checkout__payment-loading">Loading secure payment form…</p>';
+
+      // ── Dev mock: bypass Stripe on localhost ──────────────────────────────
+      if (isDev()) {
+        mountEl.innerHTML = '<p class="checkout__payment-loading">⚡ Dev mode — payment mocked (localhost)</p>';
+        this.mountedKey = `${tierId}|${email}`;
+        this.building = false;
+        this.setPayBtn(false, 'Complete Payment (Mock)');
+        return;
+      }
+
+      try {
+        const res = await fetch('/api/create-checkout', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tierId, email, currency }),
+        });
+        const raw = await res.text();
+        let data = {};
+        try { data = raw ? JSON.parse(raw) : {}; } catch (_) {}
+        if (!res.ok || !data.clientSecret) {
+          this.showError(data.error || 'Payment setup failed. Please try again.');
+          this.setPayBtn(true, 'Enter your email to continue');
+          this.building = false;
+          return;
+        }
+        this.checkoutData = data;
+
+        if (typeof window.Stripe === 'undefined') {
+          this.showError('Payment provider failed to load. Please refresh.');
+          this.building = false;
+          return;
+        }
+
+        this.stripe = window.Stripe(CONFIG.stripePk);
+        this.elements = this.stripe.elements({ clientSecret: data.clientSecret });
+        const paymentEl = this.elements.create('payment');
+        mountEl.innerHTML = '';
+        paymentEl.mount('#payment-element');
+        paymentEl.on('ready', () => this.setPayBtn(false, 'Complete Payment'));
+        this.mountedKey = `${tierId}|${email}`;
+      } catch (err) {
+        this.showError('An unexpected error occurred. Please refresh and try again.');
+      } finally {
+        this.building = false;
+      }
+    },
+
+    async pay() {
+      const email = el('checkout-email').value.trim();
+      if (!EMAIL_RE.test(email)) {
+        el('checkout-email-error').textContent = 'Please enter a valid email address.';
+        el('checkout-email').focus();
+        return;
+      }
+      const currency = Currency.detect();
+
+      // ── Dev mock success path ─────────────────────────────────────────────
+      if (isDev()) {
+        MetaPixel.purchase(selectedTier, currency, null);
+        window.location.href = CONFIG.webappUrl;
+        return;
+      }
+
+      // Payment form still building (e.g. Enter pressed early) — let it finish;
+      // avoids a redundant concurrent create-checkout call.
+      if (this.building) return;
+      if (!this.stripe || !this.elements) { this.build(email); return; }
+
+      this.setPayBtn(true, 'Processing…');
+      this.showError('');
+
+      const { error } = await this.stripe.confirmPayment({
+        elements: this.elements,
+        confirmParams: { return_url: window.location.href },
+        redirect: 'if_required',
+      });
+
+      if (error) {
+        this.showError(error.message || 'Payment failed. Please try again.');
+        this.setPayBtn(false, 'Complete Payment');
+        return;
+      }
+
+      // Payment succeeded — track, provision the account, hand off to the webapp.
+      MetaPixel.purchase(selectedTier, currency, this.checkoutData?.subscriptionId);
+
+      let tokens = null;
+      try {
+        const provRes = await fetch('/api/provision-account', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            email,
+            selectedPlan: selectedTier,
+            funnelVersion: CONFIG.funnelVersion,
+          }),
+        });
+        const provData = await provRes.json();
+        if (provData.provisioned) {
+          tokens = { access_token: provData.access_token, refresh_token: provData.refresh_token };
+        }
+      } catch (_) { /* non-fatal — user can still log in with the account we created */ }
+
+      // Cross-origin session handoff via URL hash (same mechanism as the funnel).
+      const hash = tokens
+        ? '#access_token=' + encodeURIComponent(tokens.access_token) +
+          '&refresh_token=' + encodeURIComponent(tokens.refresh_token)
+        : '';
+      window.location.href = CONFIG.webappUrl + hash;
+    },
+  };
+
+  // =========================================================================
+  // Interactions
+  // =========================================================================
+  function scrollToPricing() {
+    el('pricing').scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  function wireInteractions() {
+    // CTA buttons → scroll to pricing (except the pricing button itself).
+    document.addEventListener('click', (e) => {
+      const cta = e.target.closest('[data-cta]');
+      if (cta) { scrollToPricing(); return; }
+
+      const checkoutBtn = e.target.closest('[data-action="checkout"]');
+      if (checkoutBtn) { Checkout.open(); return; }
+
+      const tierEl = e.target.closest('.tier');
+      if (tierEl) { selectTier(tierEl.getAttribute('data-tier')); return; }
+
+      if (e.target.closest('[data-close-modal]')) { Checkout.close(); return; }
+
+      const faqQ = e.target.closest('.faq__q');
+      if (faqQ) {
+        const item = faqQ.closest('.faq__item');
+        const a = item.querySelector('.faq__a');
+        const open = item.classList.toggle('faq__item--open');
+        faqQ.setAttribute('aria-expanded', open);
+        a.style.maxHeight = open ? a.scrollHeight + 'px' : '0';
+        return;
+      }
+    });
+
+    // Keyboard: Enter/Space selects a tier; Esc closes the modal.
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') Checkout.close();
+      if ((e.key === 'Enter' || e.key === ' ') && document.activeElement?.classList.contains('tier')) {
+        e.preventDefault();
+        selectTier(document.activeElement.getAttribute('data-tier'));
+      }
+    });
+
+    // Checkout form
+    el('checkout-email').addEventListener('input', () => Checkout.onEmailInput());
+    el('checkout-form').addEventListener('submit', (e) => { e.preventDefault(); Checkout.pay(); });
+
+    // Header + sticky CTA buttons already carry data-cta; nothing else needed.
+  }
+
+  // Sticky mobile CTA: show once the user scrolls past the hero, hide near footer.
+  function wireStickyCta() {
+    const bar = el('sticky-cta');
+    const hero = el('hero');
+    const footer = el('site-footer');
+    const onScroll = () => {
+      const pastHero = window.scrollY > (hero?.offsetHeight || 400);
+      const nearFooter = footer.getBoundingClientRect().top < window.innerHeight + 80;
+      const modalOpen = el('checkout-modal').classList.contains('modal--open');
+      bar.classList.toggle('sticky-cta--visible', pastHero && !nearFooter && !modalOpen);
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    onScroll();
+  }
+
+  // Scroll reveal + before/after bar fill animation.
+  function wireReveal() {
+    if (!('IntersectionObserver' in window)) {
+      document.querySelectorAll('.reveal').forEach((n) => n.classList.add('reveal--in'));
+      document.querySelectorAll('.ba-bar__fill').forEach((f) => { f.style.width = (f.dataset.fill * 100) + '%'; });
+      return;
+    }
+    const obs = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) return;
+        entry.target.classList.add('reveal--in');
+        entry.target.querySelectorAll?.('.ba-bar__fill').forEach((f) => { f.style.width = (f.dataset.fill * 100) + '%'; });
+        obs.unobserve(entry.target);
+      });
+    }, { threshold: 0.15 });
+    document.querySelectorAll('.reveal').forEach((n) => obs.observe(n));
+  }
+
+  // =========================================================================
+  // Boot
+  // =========================================================================
+  async function init() {
+    try {
+      const res = await fetch('content.json');
+      CONTENT = await res.json();
+    } catch (err) {
+      console.error('[landing] Failed to load content.json', err);
+      return;
+    }
+
+    if (CONTENT.brand?.name) { document.title = CONTENT.meta?.title || document.title; el('brand-name').textContent = CONTENT.brand.name; }
+
+    renderHero(CONTENT.hero);
+    renderProof(CONTENT.socialProof);
+    renderProblem(CONTENT.problem);
+    renderHow(CONTENT.howItWorks);
+    renderFeatures(CONTENT.features);
+    renderBeforeAfter(CONTENT.beforeAfter);
+    renderPersonas(CONTENT.whoItHelps);
+    renderExpectations(CONTENT.expectations);
+    renderTestimonials(CONTENT.testimonials);
+    renderScience(CONTENT.science);
+    renderPricing(CONTENT.pricing);
+    renderGuarantee(CONTENT.guarantee, CONTENT.privacy, CONTENT.paymentSecurity);
+    renderFaq(CONTENT.faq);
+    renderFinalCta(CONTENT.finalCta);
+    renderFooter(CONTENT.footer);
+
+    wireInteractions();
+    wireStickyCta();
+    wireReveal();
+    updateStickyPrice();
+
+    // Live pricing — overwrite the static EUR fallback once loaded.
+    Currency.fetchPrices().then(updatePrices);
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+  else init();
+})();

--- a/funnel/vercel.json
+++ b/funnel/vercel.json
@@ -2,7 +2,12 @@
   "redirects": [
     {
       "source": "/",
-      "destination": "/funnel-v2/",
+      "destination": "/landing-page/",
+      "permanent": false
+    },
+    {
+      "source": "/landing-page",
+      "destination": "/landing-page/",
       "permanent": false
     },
     {

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -62,6 +62,15 @@ else
   fail_critical "Funnel page — status=$FUNNEL_STATUS title=$FUNNEL_TITLE"
 fi
 
+# Landing page (second acquisition channel; homepage at / redirects here)
+LANDING_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$FUNNEL_URL/landing-page/")
+LANDING_TITLE=$(curl -s "$FUNNEL_URL/landing-page/" | grep -o '<title>[^<]*</title>')
+if [ "$LANDING_STATUS" = "200" ] && echo "$LANDING_TITLE" | grep -q "Mind Compass"; then
+  pass "Landing page loads (HTTP 200, title contains 'Mind Compass')"
+else
+  fail_critical "Landing page — status=$LANDING_STATUS title=$LANDING_TITLE"
+fi
+
 WEBAPP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$WEBAPP_URL/")
 if [ "$WEBAPP_STATUS" = "200" ]; then
   pass "Webapp page loads (HTTP 200)"


### PR DESCRIPTION
Adds a bespoke, mobile-first landing page (`funnel/landing-page/`) that sells Mind Compass directly with an embedded Stripe checkout — a second acquisition channel alongside the quiz funnel.

Closes #87

## What changed
- **`funnel/landing-page/`** — `index.html`, `landing.css`, `landing.js`, `content.json`. Bespoke marketing page that reuses the funnel's serverless backend (`/api/prices`, `/api/create-checkout`, `/api/provision-account`), the same Stripe publishable key, live multi-currency pricing (EUR fallback), and Meta Pixel (PageView/ViewContent/InitiateCheckout/Purchase with CAPI dedup). Persuasion-first copy — emotion + benefit + shame-reframe lead; science kept as a subordinate trust block.
- **`funnel/vercel.json`** — `/` now redirects to `/landing-page/`; `/landing-page` normalized; `/funnel-v2` stays reachable.
- **`scripts/smoke-test.sh`** — added landing-page HTTP 200 + title health check.
- **`PLAN_issue_87.md`** — implementation plan/tracker.

## Verification
- Local: HTTP 200, valid `content.json`, `node --check` clean, all assets + engine CSS resolve, dev-mock gated to localhost.
- `/review` + `/peer-review`: no CRITICAL/HIGH issues; one LOW (concurrent create-checkout on Enter) fixed with a `building` guard.
- Note: the production landing check in the smoke test passes only **after** this deploys to Vercel.

Smoke test runs automatically on push via Claude Code hook.