### PR TITLE
feat: two parallel landing variants — rebuilt reviews, direct copy, 3 themes

### DIFF
--- a/funnel/landing-direct/index.html
+++ b/funnel/landing-direct/index.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="warm">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>Mind Compass — Take back control</title>
+    <meta name="description" content="A private plan built around what actually triggers you. Two minutes to set up.">
+    <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+
+    <meta property="og:title" content="Mind Compass — Take back control">
+    <meta property="og:description" content="A private plan built around what actually triggers you. Two minutes to set up.">
+    <meta property="og:type" content="website">
+
+    <link rel="stylesheet" href="../landing-shared/core.css?v=20260817">
+    <link id="theme-css" rel="stylesheet" href="../landing-shared/theme-warm.css?v=20260817">
+    <script>
+      /* Resolve the theme synchronously, before the parser reaches <body>, so
+         there is no flash of the wrong palette. ?theme= wins, then the last
+         choice, then warm. */
+      (function () {
+        var allowed = ['warm', 'dark', 'clean'];
+        var t = new URLSearchParams(location.search).get('theme');
+        if (!t) { try { t = localStorage.getItem('mc_theme'); } catch (e) {} }
+        if (allowed.indexOf(t) === -1) t = 'warm';
+        try { localStorage.setItem('mc_theme', t); } catch (e) {}
+        document.documentElement.setAttribute('data-theme', t);
+        if (t !== 'warm') {
+          document.getElementById('theme-css').href =
+            '../landing-shared/theme-' + t + '.css?v=20260817';
+        }
+      })();
+    </script>
+
+    <link rel="preload" as="image" href="../assets/after_state_male.png" fetchpriority="high">
+
+    <!-- ── Meta Pixel (shared with the funnel — same pixel id) ─────────────── -->
+    <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '1530402652053089');
+      fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+      src="https://www.facebook.com/tr?id=1530402652053089&ev=PageView&noscript=1"/></noscript>
+</head>
+<body id="top">
+    <header class="hdr" id="hdr"></header>
+
+    <main>
+        <!-- Every section is rendered from ../landing-shared/content.json. -->
+        <section class="hero" id="hero" aria-label="Introduction"></section>
+        <section class="proof" id="proof" aria-label="Social proof"></section>
+        <section class="problem" id="problem" aria-label="The problem"></section>
+        <section class="loop band band--invert" id="loop" aria-label="The loop"></section>
+        <section class="personas band band--tint" id="personas" aria-label="Who this is for"></section>
+        <section class="how" id="how" aria-label="How it works"></section>
+        <section class="tw band band--tint" id="testimonials" aria-label="Member reviews"></section>
+        <section class="pricing" id="pricing" aria-label="Pricing"></section>
+        <section class="trust band band--tint" id="trust" aria-label="Privacy, payment and research"></section>
+        <section class="faq" id="faq" aria-label="Frequently asked questions"></section>
+        <section class="final band band--invert" id="final" aria-label="Get started"></section>
+    </main>
+
+    <footer class="ftr" id="ftr"></footer>
+
+    <!-- Sticky mobile CTA -->
+    <div class="sticky" id="sticky">
+        <div class="sticky__price" id="sticky-price"></div>
+        <button class="btn btn--cta" data-cta="sticky">Start today</button>
+    </div>
+
+    <!-- Micro-quiz sheet. Inert on this variant (flow: 'direct' never opens it);
+         kept so both variants share one DOM contract and one script. -->
+    <div class="quiz" id="quiz" aria-hidden="true" role="dialog" aria-modal="true">
+        <div class="quiz__scrim" data-quiz="close"></div>
+        <div class="quiz__sheet" role="document">
+            <button class="quiz__close" data-quiz="close" aria-label="Close">&times;</button>
+            <div class="quiz__bar"><div class="quiz__bar-fill" id="quiz-bar"></div></div>
+            <div id="quiz-body"></div>
+        </div>
+    </div>
+
+    <!-- Checkout modal (email + Stripe Payment Element) -->
+    <div class="modal" id="checkout" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="pay-title">
+        <div class="modal__scrim" data-close-modal></div>
+        <div class="modal__dialog" role="document">
+            <button class="modal__close" data-close-modal aria-label="Close">&times;</button>
+            <h2 class="modal__title" id="pay-title">Complete your order</h2>
+            <div class="modal__summary" id="pay-summary"></div>
+
+            <form id="pay-form" novalidate>
+                <label class="field">
+                    <span class="field__label">Email address</span>
+                    <input type="email" id="email" class="field__input" autocomplete="email"
+                           placeholder="you@example.com" required>
+                    <span class="field__error" id="email-error"></span>
+                </label>
+
+                <div id="pay-mount" class="pay__mount">
+                    <p class="pay__loading">Loading secure payment form…</p>
+                </div>
+
+                <div class="pay__error" id="pay-error" role="alert"></div>
+
+                <button type="submit" class="btn btn--cta btn--block btn--off" id="pay-btn" disabled>
+                    Enter your email to continue
+                </button>
+
+                <p class="pay__legal" id="pay-legal"></p>
+                <p class="pay__secure">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="10" width="16" height="10" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3"/></svg>
+                    Secure payment powered by Stripe
+                </p>
+            </form>
+        </div>
+    </div>
+
+    <!-- Live theme comparison, enabled with ?themepicker=1 -->
+    <div class="themepicker" id="themepicker"></div>
+
+    <script>
+      window.LANDING_CONFIG = {
+        flow: 'direct',
+        funnelVersion: 'landing-direct',
+        pixelContentName: 'LandingDirect',
+      };
+    </script>
+    <script src="https://js.stripe.com/v3/"></script>
+    <script src="../landing-shared/landing.js?v=20260817"></script>
+</body>
+</html>

--- a/funnel/landing-direct/index.html
+++ b/funnel/landing-direct/index.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>Mind Compass — Take back control</title>
-    <meta name="description" content="A private plan built around what actually triggers you. Two minutes to set up.">
+    <title>Mind Compass — Quit Porn for Good</title>
+    <meta name="description" content="Quit porn with a plan built around what actually triggers you. Not a blocker, not willpower. Private, judgment-free, two minutes to set up.">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
 
-    <meta property="og:title" content="Mind Compass — Take back control">
-    <meta property="og:description" content="A private plan built around what actually triggers you. Two minutes to set up.">
+    <meta property="og:title" content="Mind Compass — Quit Porn for Good">
+    <meta property="og:description" content="Quit porn with a plan built around what actually triggers you. Not a blocker, not willpower. Private, judgment-free, two minutes to set up.">
     <meta property="og:type" content="website">
 
     <link rel="stylesheet" href="../landing-shared/core.css?v=20260817">

--- a/funnel/landing-quiz/index.html
+++ b/funnel/landing-quiz/index.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="warm">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>Mind Compass — Take back control</title>
+    <meta name="description" content="A private plan built around what actually triggers you. Two minutes to set up.">
+    <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+
+    <meta property="og:title" content="Mind Compass — Take back control">
+    <meta property="og:description" content="A private plan built around what actually triggers you. Two minutes to set up.">
+    <meta property="og:type" content="website">
+
+    <link rel="stylesheet" href="../landing-shared/core.css?v=20260817">
+    <link id="theme-css" rel="stylesheet" href="../landing-shared/theme-warm.css?v=20260817">
+    <script>
+      /* Resolve the theme synchronously, before the parser reaches <body>, so
+         there is no flash of the wrong palette. ?theme= wins, then the last
+         choice, then warm. */
+      (function () {
+        var allowed = ['warm', 'dark', 'clean'];
+        var t = new URLSearchParams(location.search).get('theme');
+        if (!t) { try { t = localStorage.getItem('mc_theme'); } catch (e) {} }
+        if (allowed.indexOf(t) === -1) t = 'warm';
+        try { localStorage.setItem('mc_theme', t); } catch (e) {}
+        document.documentElement.setAttribute('data-theme', t);
+        if (t !== 'warm') {
+          document.getElementById('theme-css').href =
+            '../landing-shared/theme-' + t + '.css?v=20260817';
+        }
+      })();
+    </script>
+
+    <link rel="preload" as="image" href="../assets/after_state_male.png" fetchpriority="high">
+
+    <!-- ── Meta Pixel (shared with the funnel — same pixel id) ─────────────── -->
+    <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '1530402652053089');
+      fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+      src="https://www.facebook.com/tr?id=1530402652053089&ev=PageView&noscript=1"/></noscript>
+</head>
+<body id="top">
+    <header class="hdr" id="hdr"></header>
+
+    <main>
+        <!-- Every section is rendered from ../landing-shared/content.json. -->
+        <section class="hero" id="hero" aria-label="Introduction"></section>
+        <section class="proof" id="proof" aria-label="Social proof"></section>
+        <section class="problem" id="problem" aria-label="The problem"></section>
+        <section class="loop band band--invert" id="loop" aria-label="The loop"></section>
+        <section class="personas band band--tint" id="personas" aria-label="Who this is for"></section>
+        <section class="how" id="how" aria-label="How it works"></section>
+        <section class="tw band band--tint" id="testimonials" aria-label="Member reviews"></section>
+        <section class="pricing" id="pricing" aria-label="Pricing"></section>
+        <section class="trust band band--tint" id="trust" aria-label="Privacy, payment and research"></section>
+        <section class="faq" id="faq" aria-label="Frequently asked questions"></section>
+        <section class="final band band--invert" id="final" aria-label="Get started"></section>
+    </main>
+
+    <footer class="ftr" id="ftr"></footer>
+
+    <!-- Sticky mobile CTA -->
+    <div class="sticky" id="sticky">
+        <div class="sticky__price" id="sticky-price"></div>
+        <button class="btn btn--cta" data-cta="sticky">Start today</button>
+    </div>
+
+    <!-- Micro-quiz sheet -->
+    <div class="quiz" id="quiz" aria-hidden="true" role="dialog" aria-modal="true">
+        <div class="quiz__scrim" data-quiz="close"></div>
+        <div class="quiz__sheet" role="document">
+            <button class="quiz__close" data-quiz="close" aria-label="Close">&times;</button>
+            <div class="quiz__bar"><div class="quiz__bar-fill" id="quiz-bar"></div></div>
+            <div id="quiz-body"></div>
+        </div>
+    </div>
+
+    <!-- Checkout modal (email + Stripe Payment Element) -->
+    <div class="modal" id="checkout" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="pay-title">
+        <div class="modal__scrim" data-close-modal></div>
+        <div class="modal__dialog" role="document">
+            <button class="modal__close" data-close-modal aria-label="Close">&times;</button>
+            <h2 class="modal__title" id="pay-title">Complete your order</h2>
+            <div class="modal__summary" id="pay-summary"></div>
+
+            <form id="pay-form" novalidate>
+                <label class="field">
+                    <span class="field__label">Email address</span>
+                    <input type="email" id="email" class="field__input" autocomplete="email"
+                           placeholder="you@example.com" required>
+                    <span class="field__error" id="email-error"></span>
+                </label>
+
+                <div id="pay-mount" class="pay__mount">
+                    <p class="pay__loading">Loading secure payment form…</p>
+                </div>
+
+                <div class="pay__error" id="pay-error" role="alert"></div>
+
+                <button type="submit" class="btn btn--cta btn--block btn--off" id="pay-btn" disabled>
+                    Enter your email to continue
+                </button>
+
+                <p class="pay__legal" id="pay-legal"></p>
+                <p class="pay__secure">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="10" width="16" height="10" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3"/></svg>
+                    Secure payment powered by Stripe
+                </p>
+            </form>
+        </div>
+    </div>
+
+    <!-- Live theme comparison, enabled with ?themepicker=1 -->
+    <div class="themepicker" id="themepicker"></div>
+
+    <script>
+      window.LANDING_CONFIG = {
+        flow: 'quiz',
+        funnelVersion: 'landing-quiz',
+        pixelContentName: 'LandingQuiz',
+      };
+    </script>
+    <script src="https://js.stripe.com/v3/"></script>
+    <script src="../landing-shared/landing.js?v=20260817"></script>
+</body>
+</html>

--- a/funnel/landing-quiz/index.html
+++ b/funnel/landing-quiz/index.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>Mind Compass — Take back control</title>
-    <meta name="description" content="A private plan built around what actually triggers you. Two minutes to set up.">
+    <title>Mind Compass — Quit Porn for Good</title>
+    <meta name="description" content="Quit porn with a plan built around what actually triggers you. Not a blocker, not willpower. Private, judgment-free, two minutes to set up.">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
 
-    <meta property="og:title" content="Mind Compass — Take back control">
-    <meta property="og:description" content="A private plan built around what actually triggers you. Two minutes to set up.">
+    <meta property="og:title" content="Mind Compass — Quit Porn for Good">
+    <meta property="og:description" content="Quit porn with a plan built around what actually triggers you. Not a blocker, not willpower. Private, judgment-free, two minutes to set up.">
     <meta property="og:type" content="website">
 
     <link rel="stylesheet" href="../landing-shared/core.css?v=20260817">

--- a/funnel/landing-shared/content.json
+++ b/funnel/landing-shared/content.json
@@ -4,15 +4,15 @@
     "tagline": "Take back control"
   },
   "meta": {
-    "title": "Mind Compass — Take back control",
-    "description": "A private plan built around what actually triggers you. Two minutes to set up. Nobody has to know."
+    "title": "Mind Compass — Quit Porn for Good",
+    "description": "Quit porn with a plan built around what actually triggers you. Not a blocker, not willpower. Private, judgment-free, two minutes to set up."
   },
 
   "hero": {
     "eyebrow": "Private · Nobody has to know",
-    "headline": "Someday starts today.",
-    "headlineAccent": "today",
-    "subheadline": "A private plan built around what actually triggers you. Two minutes to set up.",
+    "headline": "Quit porn. For real this time.",
+    "headlineAccent": "real",
+    "subheadline": "A plan built around what actually triggers you — not a blocker, not willpower. Two minutes to set up.",
     "reassurance": "100% private · Cancel anytime · 30-day refund",
     "image": "../assets/after_state_male.png",
     "imageAlt": "Mind Compass member"
@@ -20,7 +20,7 @@
 
   "proof": {
     "stats": [
-      { "value": "200,000+", "label": "have started their reset" },
+      { "value": "200,000+", "label": "have started quitting porn" },
       { "value": "4.8", "label": "average rating", "isRating": true },
       { "value": "83%", "label": "feel more in control" }
     ]
@@ -28,19 +28,19 @@
 
   "problem": {
     "eyebrow": "You're not broken",
-    "headline": "It's not willpower. It's a hijacked reward system.",
-    "body": "Your brain learned a shortcut. Now everything slower than a screen feels flat. What got wired can get rewired.",
+    "headline": "It was never willpower. Porn rewired your reward system.",
+    "body": "Your brain learned a shortcut: infinite novelty, zero effort. Next to that, real life feels flat. What got wired can get rewired.",
     "painPoints": [
       "\"Never again\" — and then it's Friday night.",
       "Foggy, flat and unmotivated by 2pm.",
-      "Real intimacy can't compete with a screen.",
+      "Porn got easier than intimacy. You noticed.",
       "The shame makes the urge louder, not quieter."
     ],
     "loopLabel": "The loop running underneath",
     "loop": [
       { "icon": "spark",  "title": "Trigger", "body": "Stress, boredom, a late scroll." },
       { "icon": "flame",  "title": "Craving", "body": "Dopamine spikes before you decide." },
-      { "icon": "swirl",  "title": "Binge",   "body": "More stimulation than you were built for." },
+      { "icon": "swirl",  "title": "Binge",   "body": "Tabs open. An hour gone." },
       { "icon": "fog",    "title": "Crash",   "body": "Guilt and fog — the next trigger." }
     ],
     "loopNote": "…and round it goes.",
@@ -52,12 +52,12 @@
 
   "personas": {
     "eyebrow": "Sound familiar?",
-    "headline": "You'll recognise yourself in one of these",
+    "headline": "You'll recognize yourself in one of these",
     "items": [
       { "title": "The relapse cycle", "body": "You've quit a hundred times. You need a method, not more shame." },
-      { "title": "The foggy one",     "body": "Flat and unfocused — and you already suspect why." },
+      { "title": "The foggy one",     "body": "Flat and unfocused. You already know porn is part of it." },
       { "title": "Checked out",       "body": "You want to be present again with the person you love." },
-      { "title": "The high performer", "body": "Everything looks fine. Privately, it's costing you." }
+      { "title": "The high performer", "body": "Career's fine. Gym's fine. The tab you close at 1am isn't." }
     ]
   },
 
@@ -74,7 +74,7 @@
 
   "testimonials": {
     "eyebrow": "Members",
-    "headline": "People who stopped white-knuckling it",
+    "headline": "People who actually quit",
     "note": "Reviews from Mind Compass members. Some names shortened for privacy.",
     "moreLabel": "Read more reviews",
     "lessLabel": "Show fewer",
@@ -149,8 +149,8 @@
     "headline": "Your plan is ready",
     "anchor": "One therapy session costs about €80. One month of Mind Compass costs less than a coffee a week.",
     "goals": [
-      "Understand what actually triggers you",
-      "Get through urges without white-knuckling",
+      "Quit porn without relying on willpower",
+      "Know exactly what to do when an urge hits",
       "Get your focus and energy back",
       "Be present again with the people who matter"
     ],
@@ -205,7 +205,7 @@
     },
     "science": {
       "headline": "The method isn't guesswork",
-      "summary": "Mind Compass is built on cognitive behavioral therapy — the same approach clinicians use for compulsive behavior — and on how the brain's reward system actually adapts.",
+      "summary": "Mind Compass is built on cognitive behavioral therapy — the same approach clinicians use for compulsive porn use — and on how the brain's reward system actually adapts.",
       "toggleLabel": "See the research",
       "points": [
         {
@@ -241,8 +241,8 @@
         "answer": "30 days. If it's not for you, we refund you in full — see our money-back policy for the details."
       },
       {
-        "question": "My willpower is gone. I've failed before.",
-        "answer": "Good — willpower isn't what this runs on. You get a plan for the exact moment the urge hits, so you're not relying on gritting your teeth."
+        "question": "I've tried to quit porn before and failed.",
+        "answer": "Everyone here has. Willpower isn't what this runs on — you get a plan for the exact moment the urge hits, so you're not relying on gritting your teeth at 1am."
       },
       {
         "question": "My triggers are everywhere. I can't escape them.",
@@ -250,13 +250,13 @@
       },
       {
         "question": "How is this different from a blocker app?",
-        "answer": "Blockers fight the symptom and you route around them by week two. This works on the pattern underneath — what sets you off, and what to do instead."
+        "answer": "A blocker hides porn from you and you route around it by week two. This works on the pattern underneath — what sets you off, and what to do instead. You stop wanting it rather than fighting to reach it."
       }
     ]
   },
 
   "finalCta": {
-    "headline": "Start tonight.",
+    "headline": "Quit porn. Starting tonight.",
     "subheadline": "Two minutes now. A different tomorrow.",
     "cta": "Start today"
   },
@@ -285,7 +285,7 @@
     "questions": [
       {
         "id": "trigger",
-        "prompt": "What usually pulls you in?",
+        "prompt": "What usually pulls you back to porn?",
         "options": [
           { "label": "Stress or anxiety",    "challenge": "Worrier" },
           { "label": "Boredom and brain fog", "challenge": "Foggy Thinker" },

--- a/funnel/landing-shared/content.json
+++ b/funnel/landing-shared/content.json
@@ -1,0 +1,322 @@
+{
+  "brand": {
+    "name": "Mind Compass",
+    "tagline": "Take back control"
+  },
+  "meta": {
+    "title": "Mind Compass — Take back control",
+    "description": "A private plan built around what actually triggers you. Two minutes to set up. Nobody has to know."
+  },
+
+  "hero": {
+    "eyebrow": "Private · Nobody has to know",
+    "headline": "Someday starts today.",
+    "headlineAccent": "today",
+    "subheadline": "A private plan built around what actually triggers you. Two minutes to set up.",
+    "reassurance": "100% private · Cancel anytime · 30-day refund",
+    "image": "../assets/after_state_male.png",
+    "imageAlt": "Mind Compass member"
+  },
+
+  "proof": {
+    "stats": [
+      { "value": "200,000+", "label": "have started their reset" },
+      { "value": "4.8", "label": "average rating", "isRating": true },
+      { "value": "83%", "label": "feel more in control" }
+    ]
+  },
+
+  "problem": {
+    "eyebrow": "You're not broken",
+    "headline": "It's not willpower. It's a hijacked reward system.",
+    "body": "Your brain learned a shortcut. Now everything slower than a screen feels flat. What got wired can get rewired.",
+    "painPoints": [
+      "\"Never again\" — and then it's Friday night.",
+      "Foggy, flat and unmotivated by 2pm.",
+      "Real intimacy can't compete with a screen.",
+      "The shame makes the urge louder, not quieter."
+    ],
+    "loopLabel": "The loop running underneath",
+    "loop": [
+      { "icon": "spark",  "title": "Trigger", "body": "Stress, boredom, a late scroll." },
+      { "icon": "flame",  "title": "Craving", "body": "Dopamine spikes before you decide." },
+      { "icon": "swirl",  "title": "Binge",   "body": "More stimulation than you were built for." },
+      { "icon": "fog",    "title": "Crash",   "body": "Guilt and fog — the next trigger." }
+    ],
+    "loopNote": "…and round it goes.",
+    "breakout": {
+      "label": "Where we cut in",
+      "body": "One tap, right between the craving and the binge. That gap is all you need — and it widens every single time you use it."
+    }
+  },
+
+  "personas": {
+    "eyebrow": "Sound familiar?",
+    "headline": "You'll recognise yourself in one of these",
+    "items": [
+      { "title": "The relapse cycle", "body": "You've quit a hundred times. You need a method, not more shame." },
+      { "title": "The foggy one",     "body": "Flat and unfocused — and you already suspect why." },
+      { "title": "Checked out",       "body": "You want to be present again with the person you love." },
+      { "title": "The high performer", "body": "Everything looks fine. Privately, it's costing you." }
+    ]
+  },
+
+  "how": {
+    "eyebrow": "How it works",
+    "headline": "Three steps. That's the whole thing.",
+    "steps": [
+      { "title": "Answer 3 questions", "body": "We map what actually sets you off." },
+      { "title": "Get your plan",      "body": "Built around your triggers, not a generic program." },
+      { "title": "Tap when it hits",   "body": "One button turns the impulse into a choice." }
+    ],
+    "chips": ["Urge button", "Streak tracking", "24/7 coach", "Private by default"]
+  },
+
+  "testimonials": {
+    "eyebrow": "Members",
+    "headline": "People who stopped white-knuckling it",
+    "note": "Reviews from Mind Compass members. Some names shortened for privacy.",
+    "moreLabel": "Read more reviews",
+    "lessLabel": "Show fewer",
+    "items": [
+      {
+        "rating": 5,
+        "title": "Finally something that sticks",
+        "content": "Concise and easy — exactly what you need when you're trying to break a dopamine habit. It's the first thing that's actually helped me stay consistent.",
+        "author": "S. Krupert"
+      },
+      {
+        "rating": 5,
+        "title": "90 days and counting",
+        "content": "I never made it past a weekend before. The streak tracker turned quitting into something I actually look forward to protecting each morning.",
+        "author": "Matt R.",
+        "badge": "Day 90"
+      },
+      {
+        "rating": 5,
+        "title": "The urge button actually works",
+        "content": "When a craving hits I tap the button and follow the steps instead of reaching for my phone. That one pause has saved me more times than I can count.",
+        "author": "Danny N."
+      },
+      {
+        "rating": 5,
+        "title": "Got my focus back",
+        "content": "Before this I procrastinated for hours every day. Now I finally feel like I'm breaking away from the compulsive habit — and my head is so much clearer.",
+        "author": "Q. Zhao"
+      },
+      {
+        "rating": 5,
+        "title": "My relationship came back",
+        "content": "I didn't realize how checked-out I'd become until I stopped. Being fully present with my partner again is worth more than anything I paid for this.",
+        "author": "J. Rivera"
+      },
+      {
+        "rating": 5,
+        "title": "No more shame spiral",
+        "content": "The biggest shift was learning I'm not broken. Once the shame lifted, the urges got so much easier to sit with and let pass.",
+        "author": "Chris M."
+      },
+      {
+        "rating": 5,
+        "title": "Like a coach in my pocket",
+        "content": "Mind Compass is like a personal wellbeing coach. Everything's in one place and it makes you think twice before ruining your progress.",
+        "author": "Paul V."
+      },
+      {
+        "rating": 5,
+        "title": "Energy I forgot I had",
+        "content": "Two weeks in and I'm waking up motivated instead of foggy. The daily lessons are short enough that I actually keep up with them.",
+        "author": "T. Okafor",
+        "badge": "Day 14"
+      },
+      {
+        "rating": 5,
+        "title": "Private and judgment-free",
+        "content": "Nothing about the app announces what it's for, and there's zero lecturing. It just quietly helps. That's exactly what I needed.",
+        "author": "Anonymous"
+      },
+      {
+        "rating": 5,
+        "title": "Wish I'd found this sooner",
+        "content": "I'd tried blockers and cold turkey for years. Having an actual plan built around my triggers is the difference between hoping and knowing it'll work.",
+        "author": "Sam K."
+      }
+    ]
+  },
+
+  "pricing": {
+    "eyebrow": "Start today",
+    "headline": "Your plan is ready",
+    "anchor": "One therapy session costs about €80. One month of Mind Compass costs less than a coffee a week.",
+    "goals": [
+      "Understand what actually triggers you",
+      "Get through urges without white-knuckling",
+      "Get your focus and energy back",
+      "Be present again with the people who matter"
+    ],
+    "reasonWhy": "Introductory pricing on your first term.",
+    "cta": "Start today",
+    "guaranteeLine": "30 days. Not for you? Full refund.",
+    "tiers": [
+      {
+        "id": "7_day",
+        "name": "7-DAY PLAN",
+        "originalPrice": "€49.99",
+        "discountedPrice": "€10.50",
+        "pricePerDay": "€1.50/day",
+        "recommended": false,
+        "savings": "79% OFF"
+      },
+      {
+        "id": "1_month",
+        "name": "1-MONTH PLAN",
+        "badge": "MOST POPULAR",
+        "originalPrice": "€49.99",
+        "discountedPrice": "€19.99",
+        "pricePerDay": "€0.66/day",
+        "recommended": true,
+        "savings": "60% OFF"
+      },
+      {
+        "id": "3_month",
+        "name": "3-MONTH PLAN",
+        "originalPrice": "€99.99",
+        "discountedPrice": "€34.99",
+        "pricePerDay": "€0.38/day",
+        "recommended": false,
+        "savings": "65% OFF"
+      }
+    ],
+    "legalDisclaimer": "By clicking \"Start today\", you agree to automatic subscription renewal at the rate shown above. Cancel anytime via aicompass.tech@gmail.com. See our Subscription Policy for details."
+  },
+
+  "trust": {
+    "privacy": {
+      "headline": "Completely private",
+      "points": [
+        "Nothing on your device announces what this is for.",
+        "Your data stays yours — private and secure.",
+        "No lecturing, no judgment. Ever."
+      ]
+    },
+    "payment": {
+      "headline": "Pay safe & secure",
+      "icons": ["PayPal", "Apple Pay", "Visa", "Mastercard", "Maestro", "Amex"]
+    },
+    "science": {
+      "headline": "The method isn't guesswork",
+      "summary": "Mind Compass is built on cognitive behavioral therapy — the same approach clinicians use for compulsive behavior — and on how the brain's reward system actually adapts.",
+      "toggleLabel": "See the research",
+      "points": [
+        {
+          "claim": "A recognized condition",
+          "detail": "Compulsive sexual behavior is recognized by the World Health Organization in the ICD-11. You're dealing with something real.",
+          "source": "WHO ICD-11 (6C72)"
+        },
+        {
+          "claim": "CBT is proven for compulsive behavior",
+          "detail": "Cognitive behavioral therapy is one of the most evidence-based approaches for changing compulsive habits.",
+          "source": "Antons et al., J. Behavioral Addictions (2022)"
+        },
+        {
+          "claim": "Your brain adapts — and can re-adapt",
+          "detail": "Brain-imaging studies show compulsive sexual behavior involves reward and cue-reactivity patterns similar to other addictions.",
+          "source": "Voon et al., PLoS ONE (2014)"
+        }
+      ],
+      "disclaimer": "Mind Compass is a self-improvement and educational program, not a medical device or a substitute for professional care. Individual results vary."
+    }
+  },
+
+  "faq": {
+    "eyebrow": "Before you start",
+    "headline": "People often ask",
+    "questions": [
+      {
+        "question": "Is this really private?",
+        "answer": "Yes. Nothing about the app or your account announces what it's for, and your data is private and secure. No one sees it but you."
+      },
+      {
+        "question": "What if it doesn't work for me?",
+        "answer": "30 days. If it's not for you, we refund you in full — see our money-back policy for the details."
+      },
+      {
+        "question": "My willpower is gone. I've failed before.",
+        "answer": "Good — willpower isn't what this runs on. You get a plan for the exact moment the urge hits, so you're not relying on gritting your teeth."
+      },
+      {
+        "question": "My triggers are everywhere. I can't escape them.",
+        "answer": "You don't have to. The goal is taking their power away, not removing them. You'll learn what to do in the ten seconds that matter."
+      },
+      {
+        "question": "How is this different from a blocker app?",
+        "answer": "Blockers fight the symptom and you route around them by week two. This works on the pattern underneath — what sets you off, and what to do instead."
+      }
+    ]
+  },
+
+  "finalCta": {
+    "headline": "Start tonight.",
+    "subheadline": "Two minutes now. A different tomorrow.",
+    "cta": "Start today"
+  },
+
+  "footer": {
+    "company": "Mind Compass",
+    "supportEmail": "aicompass.tech@gmail.com",
+    "links": [
+      { "label": "Terms of Use", "href": "/legal/terms-of-use.html" },
+      { "label": "Privacy Policy", "href": "/legal/privacy-policy.html" },
+      { "label": "Subscription Policy", "href": "/legal/subscription-policy.html" },
+      { "label": "Cookie Policy", "href": "/legal/cookie-policy.html" }
+    ]
+  },
+
+  "quiz": {
+    "openCta": "Build my plan — 2 min",
+    "title": "Three questions.",
+    "subtitle": "That's all we need to build your plan.",
+    "buildingLabel": "Building your plan",
+    "buildingSteps": [
+      "Reading your triggers",
+      "Matching your recovery track",
+      "Setting your first-week targets"
+    ],
+    "questions": [
+      {
+        "id": "trigger",
+        "prompt": "What usually pulls you in?",
+        "options": [
+          { "label": "Stress or anxiety",    "challenge": "Worrier" },
+          { "label": "Boredom and brain fog", "challenge": "Foggy Thinker" },
+          { "label": "No energy or drive",   "challenge": "Low Drive" },
+          { "label": "Beating myself up",    "challenge": "Inner Critic" }
+        ]
+      },
+      {
+        "id": "duration",
+        "prompt": "How long has this been going on?",
+        "options": [
+          { "label": "Under a year", "stage": "Emerging" },
+          { "label": "1–3 years",    "stage": "Recent" },
+          { "label": "3–5 years",    "stage": "Established" },
+          { "label": "5+ years",     "stage": "Deeply Rooted" }
+        ]
+      },
+      {
+        "id": "want",
+        "prompt": "What do you most want back?",
+        "options": [
+          { "label": "My focus",              "goal": "Focus levels" },
+          { "label": "My confidence",         "goal": "Self-confidence" },
+          { "label": "My relationship",       "goal": "Relationships" },
+          { "label": "Control over my time",  "goal": "Self-control" }
+        ]
+      }
+    ],
+    "resultEyebrow": "Your plan is ready",
+    "resultHeadline": "The {goal} track",
+    "resultBody": "Built for {challenge} triggers, at a {stage} stage. Your first week focuses on the moments that catch you out — not on white-knuckling through the rest.",
+    "resultTags": ["Personalized", "{stage} stage", "{goal}"]
+  }
+}

--- a/funnel/landing-shared/core.css
+++ b/funnel/landing-shared/core.css
@@ -1,0 +1,1012 @@
+/* ============================================================================
+   Mind Compass — landing v2 core
+   ----------------------------------------------------------------------------
+   Structure + layout only. Every colour, font and radius comes from a token
+   that theme-*.css overrides, so /landing-quiz/ and /landing-direct/ can be
+   flipped between three visual directions with ?theme=warm|dark|clean.
+
+   Deliberately NOT uniform: section padding, background and layout shape vary
+   from section to section. The v1 page read as generated largely because every
+   band was 56px of padding wrapped around another grid of bordered cards.
+   ============================================================================ */
+
+/* ---- Token contract ------------------------------------------------------ */
+/* Themes must define all of these. Values here are a neutral safety net so a
+   missing theme file degrades to something readable instead of unstyled. */
+:root {
+  --c-bg: #ffffff;
+  --c-bg-alt: #f5f5f7;
+  --c-surface: #ffffff;
+  --c-ink: #16161d;
+  --c-ink-2: #55555f;
+  --c-ink-3: #8a8a95;
+  --c-line: #e4e4ea;
+  --c-line-strong: #c9c9d2;
+
+  --c-brand: #5b5bd6;
+  --c-brand-soft: #eeeefb;
+  --c-accent: #ff7a59;
+  --c-accent-soft: #fff0eb;
+  --c-cta: #22c55e;
+  --c-cta-hover: #16a34a;
+  --c-cta-ink: #ffffff;
+
+  --c-invert-bg: #16161d;
+  --c-invert-ink: #ffffff;
+  --c-invert-ink-2: rgba(255, 255, 255, 0.66);
+  --c-invert-line: rgba(255, 255, 255, 0.14);
+
+  --c-star: #f5a524;
+  --c-danger: #e5484d;
+
+  --font-display: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --display-weight: 800;
+  --display-tracking: -0.03em;
+  --display-case: none;
+  --eyebrow-tracking: 0.1em;
+
+  --radius: 12px;
+  --radius-lg: 18px;
+  --radius-pill: 999px;
+  --card-border: 1px solid var(--c-line);
+
+  --shadow-1: 0 1px 2px rgba(20, 20, 40, 0.05);
+  --shadow-2: 0 10px 30px rgba(20, 20, 40, 0.08);
+
+  --container: 1080px;
+  --header-h: 58px;
+  --gutter: 20px;
+}
+
+/* ---- Reset --------------------------------------------------------------- */
+*, *::before, *::after { box-sizing: border-box; }
+
+html {
+  scroll-behavior: smooth;
+  -webkit-text-size-adjust: 100%;
+  scroll-padding-top: calc(var(--header-h) + 12px);
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: 17px;
+  line-height: 1.55;
+  color: var(--c-ink);
+  background: var(--c-bg);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+img, svg { max-width: 100%; display: block; }
+p { margin: 0 0 1em; }
+a { color: inherit; }
+button { font: inherit; }
+
+h1, h2, h3 {
+  font-family: var(--font-display);
+  font-weight: var(--display-weight);
+  letter-spacing: var(--display-tracking);
+  line-height: 1.08;
+  margin: 0 0 0.4em;
+}
+
+/* ---- Layout -------------------------------------------------------------- */
+.container {
+  width: 100%;
+  max-width: var(--container);
+  margin: 0 auto;
+  padding: 0 var(--gutter);
+}
+.container--narrow { max-width: 720px; }
+
+/* Sections carry their own rhythm; see each block below. */
+.band { position: relative; }
+.band--tint { background: var(--c-bg-alt); }
+.band--invert {
+  background: var(--c-invert-bg);
+  color: var(--c-invert-ink);
+}
+.band--invert h2, .band--invert h3 { color: var(--c-invert-ink); }
+.band--invert p { color: var(--c-invert-ink-2); }
+
+.eyebrow {
+  display: inline-block;
+  font-family: var(--font-body);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: var(--eyebrow-tracking);
+  text-transform: uppercase;
+  color: var(--c-accent);
+  margin-bottom: 14px;
+}
+.band--invert .eyebrow { color: var(--c-accent); }
+
+.h2 { font-size: 27px; margin-bottom: 14px; text-transform: var(--display-case); }
+.lede { color: var(--c-ink-2); font-size: 17px; max-width: 46ch; }
+.band--invert .lede { color: var(--c-invert-ink-2); }
+
+/* A hand-drawn-ish underline under one word of a headline. Purely decorative;
+   this is the single most effective "a person made this" signal on the page. */
+.mark {
+  position: relative;
+  /* z-index:0 is load-bearing: it makes .mark a stacking context so the
+     ::after at -1 sits behind the text but still above the section background
+     instead of disappearing under it. */
+  z-index: 0;
+  white-space: nowrap;
+  color: inherit;
+}
+.mark::after {
+  content: "";
+  position: absolute;
+  left: -2%;
+  right: -2%;
+  bottom: -0.06em;
+  height: 0.34em;
+  background: var(--c-accent);
+  opacity: 0.32;
+  border-radius: 0.2em 0.6em 0.3em 0.5em;
+  transform: rotate(-0.6deg);
+  z-index: -1;
+}
+
+/* ---- Buttons ------------------------------------------------------------- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  font-family: var(--font-body);
+  font-size: 17px;
+  font-weight: 700;
+  line-height: 1;
+  padding: 17px 30px;
+  border: none;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform .12s ease, background .16s ease, box-shadow .16s ease, opacity .16s ease;
+}
+.btn:active { transform: translateY(1px); }
+.btn--cta {
+  background: var(--c-cta);
+  color: var(--c-cta-ink);
+  box-shadow: var(--shadow-2);
+}
+.btn--cta:hover { background: var(--c-cta-hover); }
+.btn--brand { background: var(--c-brand); color: #fff; }
+.btn--quiet {
+  background: transparent;
+  color: var(--c-ink);
+  border: 1.5px solid var(--c-line-strong);
+}
+.btn--quiet:hover { border-color: var(--c-ink); }
+.btn--sm { padding: 11px 20px; font-size: 15px; }
+.btn--lg { padding: 19px 36px; font-size: 18px; }
+.btn--block { width: 100%; }
+.btn[disabled], .btn--off {
+  background: var(--c-line);
+  color: var(--c-ink-3);
+  box-shadow: none;
+  cursor: not-allowed;
+}
+
+/* ---- Header -------------------------------------------------------------- */
+.hdr {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  background: color-mix(in srgb, var(--c-bg) 88%, transparent);
+  backdrop-filter: saturate(160%) blur(12px);
+  -webkit-backdrop-filter: saturate(160%) blur(12px);
+  border-bottom: 1px solid var(--c-line);
+}
+.hdr__inner {
+  height: var(--header-h);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.hdr__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-display);
+  font-weight: var(--display-weight);
+  font-size: 18px;
+  letter-spacing: var(--display-tracking);
+  text-decoration: none;
+  color: var(--c-ink);
+}
+.hdr__brand svg { width: 20px; height: 20px; color: var(--c-brand); }
+
+/* Theme switcher — dev/AB affordance, hidden unless ?themepicker=1 */
+.themepicker {
+  position: fixed;
+  right: 14px;
+  bottom: 84px;
+  z-index: 60;
+  display: none;
+  gap: 6px;
+  background: var(--c-surface);
+  border: 1px solid var(--c-line);
+  border-radius: var(--radius-pill);
+  padding: 6px;
+  box-shadow: var(--shadow-2);
+}
+.themepicker--on { display: flex; }
+.themepicker button {
+  border: none;
+  background: transparent;
+  color: var(--c-ink-2);
+  font-size: 12px;
+  font-weight: 700;
+  padding: 6px 11px;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+}
+.themepicker button[aria-current="true"] { background: var(--c-ink); color: var(--c-bg); }
+
+/* ============================================================================
+   HERO — asymmetric: copy left, portrait right, portrait bleeds past the grid
+   ============================================================================ */
+.hero { padding: 34px 0 0; overflow: hidden; }
+.hero__grid { display: grid; gap: 26px; }
+.hero__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--c-ink-2);
+  background: var(--c-bg-alt);
+  border: 1px solid var(--c-line);
+  padding: 6px 14px;
+  border-radius: var(--radius-pill);
+  margin-bottom: 18px;
+}
+.hero__badge svg { width: 14px; height: 14px; color: var(--c-brand); }
+.hero__title {
+  font-size: clamp(38px, 11vw, 52px);
+  margin-bottom: 16px;
+  text-transform: var(--display-case);
+}
+.hero__sub { font-size: 18px; color: var(--c-ink-2); margin-bottom: 26px; max-width: 34ch; }
+.hero__actions { display: flex; flex-direction: column; gap: 10px; align-items: stretch; }
+.hero__reassure {
+  margin: 16px 0 0;
+  font-size: 13px;
+  color: var(--c-ink-3);
+}
+.hero__media {
+  position: relative;
+  /* Same reason as .mark — contains the blob's negative z-index. */
+  z-index: 0;
+  margin: 4px calc(var(--gutter) * -1) 0;
+}
+.hero__media img {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+  object-position: 50% 22%;
+  border-radius: 0;
+}
+/* Off-grid accent blob — breaks the perfect rectangle. */
+.hero__blob {
+  position: absolute;
+  width: 190px;
+  height: 190px;
+  border-radius: 50%;
+  background: var(--c-accent);
+  opacity: 0.14;
+  filter: blur(6px);
+  top: -46px;
+  right: -40px;
+  z-index: -1;
+}
+
+/* ---- Proof strip: hairline-separated inline band, not cards -------------- */
+.proof { border-top: 1px solid var(--c-line); border-bottom: 1px solid var(--c-line); }
+.proof__row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+.proof__cell {
+  padding: 18px 8px;
+  text-align: center;
+}
+.proof__cell + .proof__cell { border-left: 1px solid var(--c-line); }
+.proof__value {
+  font-family: var(--font-display);
+  font-weight: var(--display-weight);
+  font-size: 23px;
+  letter-spacing: var(--display-tracking);
+  line-height: 1.1;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.proof__value svg { width: 16px; height: 16px; color: var(--c-star); }
+.proof__label { font-size: 12px; color: var(--c-ink-3); line-height: 1.35; }
+
+/* ============================================================================
+   PROBLEM — two columns on desktop, pain points as a plain list (no cards)
+   ============================================================================ */
+.problem { padding: 54px 0 44px; }
+.problem__grid { display: grid; gap: 28px; }
+.problem__list { list-style: none; padding: 0; margin: 0; display: grid; }
+.problem__item {
+  display: flex;
+  gap: 13px;
+  align-items: flex-start;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--c-line);
+  color: var(--c-ink-2);
+  font-size: 16px;
+}
+.problem__item:first-child { border-top: 1px solid var(--c-line); }
+.problem__item svg { width: 17px; height: 17px; flex: 0 0 auto; margin-top: 3px; color: var(--c-danger); }
+
+/* ---- The loop: inverted full-bleed band, connected steps ----------------- */
+.loop { padding: 44px 0 48px; }
+.loop__label {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: var(--eyebrow-tracking);
+  text-transform: uppercase;
+  color: var(--c-accent);
+  margin-bottom: 22px;
+}
+.loop__steps {
+  display: grid;
+  gap: 0;
+  position: relative;
+}
+.loop__step {
+  display: grid;
+  grid-template-columns: 42px 1fr;
+  gap: 14px;
+  padding: 0 0 20px;
+  position: relative;
+}
+.loop__step::before {
+  content: "";
+  position: absolute;
+  left: 20px;
+  top: 40px;
+  bottom: 0;
+  width: 1px;
+  background: var(--c-invert-line);
+}
+.loop__step:last-child::before { display: none; }
+.loop__icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  border: 1px solid var(--c-invert-line);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--c-accent);
+  background: var(--c-invert-bg);
+}
+.loop__icon svg { width: 19px; height: 19px; }
+.loop__step-title { font-size: 17px; margin-bottom: 3px; }
+.loop__step-body { font-size: 15px; margin: 0; }
+.loop__note {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--c-invert-ink-2);
+  font-size: 14px;
+  font-style: italic;
+  margin-top: 2px;
+}
+.loop__note svg { width: 15px; height: 15px; }
+.loop__break {
+  margin-top: 28px;
+  border-top: 1px solid var(--c-invert-line);
+  padding-top: 24px;
+}
+.loop__break-label {
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: var(--eyebrow-tracking);
+  text-transform: uppercase;
+  color: var(--c-cta);
+  margin-bottom: 8px;
+}
+.loop__break-body { font-size: 17px; margin: 0; max-width: 52ch; }
+.loop__break-body strong { color: var(--c-invert-ink); }
+
+/* ============================================================================
+   PERSONAS — hanging index numerals, hairlines, zero boxes
+   ============================================================================ */
+.personas { padding: 50px 0; }
+.personas__grid { display: grid; gap: 0; margin-top: 24px; }
+.persona {
+  display: grid;
+  grid-template-columns: 44px 1fr;
+  gap: 12px;
+  padding: 20px 0;
+  border-top: 1px solid var(--c-line);
+}
+.persona__idx {
+  font-family: var(--font-display);
+  font-size: 14px;
+  font-weight: var(--display-weight);
+  color: var(--c-accent);
+  padding-top: 3px;
+}
+.persona__title { font-size: 18px; margin-bottom: 3px; }
+.persona__body { color: var(--c-ink-2); margin: 0; font-size: 16px; }
+
+/* ============================================================================
+   HOW — oversized numerals, rule-separated, chips underneath
+   ============================================================================ */
+.how { padding: 52px 0; }
+.how__steps { display: grid; gap: 0; margin-top: 22px; }
+.how__step { padding: 22px 0; border-top: 1px solid var(--c-line-strong); }
+.how__num {
+  font-family: var(--font-display);
+  font-weight: var(--display-weight);
+  font-size: 40px;
+  line-height: 1;
+  letter-spacing: var(--display-tracking);
+  color: var(--c-line-strong);
+  margin-bottom: 8px;
+}
+.how__step-title { font-size: 19px; margin-bottom: 4px; }
+.how__step-body { color: var(--c-ink-2); margin: 0; }
+.how__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 28px;
+  padding-top: 24px;
+  border-top: 1px solid var(--c-line);
+}
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--c-ink-2);
+  background: var(--c-bg-alt);
+  border: 1px solid var(--c-line);
+  border-radius: var(--radius-pill);
+  padding: 8px 15px;
+}
+.chip svg { width: 14px; height: 14px; color: var(--c-cta); }
+
+/* ============================================================================
+   TESTIMONIALS — bulletproof by construction.
+   Desktop: CSS multi-column wall. Mobile: native scroll-snap strip.
+   No transform animation, no oversized composited layer, no rAF loop —
+   nothing here can fail to paint the way the v1 6320px marquee did.
+   ============================================================================ */
+.tw { padding: 50px 0 54px; }
+.tw__wall { margin-top: 26px; }
+.tw__card {
+  background: var(--c-surface);
+  border: var(--card-border);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+  box-shadow: var(--shadow-1);
+}
+.tw__stars { display: flex; gap: 2px; margin-bottom: 9px; }
+.tw__stars svg { width: 15px; height: 15px; color: var(--c-star); }
+.tw__title { font-size: 16px; margin-bottom: 5px; }
+.tw__quote { color: var(--c-ink-2); font-size: 15px; margin: 0 0 14px; }
+.tw__by { display: flex; align-items: center; gap: 8px; font-size: 13px; }
+.tw__name { font-weight: 700; }
+.tw__badge {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--c-cta-hover);
+  background: color-mix(in srgb, var(--c-cta) 14%, transparent);
+  border-radius: var(--radius-pill);
+  padding: 3px 9px;
+}
+.tw__note { margin: 18px 0 0; font-size: 12px; color: var(--c-ink-3); }
+.tw__more { margin-top: 22px; text-align: center; }
+.tw__swipe {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  color: var(--c-ink-3);
+  margin-top: 12px;
+}
+.tw__swipe svg { width: 14px; height: 14px; }
+.tw__progress {
+  height: 3px;
+  background: var(--c-line);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+  margin-top: 10px;
+}
+.tw__progress-bar {
+  height: 100%;
+  width: 22%;
+  background: var(--c-accent);
+  border-radius: inherit;
+  transition: width .1s linear;
+}
+
+/* Mobile: horizontal snap strip, full-bleed out of the container. */
+@media (max-width: 767px) {
+  .tw__wall {
+    display: flex;
+    gap: 12px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+    padding: 4px var(--gutter) 14px;
+    margin: 26px calc(var(--gutter) * -1) 0;
+    scroll-padding-left: var(--gutter);
+    scrollbar-width: none;
+  }
+  .tw__wall::-webkit-scrollbar { display: none; }
+  .tw__card {
+    flex: 0 0 84%;
+    scroll-snap-align: start;
+    display: flex;
+    flex-direction: column;
+  }
+  .tw__quote { flex: 1 1 auto; }
+  .tw__more { display: none; }
+}
+
+/* Desktop: static masonry wall. Extra cards revealed by the More button. */
+@media (min-width: 768px) {
+  .tw__wall { columns: 3; column-gap: 18px; }
+  .tw__card { break-inside: avoid; margin-bottom: 18px; display: block; }
+  .tw__card--extra { display: none; }
+  .tw__wall--open .tw__card--extra { display: block; }
+  .tw__swipe, .tw__progress { display: none; }
+}
+
+/* ============================================================================
+   PRICING
+   ============================================================================ */
+.pricing { padding: 54px 0; }
+.pricing__anchor {
+  max-width: 32ch;
+  margin: 0 auto 26px;
+  font-family: var(--font-display);
+  font-weight: var(--display-weight);
+  font-size: 19px;
+  line-height: 1.35;
+  letter-spacing: var(--display-tracking);
+  text-align: center;
+  color: var(--c-ink);
+  border-left: 3px solid var(--c-accent);
+  padding: 4px 0 4px 16px;
+  text-align: left;
+}
+.pricing__goals { max-width: 520px; margin: 0 auto 26px; display: grid; gap: 9px; }
+.pricing__goal { display: flex; gap: 10px; align-items: flex-start; font-size: 15px; color: var(--c-ink-2); }
+.pricing__goal svg { width: 17px; height: 17px; flex: 0 0 auto; margin-top: 2px; color: var(--c-cta); }
+
+.pricing__reason {
+  max-width: 520px;
+  margin: 0 auto 12px;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--c-accent);
+  text-align: center;
+}
+.tiers { display: grid; gap: 12px; max-width: 520px; margin: 0 auto; }
+.tier {
+  position: relative;
+  background: var(--c-surface);
+  border: 2px solid var(--c-line);
+  border-radius: var(--radius-lg);
+  padding: 18px;
+  cursor: pointer;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 13px;
+  transition: border-color .15s ease, box-shadow .15s ease;
+}
+.tier:hover { border-color: var(--c-brand); }
+.tier--on { border-color: var(--c-brand); box-shadow: 0 0 0 4px var(--c-brand-soft); }
+.tier__radio {
+  width: 21px; height: 21px;
+  border-radius: 50%;
+  border: 2px solid var(--c-line-strong);
+  position: relative;
+}
+.tier--on .tier__radio { border-color: var(--c-brand); }
+.tier--on .tier__radio::after {
+  content: "";
+  position: absolute; inset: 4px;
+  border-radius: 50%;
+  background: var(--c-brand);
+}
+.tier__name { font-weight: 800; font-size: 15px; letter-spacing: 0.02em; }
+.tier__perday { color: var(--c-ink-2); font-size: 14px; }
+.tier__savings {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 800;
+  color: var(--c-cta-hover);
+  background: color-mix(in srgb, var(--c-cta) 14%, transparent);
+  border-radius: var(--radius-pill);
+  padding: 2px 8px;
+  margin-top: 3px;
+}
+.tier__prices { text-align: right; }
+.tier__was { color: var(--c-ink-3); text-decoration: line-through; font-size: 13px; }
+.tier__now { font-family: var(--font-display); font-weight: var(--display-weight); font-size: 20px; }
+.tier__badge {
+  position: absolute;
+  top: -10px; left: 50%;
+  transform: translateX(-50%);
+  background: var(--c-accent);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.07em;
+  padding: 4px 11px;
+  border-radius: var(--radius-pill);
+  white-space: nowrap;
+}
+.pricing__act { max-width: 520px; margin: 22px auto 0; }
+.pricing__guarantee {
+  max-width: 520px;
+  margin: 14px auto 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  font-size: 15px;
+  font-weight: 700;
+}
+.pricing__guarantee svg { width: 19px; height: 19px; color: var(--c-cta); }
+.pricing__legal { max-width: 520px; margin: 14px auto 0; font-size: 11.5px; color: var(--c-ink-3); text-align: center; }
+
+/* ============================================================================
+   TRUST — privacy / payment / research accordion, below the price
+   ============================================================================ */
+.trust { padding: 46px 0; }
+.trust__grid { display: grid; gap: 30px; }
+.trust__h { font-size: 17px; margin-bottom: 12px; }
+.trust__list { list-style: none; padding: 0; margin: 0; display: grid; gap: 9px; }
+.trust__list li { display: flex; gap: 10px; font-size: 15px; color: var(--c-ink-2); }
+.trust__list svg { width: 16px; height: 16px; flex: 0 0 auto; margin-top: 3px; color: var(--c-brand); }
+.paysec { display: flex; flex-wrap: wrap; gap: 7px; }
+.paysec span {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--c-ink-2);
+  background: var(--c-surface);
+  border: 1px solid var(--c-line);
+  border-radius: var(--radius);
+  padding: 6px 11px;
+}
+.sci__summary { color: var(--c-ink-2); font-size: 15px; margin-bottom: 12px; }
+.sci__toggle {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--c-brand);
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.sci__toggle svg { width: 14px; height: 14px; transition: transform .2s ease; }
+.sci--open .sci__toggle svg { transform: rotate(180deg); }
+.sci__body { max-height: 0; overflow: hidden; transition: max-height .3s ease; }
+.sci__point { padding: 14px 0; border-bottom: 1px solid var(--c-line); }
+.sci__point:first-child { padding-top: 16px; }
+.sci__claim { font-weight: 700; font-size: 15px; margin-bottom: 3px; }
+.sci__detail { color: var(--c-ink-2); font-size: 14px; margin: 0 0 4px; }
+.sci__source { color: var(--c-ink-3); font-size: 12px; font-style: italic; }
+.sci__disclaimer { color: var(--c-ink-3); font-size: 12px; margin: 14px 0 0; }
+
+/* ============================================================================
+   FAQ — hairlines only, no card chrome
+   ============================================================================ */
+.faq { padding: 50px 0; }
+.faq__list { margin-top: 20px; }
+.faq__item { border-top: 1px solid var(--c-line); }
+.faq__item:last-child { border-bottom: 1px solid var(--c-line); }
+.faq__q {
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  font-size: 17px;
+  font-weight: 700;
+  color: var(--c-ink);
+  padding: 19px 42px 19px 0;
+  cursor: pointer;
+  position: relative;
+}
+.faq__q::after,
+.faq__q::before {
+  content: "";
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  width: 14px;
+  height: 2px;
+  background: var(--c-ink-3);
+  border-radius: 2px;
+  transition: transform .22s ease;
+}
+.faq__q::before { transform: translateY(-50%) rotate(90deg); }
+.faq__q::after { transform: translateY(-50%); }
+.faq__item--open .faq__q::before { transform: translateY(-50%) rotate(0deg); }
+.faq__a { max-height: 0; overflow: hidden; transition: max-height .28s ease; }
+.faq__a p { color: var(--c-ink-2); font-size: 16px; margin: 0 0 19px; max-width: 62ch; }
+
+/* ============================================================================
+   FINAL CTA — full-bleed accent band
+   ============================================================================ */
+.final { padding: 56px 0 60px; text-align: center; background: var(--c-invert-bg); color: var(--c-invert-ink); }
+.final__title { font-size: clamp(30px, 9vw, 42px); color: var(--c-invert-ink); margin-bottom: 10px; text-transform: var(--display-case); }
+.final__sub { color: var(--c-invert-ink-2); margin: 0 auto 26px; max-width: 30ch; font-size: 17px; }
+
+/* ---- Footer -------------------------------------------------------------- */
+.ftr {
+  background: var(--c-bg-alt);
+  border-top: 1px solid var(--c-line);
+  padding: 34px 0 calc(34px + env(safe-area-inset-bottom));
+  font-size: 13px;
+  color: var(--c-ink-3);
+}
+.ftr__inner { display: grid; gap: 18px; }
+.ftr__brand { display: inline-flex; align-items: center; gap: 8px; font-family: var(--font-display); font-weight: var(--display-weight); font-size: 16px; color: var(--c-ink); margin-bottom: 8px; }
+.ftr__brand svg { width: 17px; height: 17px; color: var(--c-brand); }
+.ftr__links { display: flex; flex-wrap: wrap; gap: 6px 18px; }
+.ftr__links a { text-decoration: none; }
+.ftr__links a:hover { color: var(--c-ink); text-decoration: underline; }
+
+/* ---- Sticky mobile CTA ---------------------------------------------------- */
+.sticky {
+  position: fixed;
+  left: 0; right: 0; bottom: 0;
+  z-index: 45;
+  background: color-mix(in srgb, var(--c-bg) 94%, transparent);
+  backdrop-filter: saturate(160%) blur(12px);
+  -webkit-backdrop-filter: saturate(160%) blur(12px);
+  border-top: 1px solid var(--c-line);
+  padding: 11px 16px calc(11px + env(safe-area-inset-bottom));
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  transform: translateY(130%);
+  transition: transform .25s ease;
+}
+.sticky--on { transform: translateY(0); }
+.sticky__price { flex: 0 0 auto; font-size: 12px; line-height: 1.2; color: var(--c-ink-3); }
+.sticky__price strong { display: block; font-size: 17px; font-weight: 800; color: var(--c-ink); }
+.sticky .btn { flex: 1 1 auto; }
+
+/* ============================================================================
+   QUIZ MODAL (quiz variant only)
+   ============================================================================ */
+.quiz { position: fixed; inset: 0; z-index: 90; display: none; }
+.quiz--open { display: block; }
+.quiz__scrim { position: absolute; inset: 0; background: color-mix(in srgb, var(--c-invert-bg) 62%, transparent); }
+.quiz__sheet {
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  max-height: 94vh;
+  overflow-y: auto;
+  background: var(--c-bg);
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  padding: 26px var(--gutter) calc(26px + env(safe-area-inset-bottom));
+  animation: sheet-in .26s ease;
+}
+@keyframes sheet-in { from { transform: translateY(26px); opacity: .5 } to { transform: none; opacity: 1 } }
+.quiz__bar { height: 4px; background: var(--c-line); border-radius: var(--radius-pill); overflow: hidden; margin-bottom: 22px; }
+.quiz__bar-fill { height: 100%; width: 0; background: var(--c-accent); border-radius: inherit; transition: width .3s ease; }
+.quiz__step { font-size: 12px; font-weight: 700; letter-spacing: var(--eyebrow-tracking); text-transform: uppercase; color: var(--c-ink-3); margin-bottom: 10px; }
+.quiz__prompt { font-size: 25px; margin-bottom: 20px; }
+.quiz__opts { display: grid; gap: 10px; }
+.quiz__opt {
+  text-align: left;
+  background: var(--c-surface);
+  border: 2px solid var(--c-line);
+  border-radius: var(--radius);
+  padding: 17px 18px;
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--c-ink);
+  cursor: pointer;
+  transition: border-color .14s ease, background .14s ease, transform .1s ease;
+}
+.quiz__opt:hover { border-color: var(--c-brand); }
+.quiz__opt--on { border-color: var(--c-brand); background: var(--c-brand-soft); }
+.quiz__back {
+  margin-top: 18px;
+  background: none;
+  border: none;
+  color: var(--c-ink-3);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 6px 0;
+}
+.quiz__close {
+  position: absolute;
+  top: 12px; right: 14px;
+  background: none; border: none;
+  font-size: 26px; line-height: 1;
+  color: var(--c-ink-3);
+  cursor: pointer;
+}
+/* Building state */
+.build__title { font-size: 21px; margin-bottom: 20px; }
+.build__list { list-style: none; padding: 0; margin: 0; display: grid; gap: 13px; }
+.build__row { display: flex; align-items: center; gap: 11px; font-size: 16px; color: var(--c-ink-3); transition: color .3s ease; }
+.build__row svg { width: 19px; height: 19px; flex: 0 0 auto; }
+.build__row--done { color: var(--c-ink); }
+.build__row--done svg { color: var(--c-cta); }
+.build__spin { animation: spin 1s linear infinite; color: var(--c-brand); }
+@keyframes spin { to { transform: rotate(360deg) } }
+
+/* Personalized plan card injected above pricing */
+.plan {
+  max-width: 520px;
+  margin: 0 auto 26px;
+  background: var(--c-surface);
+  border: 2px solid var(--c-brand);
+  border-radius: var(--radius-lg);
+  padding: 22px;
+  box-shadow: var(--shadow-2);
+}
+.plan__eyebrow { font-size: 12px; font-weight: 700; letter-spacing: var(--eyebrow-tracking); text-transform: uppercase; color: var(--c-cta-hover); display: inline-flex; align-items: center; gap: 6px; margin-bottom: 9px; }
+.plan__eyebrow svg { width: 15px; height: 15px; }
+.plan__title { font-size: 23px; margin-bottom: 8px; }
+.plan__body { color: var(--c-ink-2); font-size: 15px; margin: 0 0 14px; }
+.plan__tags { display: flex; flex-wrap: wrap; gap: 7px; }
+.plan__tag {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--c-brand);
+  background: var(--c-brand-soft);
+  border-radius: var(--radius-pill);
+  padding: 5px 11px;
+}
+
+/* ============================================================================
+   CHECKOUT MODAL
+   ============================================================================ */
+.modal { position: fixed; inset: 0; z-index: 100; display: none; align-items: flex-end; justify-content: center; }
+.modal--open { display: flex; }
+.modal__scrim { position: absolute; inset: 0; background: color-mix(in srgb, var(--c-invert-bg) 55%, transparent); }
+.modal__dialog {
+  position: relative;
+  background: var(--c-bg);
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  width: 100%;
+  max-width: 460px;
+  max-height: 92vh;
+  overflow-y: auto;
+  padding: 26px 20px calc(26px + env(safe-area-inset-bottom));
+  animation: sheet-in .25s ease;
+}
+.modal__close { position: absolute; top: 12px; right: 14px; background: none; border: none; font-size: 26px; line-height: 1; color: var(--c-ink-3); cursor: pointer; }
+.modal__title { font-size: 21px; margin-bottom: 12px; padding-right: 26px; }
+.modal__summary {
+  background: var(--c-bg-alt);
+  border: 1px solid var(--c-line);
+  border-radius: var(--radius);
+  padding: 13px 15px;
+  margin-bottom: 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.modal__summary-name { font-weight: 700; font-size: 15px; }
+.modal__summary-perday { color: var(--c-ink-3); font-size: 12px; }
+.modal__summary-price { font-family: var(--font-display); font-weight: var(--display-weight); font-size: 19px; }
+
+.field { display: block; margin-bottom: 14px; }
+.field__label { display: block; font-weight: 700; font-size: 13px; margin-bottom: 6px; }
+.field__input {
+  width: 100%;
+  font: inherit;
+  font-size: 16px;
+  padding: 13px 14px;
+  border: 1.5px solid var(--c-line-strong);
+  border-radius: var(--radius);
+  background: var(--c-surface);
+  color: var(--c-ink);
+}
+.field__input:focus { outline: none; border-color: var(--c-brand); box-shadow: 0 0 0 3px var(--c-brand-soft); }
+.field__error { display: block; color: var(--c-danger); font-size: 13px; margin-top: 5px; min-height: 1em; }
+.pay__mount { margin-bottom: 14px; min-height: 40px; }
+.pay__loading { color: var(--c-ink-3); font-size: 14px; text-align: center; padding: 12px; }
+.pay__error { color: var(--c-danger); font-size: 14px; margin-bottom: 10px; min-height: 1em; }
+.pay__legal { color: var(--c-ink-3); font-size: 11.5px; margin-top: 13px; }
+.pay__secure { color: var(--c-ink-3); font-size: 12.5px; text-align: center; margin: 9px 0 0; display: flex; align-items: center; justify-content: center; gap: 6px; }
+.pay__secure svg { width: 13px; height: 13px; }
+
+/* ---- Scroll reveal -------------------------------------------------------- */
+.rv { opacity: 0; transform: translateY(18px); transition: opacity .55s ease, transform .55s ease; }
+.rv--in { opacity: 1; transform: none; }
+
+/* ============================================================================
+   RESPONSIVE
+   ============================================================================ */
+@media (min-width: 700px) {
+  body { font-size: 18px; }
+  .h2 { font-size: 33px; }
+  .hero { padding: 56px 0 0; }
+  .hero__grid { grid-template-columns: 1.05fr 0.95fr; gap: 44px; align-items: center; }
+  .hero__actions { flex-direction: row; align-items: center; }
+  .hero__media { margin: 0; }
+  .hero__media img { border-radius: var(--radius-lg); aspect-ratio: 4 / 5; }
+  .hero__blob { top: -30px; right: -30px; width: 230px; height: 230px; }
+
+  .proof__value { font-size: 28px; }
+  .proof__label { font-size: 13px; }
+  .proof__cell { padding: 22px 12px; }
+
+  .problem { padding: 76px 0 60px; }
+  .problem__grid { grid-template-columns: 1fr 1fr; gap: 48px; align-items: start; }
+
+  .loop { padding: 62px 0 68px; }
+  .loop__steps { grid-template-columns: repeat(4, 1fr); gap: 18px; }
+  .loop__step { grid-template-columns: 1fr; gap: 12px; padding: 0; }
+  .loop__step::before { left: 42px; right: -18px; top: 21px; bottom: auto; width: auto; height: 1px; }
+  .loop__break { margin-top: 40px; padding-top: 30px; }
+
+  .personas { padding: 72px 0; }
+  .personas__grid { grid-template-columns: 1fr 1fr; column-gap: 44px; }
+
+  .how { padding: 74px 0; }
+  .how__steps { grid-template-columns: repeat(3, 1fr); column-gap: 30px; }
+  .how__num { font-size: 52px; }
+
+  .tw { padding: 72px 0; }
+  .pricing { padding: 76px 0; }
+  .pricing__anchor { font-size: 22px; max-width: 40ch; }
+  .trust { padding: 64px 0; }
+  .trust__grid { grid-template-columns: 1fr 1fr; column-gap: 48px; }
+  .trust__sci { grid-column: 1 / -1; border-top: 1px solid var(--c-line); padding-top: 26px; }
+  .faq { padding: 72px 0; }
+  .final { padding: 84px 0; }
+  .ftr__inner { display: flex; justify-content: space-between; align-items: flex-end; }
+
+  .quiz__sheet {
+    left: 50%; right: auto; bottom: auto; top: 50%;
+    transform: translate(-50%, -50%);
+    width: min(560px, calc(100vw - 40px));
+    border-radius: var(--radius-lg);
+    padding: 32px;
+  }
+  .modal__dialog { border-radius: var(--radius-lg); margin-bottom: 4vh; }
+  .modal { align-items: center; }
+
+  .sticky { display: none !important; }
+  .themepicker { bottom: 20px; }
+}
+
+@media (min-width: 1000px) {
+  .hero__title { font-size: 58px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  .rv { opacity: 1; transform: none; transition: none; }
+  .build__spin { animation: none; }
+}

--- a/funnel/landing-shared/landing.js
+++ b/funnel/landing-shared/landing.js
@@ -1,0 +1,1063 @@
+/* ============================================================================
+   Mind Compass — landing v2 shared controller
+   ----------------------------------------------------------------------------
+   Drives both variants:
+     /landing-quiz/    window.LANDING_CONFIG.flow === 'quiz'
+     /landing-direct/  window.LANDING_CONFIG.flow === 'direct'
+
+   Backend is the funnel's existing serverless API:
+     /api/prices             live multi-currency pricing
+     /api/create-checkout    Stripe PaymentIntent for the embedded checkout
+     /api/provision-account  Supabase account + session handoff
+
+   Currency + MetaPixel logic mirrors funnel/engine/app.js — keep in sync.
+   ============================================================================ */
+(function () {
+  'use strict';
+
+  const CFG = Object.assign({
+    flow: 'direct',
+    funnelVersion: 'landing-direct',
+    pixelContentName: 'LandingDirect',
+    webappUrl: 'https://mind-compass-webapp.vercel.app',
+    stripePk: 'pk_live_51RGn19EIAGyjtjbOlAiSpPQ3NnuzFCSg7ReDs1bE1zYzCuNkmZC1HvdT5tsbLu1vzMOLMwYluxHJy6TBbP38rWML00rdVcYbRg',
+    contentUrl: '../landing-shared/content.json',
+  }, window.LANDING_CONFIG || {});
+
+  const isDev = () => ['localhost', '127.0.0.1'].includes(location.hostname);
+  const el = (id) => document.getElementById(id);
+  const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  const esc = (s) => {
+    if (s == null) return '';
+    const d = document.createElement('div');
+    d.textContent = String(s);
+    return d.innerHTML;
+  };
+
+  // ==========================================================================
+  // Icons — inline SVG line set. v1 used emoji here, which is the single
+  // loudest "generated page" tell; these also inherit currentColor per theme.
+  // ==========================================================================
+  const P = (d, extra) => `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${d}${extra || ''}</svg>`;
+  const ICON = {
+    compass: P('<circle cx="12" cy="12" r="9"/><path d="m15.5 8.5-2 5-5 2 2-5z"/>'),
+    lock:    P('<rect x="4" y="10" width="16" height="10" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3"/>'),
+    check:   P('<path d="m4 12.5 5 5L20 6.5"/>'),
+    cross:   P('<path d="M6 6l12 12M18 6 6 18"/>'),
+    spark:   P('<path d="M13 2 4 14h7l-1 8 9-12h-7z"/>'),
+    flame:   P('<path d="M12 2c3 4 6 6 6 10a6 6 0 0 1-12 0c0-2 1-3.5 2-5 .5 1.5 1.5 2 2.5 2 0-3 .5-5 1.5-7z"/>'),
+    swirl:   P('<path d="M12 3a9 9 0 1 0 9 9"/><path d="M12 7a5 5 0 1 1-5 5"/><path d="M12 11a1 1 0 1 0 1 1"/>'),
+    fog:     P('<path d="M6 10a5 5 0 0 1 9.7-1.7A4 4 0 0 1 18 16H7a4 4 0 0 1-1-6z"/><path d="M4 20h6M14 20h6"/>'),
+    rotate:  P('<path d="M3 12a9 9 0 1 1 3 6.7"/><path d="M3 20v-6h6"/>'),
+    star:    '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="m12 2.5 2.9 6 6.6.9-4.8 4.6 1.2 6.5L12 17.4l-5.9 3.1 1.2-6.5L2.5 9.4l6.6-.9z"/></svg>',
+    shield:  P('<path d="M12 3 5 6v6c0 4.2 2.9 7.8 7 9 4.1-1.2 7-4.8 7-9V6z"/><path d="m9 12 2 2 4-4"/>'),
+    chevron: P('<path d="m6 9 6 6 6-6"/>'),
+    arrow:   P('<path d="M4 12h15"/><path d="m13 6 6 6-6 6"/>'),
+    swipe:   P('<path d="M4 12h13"/><path d="m12 7 5 5-5 5"/><path d="M20 8v8"/>'),
+    sparkle: P('<path d="M12 3v4M12 17v4M3 12h4M17 12h4"/><path d="m6.5 6.5 2.5 2.5M15 15l2.5 2.5M17.5 6.5 15 9M9 15l-2.5 2.5"/>'),
+    loader:  P('<path d="M12 3v4"/><path d="M12 17v4" opacity=".3"/><path d="M5.6 5.6 8.5 8.5"/><path d="m15.5 15.5 2.9 2.9" opacity=".3"/><path d="M3 12h4" opacity=".6"/><path d="M17 12h4" opacity=".3"/>'),
+  };
+  const ic = (name) => ICON[name] || '';
+
+  // ==========================================================================
+  // Currency — compact port of engine/app.js Currency
+  // ==========================================================================
+  const Currency = {
+    _META: { usd: { symbol: '$' }, eur: { symbol: '€' }, gbp: { symbol: '£' }, cad: { symbol: 'CA$' }, aud: { symbol: 'A$' } },
+    PRICES: {},
+    _fetched: false,
+    _detected: null,
+
+    _fmt(cents, c) { return `${this._META[c]?.symbol || c.toUpperCase()}${(cents / 100).toFixed(2)}`; },
+    _perDay(cents, days, c) { return `${this._META[c]?.symbol || ''}${(cents / days / 100).toFixed(2)}/day`; },
+
+    populate(raw) {
+      const SUPPORTED = ['usd', 'eur', 'gbp', 'cad', 'aud'];
+      const TIERS = [
+        { id: '7_day',   introKey: 'intro_7day',   regularKey: 'regular_monthly',   days: 7 },
+        { id: '1_month', introKey: 'intro_1month', regularKey: 'regular_monthly',   days: 30 },
+        { id: '3_month', introKey: 'intro_3month', regularKey: 'regular_quarterly', days: 90 },
+      ];
+      const amt = (key, c) => {
+        const p = raw[key];
+        if (!p) return 0;
+        return p.currency_amounts?.[c] ?? p.currency_amounts?.[p.base_currency] ?? 0;
+      };
+      for (const c of SUPPORTED) {
+        const t = {};
+        for (const tier of TIERS) {
+          t[tier.id] = {
+            original: this._fmt(amt(tier.regularKey, c), c),
+            discounted: this._fmt(amt(tier.introKey, c), c),
+            perDay: this._perDay(amt(tier.introKey, c), tier.days, c),
+          };
+        }
+        this.PRICES[c] = t;
+      }
+      this._fetched = true;
+    },
+
+    fetch() {
+      if (this._fetched) return Promise.resolve();
+      try {
+        const raw = sessionStorage.getItem('_mc_prices_v1');
+        if (raw) {
+          const { data, ts } = JSON.parse(raw);
+          if (Date.now() - ts < 3_600_000) { this.populate(data); return Promise.resolve(); }
+        }
+      } catch (_) {}
+      return fetch('/api/prices')
+        .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+        .then(({ prices }) => {
+          this.populate(prices);
+          try { sessionStorage.setItem('_mc_prices_v1', JSON.stringify({ data: prices, ts: Date.now() })); } catch (_) {}
+        })
+        .catch(() => { /* keep the static EUR fallback from content.json */ });
+    },
+
+    detect() {
+      if (this._detected) return this._detected;
+      const override = new URLSearchParams(location.search).get('currency');
+      if (override && this._META[override.toLowerCase()]) return (this._detected = override.toLowerCase());
+      try {
+        const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        if (tz) {
+          if (/^Europe\//.test(tz)) return (this._detected = tz === 'Europe/London' ? 'gbp' : 'eur');
+          if (/^Australia\//.test(tz) || tz === 'Pacific/Auckland') return (this._detected = 'aud');
+          if (/^America\/(Toronto|Vancouver|Edmonton|Winnipeg|Regina|Halifax|St_Johns|Moncton|Whitehorse|Yellowknife|Dawson)/.test(tz))
+            return (this._detected = 'cad');
+          return (this._detected = 'usd');
+        }
+      } catch (_) {}
+      return (this._detected = 'eur');
+    },
+
+    live(tierId, code) { return this.PRICES[code || this.detect()]?.[tierId] || null; },
+
+    disclaimer(tierId, code) {
+      let c = code || this.detect();
+      let t = this.PRICES[c]?.[tierId];
+      const tail = 'Cancel anytime via aicompass.tech@gmail.com. See our Subscription Policy for details.';
+      // If /api/prices never landed, fall back to the static EUR figures rather
+      // than a single fixed string — the renewal terms shown must always match
+      // the tier the buyer actually has selected.
+      if (!t) {
+        const s = CONTENT?.pricing?.tiers?.find((x) => x.id === tierId);
+        if (!s) return CONTENT?.pricing?.legalDisclaimer || tail;
+        t = { original: s.originalPrice, discounted: s.discountedPrice };
+        c = 'eur';
+      }
+      const vat = ['eur', 'gbp'].includes(c) ? ' (prices incl. VAT)' : '';
+      const cta = CONTENT?.pricing?.cta || 'Start today';
+      if (tierId === '7_day')
+        return `By clicking "${cta}", you agree to automatic subscription renewal. First week is ${t.discounted}, then ${t.original}/month${vat}. ${tail}`;
+      if (tierId === '3_month')
+        return `By clicking "${cta}", you agree to automatic subscription renewal. First 3 months are ${t.discounted}, then ${t.original} every 3 months${vat}. ${tail}`;
+      return `By clicking "${cta}", you agree to automatic subscription renewal. First month is ${t.discounted}, then ${t.original}/month${vat}. ${tail}`;
+    },
+  };
+
+  // ==========================================================================
+  // Meta Pixel — content_name carries the variant so the A/B is measurable
+  // ==========================================================================
+  const Pixel = {
+    _value(tierId, c) {
+      const cc = (c || 'usd').toLowerCase();
+      const raw = Currency.PRICES[cc]?.[tierId]?.discounted || Currency.PRICES.usd?.[tierId]?.discounted || '';
+      return parseFloat(raw.replace(/[^0-9.]/g, '')) || 19.99;
+    },
+    track(ev, params, eventId) {
+      if (typeof fbq !== 'function') return;
+      if (eventId) fbq('track', ev, params, { eventID: eventId });
+      else fbq('track', ev, params);
+    },
+    viewContent() { this.track('ViewContent', { content_name: CFG.pixelContentName, content_type: 'product' }); },
+    lead() { this.track('Lead', { content_name: CFG.pixelContentName }); },
+    initiateCheckout(tierId, c) {
+      this.track('InitiateCheckout', {
+        value: this._value(tierId, c), currency: (c || 'USD').toUpperCase(),
+        content_ids: [tierId], content_name: CFG.pixelContentName, num_items: 1,
+      });
+    },
+    purchase(tierId, c, subId) {
+      this.track('Purchase', {
+        value: this._value(tierId, c), currency: (c || 'USD').toUpperCase(),
+        content_ids: [tierId], content_name: CFG.pixelContentName, content_type: 'product',
+      }, subId ? `purchase_${subId}` : undefined);
+    },
+  };
+
+  // ==========================================================================
+  // State
+  // ==========================================================================
+  let CONTENT = null;
+  let selectedTier = '1_month';
+  let quizResult = null;   // { challenge, stage, goal, answers }
+
+  const QUIZ_KEY = 'mc_landing_quiz_v1';
+
+  function loadQuiz() {
+    try { return JSON.parse(localStorage.getItem(QUIZ_KEY) || 'null'); } catch (_) { return null; }
+  }
+  function saveQuiz(r) {
+    try { localStorage.setItem(QUIZ_KEY, JSON.stringify(r)); } catch (_) {}
+  }
+
+  const fill = (tpl, r) => String(tpl || '').replace(/\{(\w+)\}/g, (_, k) => r[k] || '');
+
+  // ==========================================================================
+  // Renderers
+  // ==========================================================================
+  function renderHeader(c) {
+    el('hdr').innerHTML = `
+      <div class="container hdr__inner">
+        <a class="hdr__brand" href="#top">${ic('compass')}${esc(c.brand.name)}</a>
+        <button class="btn btn--cta btn--sm" data-cta="header">${esc(primaryCtaLabel())}</button>
+      </div>`;
+  }
+
+  // The quiz variant promises a plan, so the button has to say so. The direct
+  // variant has no plan to give — v1's "Get my plan" scrolling to a price table
+  // was a promise with no payoff, which is a conversion leak, not a win.
+  function primaryCtaLabel() {
+    if (CFG.flow === 'quiz') return quizResult ? 'See my plan' : (CONTENT.quiz?.openCta || 'Build my plan');
+    return CONTENT.pricing.cta;
+  }
+
+  function renderHero(c) {
+    const h = c.hero;
+    let title = esc(h.headline);
+    if (h.headlineAccent) {
+      const a = esc(h.headlineAccent);
+      title = title.replace(a, `<span class="mark">${a}</span>`);
+    }
+    el('hero').innerHTML = `
+      <div class="container">
+        <div class="hero__grid">
+          <div class="hero__copy rv">
+            <span class="hero__badge">${ic('lock')}${esc(h.eyebrow)}</span>
+            <h1 class="hero__title">${title}</h1>
+            <p class="hero__sub">${esc(h.subheadline)}</p>
+            <div class="hero__actions">
+              <button class="btn btn--cta btn--lg" data-cta="hero">${esc(primaryCtaLabel())}${ic('arrow')}</button>
+            </div>
+            <p class="hero__reassure">${esc(h.reassurance)}</p>
+          </div>
+          <div class="hero__media rv">
+            <span class="hero__blob" aria-hidden="true"></span>
+            <img src="${esc(h.image)}" alt="${esc(h.imageAlt)}" width="1406" height="768" fetchpriority="high">
+          </div>
+        </div>
+      </div>`;
+  }
+
+  function renderProof(c) {
+    el('proof').innerHTML = `
+      <div class="container">
+        <div class="proof__row">
+          ${c.proof.stats.map((s) => `
+            <div class="proof__cell">
+              <div class="proof__value">${esc(s.value)}${s.isRating ? ic('star') : ''}</div>
+              <div class="proof__label">${esc(s.label)}</div>
+            </div>`).join('')}
+        </div>
+      </div>`;
+  }
+
+  function renderProblem(c) {
+    const p = c.problem;
+    el('problem').innerHTML = `
+      <div class="container">
+        <div class="problem__grid">
+          <div class="rv">
+            <span class="eyebrow">${esc(p.eyebrow)}</span>
+            <h2 class="h2">${esc(p.headline)}</h2>
+            <p class="lede">${esc(p.body)}</p>
+          </div>
+          <ul class="problem__list rv">
+            ${p.painPoints.map((t) => `<li class="problem__item">${ic('cross')}<span>${esc(t)}</span></li>`).join('')}
+          </ul>
+        </div>
+      </div>`;
+
+    // The loop lives in its own inverted band directly underneath — one dark
+    // stripe is what stops the page reading as an endless light-grey scroll.
+    el('loop').innerHTML = `
+      <div class="container">
+        <div class="loop__label rv">${esc(p.loopLabel)}</div>
+        <div class="loop__steps rv">
+          ${p.loop.map((s) => `
+            <div class="loop__step">
+              <span class="loop__icon">${ic(s.icon)}</span>
+              <div>
+                <h3 class="loop__step-title">${esc(s.title)}</h3>
+                <p class="loop__step-body">${esc(s.body)}</p>
+              </div>
+            </div>`).join('')}
+        </div>
+        <div class="loop__note rv">${ic('rotate')}${esc(p.loopNote)}</div>
+        <div class="loop__break rv">
+          <span class="loop__break-label">${esc(p.breakout.label)}</span>
+          <p class="loop__break-body">${esc(p.breakout.body)}</p>
+        </div>
+      </div>`;
+  }
+
+  function renderPersonas(c) {
+    const p = c.personas;
+    el('personas').innerHTML = `
+      <div class="container">
+        <div class="rv">
+          <span class="eyebrow">${esc(p.eyebrow)}</span>
+          <h2 class="h2">${esc(p.headline)}</h2>
+        </div>
+        <div class="personas__grid">
+          ${p.items.map((x, i) => `
+            <div class="persona rv">
+              <div class="persona__idx">0${i + 1}</div>
+              <div>
+                <h3 class="persona__title">${esc(x.title)}</h3>
+                <p class="persona__body">${esc(x.body)}</p>
+              </div>
+            </div>`).join('')}
+        </div>
+      </div>`;
+  }
+
+  function renderHow(c) {
+    const h = c.how;
+    el('how').innerHTML = `
+      <div class="container">
+        <div class="rv">
+          <span class="eyebrow">${esc(h.eyebrow)}</span>
+          <h2 class="h2">${esc(h.headline)}</h2>
+        </div>
+        <div class="how__steps">
+          ${h.steps.map((s, i) => `
+            <div class="how__step rv">
+              <div class="how__num">0${i + 1}</div>
+              <h3 class="how__step-title">${esc(s.title)}</h3>
+              <p class="how__step-body">${esc(s.body)}</p>
+            </div>`).join('')}
+        </div>
+        <div class="how__chips rv">
+          ${h.chips.map((t) => `<span class="chip">${ic('check')}${esc(t)}</span>`).join('')}
+        </div>
+      </div>`;
+  }
+
+  // --------------------------------------------------------------------------
+  // Testimonials. Deliberately motion-free: a CSS multi-column wall on desktop
+  // and a native scroll-snap strip on mobile. v1 animated a 6320px-wide flex
+  // track with will-change:transform, which iOS Safari promotes to an oversized
+  // composited layer that intermittently never paints — that is why three
+  // successive "fix the marquee" attempts all failed. Nothing here can do that:
+  // no transform, no rAF, no element wider than its own column.
+  // --------------------------------------------------------------------------
+  const VISIBLE_REVIEWS = 6;
+
+  function renderTestimonials(c) {
+    const t = c.testimonials;
+    const stars = (n) => Array.from({ length: n }, () => ic('star')).join('');
+    const card = (x, i) => `
+      <article class="tw__card${i >= VISIBLE_REVIEWS ? ' tw__card--extra' : ''}">
+        <div class="tw__stars" aria-label="${x.rating} out of 5">${stars(x.rating)}</div>
+        <h3 class="tw__title">${esc(x.title)}</h3>
+        <p class="tw__quote">${esc(x.content)}</p>
+        <div class="tw__by">
+          <span class="tw__name">${esc(x.author)}</span>
+          ${x.badge ? `<span class="tw__badge">${esc(x.badge)}</span>` : ''}
+        </div>
+      </article>`;
+
+    el('testimonials').innerHTML = `
+      <div class="container">
+        <div class="rv">
+          <span class="eyebrow">${esc(t.eyebrow)}</span>
+          <h2 class="h2">${esc(t.headline)}</h2>
+        </div>
+        <div class="tw__wall" id="tw-wall">${t.items.map(card).join('')}</div>
+        <div class="tw__progress" aria-hidden="true"><div class="tw__progress-bar" id="tw-bar"></div></div>
+        <div class="tw__swipe">${ic('swipe')} Swipe for more</div>
+        <div class="tw__more">
+          <button class="btn btn--quiet btn--sm" id="tw-more">${esc(t.moreLabel)}</button>
+        </div>
+        <p class="tw__note">${esc(t.note)}</p>
+      </div>`;
+
+    const wall = el('tw-wall');
+    const bar = el('tw-bar');
+    const more = el('tw-more');
+
+    more.addEventListener('click', () => {
+      const open = wall.classList.toggle('tw__wall--open');
+      more.textContent = open ? t.lessLabel : t.moreLabel;
+    });
+
+    // Mobile progress indicator, driven straight off scrollLeft — no observer,
+    // no timers, degrades to a static bar if the browser reports nothing.
+    const sync = () => {
+      const max = wall.scrollWidth - wall.clientWidth;
+      const pct = max > 0 ? (wall.scrollLeft / max) * 78 + 22 : 100;
+      bar.style.width = `${Math.min(100, pct)}%`;
+    };
+    wall.addEventListener('scroll', sync, { passive: true });
+    sync();
+  }
+
+  function tierCard(t) {
+    const p = Currency.live(t.id) || {};
+    return `
+      <div class="tier ${t.id === selectedTier ? 'tier--on' : ''}" data-tier="${esc(t.id)}"
+           role="button" tabindex="0" aria-pressed="${t.id === selectedTier}">
+        ${t.badge ? `<span class="tier__badge">${esc(t.badge)}</span>` : ''}
+        <span class="tier__radio"></span>
+        <div>
+          <div class="tier__name">${esc(t.name)}</div>
+          <div class="tier__perday" data-perday>${esc(p.perDay || t.pricePerDay)}</div>
+          ${t.savings ? `<span class="tier__savings">${esc(t.savings)}</span>` : ''}
+        </div>
+        <div class="tier__prices">
+          <div class="tier__was" data-was>${esc(p.original || t.originalPrice)}</div>
+          <div class="tier__now" data-now>${esc(p.discounted || t.discountedPrice)}</div>
+        </div>
+      </div>`;
+  }
+
+  function renderPricing(c) {
+    const p = c.pricing;
+    el('pricing').innerHTML = `
+      <div class="container">
+        <div class="rv" style="text-align:center">
+          <span class="eyebrow">${esc(p.eyebrow)}</span>
+          <h2 class="h2" id="pricing-title">${esc(p.headline)}</h2>
+        </div>
+        <div id="plan-slot"></div>
+        <p class="pricing__anchor rv">${esc(p.anchor)}</p>
+        <div class="pricing__goals rv">
+          ${p.goals.map((g) => `<div class="pricing__goal">${ic('check')}<span>${esc(g)}</span></div>`).join('')}
+        </div>
+        <p class="pricing__reason rv">${esc(p.reasonWhy)}</p>
+        <div class="tiers rv">${p.tiers.map(tierCard).join('')}</div>
+        <div class="pricing__act rv">
+          <button class="btn btn--cta btn--block btn--lg" data-action="checkout">${esc(p.cta)}</button>
+        </div>
+        <div class="pricing__guarantee rv">${ic('shield')}<span>${esc(p.guaranteeLine)}</span></div>
+        <p class="pricing__legal" id="pricing-legal">${esc(p.legalDisclaimer)}</p>
+      </div>`;
+    renderPlanSlot();
+  }
+
+  // Quiz variant only: locked prompt before the quiz, personalized card after.
+  function renderPlanSlot() {
+    const slot = el('plan-slot');
+    if (!slot || CFG.flow !== 'quiz') return;
+    const q = CONTENT.quiz;
+    if (!quizResult) {
+      slot.innerHTML = `
+        <div class="plan rv" style="text-align:center">
+          <span class="plan__eyebrow">${ic('sparkle')}${esc(q.subtitle)}</span>
+          <h3 class="plan__title">${esc(q.title)}</h3>
+          <button class="btn btn--brand btn--block" data-quiz="open">${esc(q.openCta)}</button>
+        </div>`;
+      return;
+    }
+    slot.innerHTML = `
+      <div class="plan">
+        <span class="plan__eyebrow">${ic('check')}${esc(q.resultEyebrow)}</span>
+        <h3 class="plan__title">${esc(fill(q.resultHeadline, quizResult))}</h3>
+        <p class="plan__body">${esc(fill(q.resultBody, quizResult))}</p>
+        <div class="plan__tags">
+          ${q.resultTags.map((t) => `<span class="plan__tag">${esc(fill(t, quizResult))}</span>`).join('')}
+        </div>
+      </div>`;
+    const title = el('pricing-title');
+    if (title) title.textContent = fill(q.resultHeadline, quizResult) + ' is ready';
+  }
+
+  function renderTrust(c) {
+    const t = c.trust;
+    el('trust').innerHTML = `
+      <div class="container">
+        <div class="trust__grid">
+          <div class="rv">
+            <h3 class="trust__h">${esc(t.privacy.headline)}</h3>
+            <ul class="trust__list">
+              ${t.privacy.points.map((x) => `<li>${ic('lock')}<span>${esc(x)}</span></li>`).join('')}
+            </ul>
+          </div>
+          <div class="rv">
+            <h3 class="trust__h">${esc(t.payment.headline)}</h3>
+            <div class="paysec">${t.payment.icons.map((x) => `<span>${esc(x)}</span>`).join('')}</div>
+          </div>
+          <div class="trust__sci rv sci" id="sci">
+            <h3 class="trust__h">${esc(t.science.headline)}</h3>
+            <p class="sci__summary">${esc(t.science.summary)}</p>
+            <button class="sci__toggle" id="sci-toggle" aria-expanded="false">
+              ${esc(t.science.toggleLabel)}${ic('chevron')}
+            </button>
+            <div class="sci__body" id="sci-body">
+              ${t.science.points.map((p) => `
+                <div class="sci__point">
+                  <div class="sci__claim">${esc(p.claim)}</div>
+                  <p class="sci__detail">${esc(p.detail)}</p>
+                  <span class="sci__source">${esc(p.source)}</span>
+                </div>`).join('')}
+              <p class="sci__disclaimer">${esc(t.science.disclaimer)}</p>
+            </div>
+          </div>
+        </div>
+      </div>`;
+  }
+
+  function renderFaq(c) {
+    const f = c.faq;
+    el('faq').innerHTML = `
+      <div class="container container--narrow">
+        <div class="rv">
+          <span class="eyebrow">${esc(f.eyebrow)}</span>
+          <h2 class="h2">${esc(f.headline)}</h2>
+        </div>
+        <div class="faq__list">
+          ${f.questions.map((q) => `
+            <div class="faq__item">
+              <button class="faq__q" aria-expanded="false">${esc(q.question)}</button>
+              <div class="faq__a"><p>${esc(q.answer)}</p></div>
+            </div>`).join('')}
+        </div>
+      </div>`;
+  }
+
+  function renderFinal(c) {
+    const f = c.finalCta;
+    el('final').innerHTML = `
+      <div class="container">
+        <h2 class="final__title rv">${esc(f.headline)}</h2>
+        <p class="final__sub rv">${esc(f.subheadline)}</p>
+        <button class="btn btn--cta btn--lg rv" data-cta="final">${esc(primaryCtaLabel())}${ic('arrow')}</button>
+      </div>`;
+  }
+
+  function renderFooter(c) {
+    const f = c.footer;
+    el('ftr').innerHTML = `
+      <div class="container ftr__inner">
+        <div>
+          <div class="ftr__brand">${ic('compass')}${esc(f.company)}</div>
+          <div>© ${new Date().getFullYear()} ${esc(f.company)}. All rights reserved.<br>
+          Support: <a href="mailto:${esc(f.supportEmail)}">${esc(f.supportEmail)}</a></div>
+        </div>
+        <div class="ftr__links">
+          ${f.links.map((l) => `<a href="${esc(l.href)}">${esc(l.label)}</a>`).join('')}
+        </div>
+      </div>`;
+  }
+
+  // ==========================================================================
+  // Pricing interactions
+  // ==========================================================================
+  function updatePrices() {
+    document.querySelectorAll('.tier').forEach((node) => {
+      const p = Currency.live(node.getAttribute('data-tier'));
+      if (!p) return;
+      const set = (sel, v) => { const n = node.querySelector(sel); if (n && v) n.textContent = v; };
+      set('[data-was]', p.original);
+      set('[data-now]', p.discounted);
+      set('[data-perday]', p.perDay);
+    });
+    updateLegal();
+    updateSticky();
+    Checkout.refreshSummary();
+  }
+
+  function updateLegal() {
+    const n = el('pricing-legal');
+    if (n) n.textContent = Currency.disclaimer(selectedTier);
+  }
+
+  function updateSticky() {
+    const p = Currency.live(selectedTier);
+    const tier = CONTENT.pricing.tiers.find((t) => t.id === selectedTier) || {};
+    const n = el('sticky-price');
+    if (n) n.innerHTML = `<strong>${esc(p?.discounted || tier.discountedPrice || '')}</strong>${esc(p?.perDay || tier.pricePerDay || '')}`;
+  }
+
+  function selectTier(id) {
+    selectedTier = id;
+    document.querySelectorAll('.tier').forEach((t) => {
+      const on = t.getAttribute('data-tier') === id;
+      t.classList.toggle('tier--on', on);
+      t.setAttribute('aria-pressed', on);
+    });
+    updateLegal();
+    updateSticky();
+    Checkout.refreshSummary();
+  }
+
+  // ==========================================================================
+  // Quiz (quiz variant only)
+  // ==========================================================================
+  const Quiz = {
+    step: 0,
+    answers: {},
+
+    open() {
+      if (CFG.flow !== 'quiz') { scrollToPricing(); return; }
+      if (quizResult) { scrollToPricing(); return; }
+      this.step = 0;
+      this.answers = {};
+      const node = el('quiz');
+      node.classList.add('quiz--open');
+      node.setAttribute('aria-hidden', 'false');
+      document.body.style.overflow = 'hidden';
+      this.paint();
+    },
+
+    close() {
+      const node = el('quiz');
+      node.classList.remove('quiz--open');
+      node.setAttribute('aria-hidden', 'true');
+      document.body.style.overflow = '';
+    },
+
+    paint() {
+      const q = CONTENT.quiz;
+      const total = q.questions.length;
+      const cur = q.questions[this.step];
+      const body = el('quiz-body');
+      el('quiz-bar').style.width = `${(this.step / total) * 100}%`;
+      body.innerHTML = `
+        <div class="quiz__step">Question ${this.step + 1} of ${total}</div>
+        <h2 class="quiz__prompt">${esc(cur.prompt)}</h2>
+        <div class="quiz__opts">
+          ${cur.options.map((o, i) => `
+            <button class="quiz__opt" data-opt="${i}">${esc(o.label)}</button>`).join('')}
+        </div>
+        ${this.step > 0 ? '<button class="quiz__back" data-quiz="back">← Back</button>' : ''}`;
+    },
+
+    pick(idx) {
+      const q = CONTENT.quiz;
+      const cur = q.questions[this.step];
+      this.answers[cur.id] = cur.options[idx];
+      if (this.step < q.questions.length - 1) {
+        this.step += 1;
+        this.paint();
+      } else {
+        this.build();
+      }
+    },
+
+    back() {
+      if (this.step === 0) return;
+      this.step -= 1;
+      this.paint();
+    },
+
+    build() {
+      const q = CONTENT.quiz;
+      el('quiz-bar').style.width = '100%';
+      el('quiz-body').innerHTML = `
+        <h2 class="build__title">${esc(q.buildingLabel)}…</h2>
+        <ul class="build__list">
+          ${q.buildingSteps.map((s, i) => `
+            <li class="build__row" data-build="${i}">
+              <span class="build__spin">${ic('loader')}</span><span>${esc(s)}</span>
+            </li>`).join('')}
+        </ul>`;
+
+      const rows = Array.from(document.querySelectorAll('[data-build]'));
+      rows.forEach((row, i) => {
+        setTimeout(() => {
+          row.classList.add('build__row--done');
+          row.querySelector('span').outerHTML = ic('check');
+        }, 420 + i * 430);
+      });
+
+      setTimeout(() => this.finish(), 420 + rows.length * 430 + 320);
+    },
+
+    finish() {
+      const a = this.answers;
+      quizResult = {
+        challenge: a.trigger?.challenge || 'Worrier',
+        stage: a.duration?.stage || 'Established',
+        goal: a.want?.goal || 'Focus levels',
+        answers: {
+          trigger: a.trigger?.label || null,
+          duration: a.duration?.label || null,
+          want: a.want?.label || null,
+        },
+      };
+      saveQuiz(quizResult);
+      Pixel.lead();
+      this.close();
+      renderPlanSlot();
+      refreshCtaLabels();
+      wireReveal();
+      scrollToPricing();
+    },
+  };
+
+  // ==========================================================================
+  // Checkout — embedded Stripe (mirrors engine initStripe)
+  // ==========================================================================
+  const Checkout = {
+    stripe: null,
+    elements: null,
+    mountedKey: null,
+    data: null,
+    building: false,
+    initiated: false,
+
+    open() {
+      if (!CONTENT.pricing.tiers.find((t) => t.id === selectedTier)) return;
+      this.refreshSummary();
+      el('pay-legal').textContent = Currency.disclaimer(selectedTier);
+      el('pay-error').textContent = '';
+      el('email-error').textContent = '';
+
+      const m = el('checkout');
+      m.classList.add('modal--open');
+      m.setAttribute('aria-hidden', 'false');
+      document.body.style.overflow = 'hidden';
+
+      Pixel.viewContent();
+      if (!this.initiated) { Pixel.initiateCheckout(selectedTier, Currency.detect()); this.initiated = true; }
+
+      const email = el('email').value.trim();
+      if (EMAIL_RE.test(email)) this.build(email);
+      setTimeout(() => el('email').focus(), 120);
+    },
+
+    close() {
+      const m = el('checkout');
+      m.classList.remove('modal--open');
+      m.setAttribute('aria-hidden', 'true');
+      document.body.style.overflow = '';
+    },
+
+    refreshSummary() {
+      const tier = CONTENT?.pricing?.tiers.find((t) => t.id === selectedTier);
+      if (!tier) return;
+      const p = Currency.live(selectedTier);
+      const sum = el('pay-summary');
+      if (sum) {
+        sum.innerHTML = `
+          <div>
+            <div class="modal__summary-name">${esc(tier.name)}</div>
+            <div class="modal__summary-perday">${esc(p?.perDay || tier.pricePerDay)}</div>
+          </div>
+          <div class="modal__summary-price">${esc(p?.discounted || tier.discountedPrice)}</div>`;
+      }
+      const legal = el('pay-legal');
+      if (legal) legal.textContent = Currency.disclaimer(selectedTier);
+    },
+
+    onEmailInput() {
+      const email = el('email').value.trim();
+      el('email-error').textContent = '';
+      if (!EMAIL_RE.test(email)) return;
+      const key = `${selectedTier}|${email}`;
+      if (key !== this.mountedKey && !this.building) this.build(email);
+    },
+
+    setBtn(disabled, text) {
+      const b = el('pay-btn');
+      if (!b) return;
+      b.disabled = disabled;
+      b.classList.toggle('btn--off', disabled);
+      if (text) b.textContent = text;
+    },
+
+    err(msg) { el('pay-error').textContent = msg || ''; },
+
+    async build(email) {
+      this.building = true;
+      const tierId = selectedTier;
+      const currency = Currency.detect();
+      const mount = el('pay-mount');
+      this.err('');
+      this.setBtn(true, 'Preparing secure checkout…');
+      mount.innerHTML = '<p class="pay__loading">Loading secure payment form…</p>';
+
+      if (isDev()) {
+        mount.innerHTML = '<p class="pay__loading">⚡ Dev mode — payment mocked (localhost)</p>';
+        this.mountedKey = `${tierId}|${email}`;
+        this.building = false;
+        this.setBtn(false, 'Complete Payment (Mock)');
+        return;
+      }
+
+      try {
+        const res = await fetch('/api/create-checkout', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tierId, email, currency }),
+        });
+        const raw = await res.text();
+        let data = {};
+        try { data = raw ? JSON.parse(raw) : {}; } catch (_) {}
+        if (!res.ok || !data.clientSecret) {
+          this.err(data.error || 'Payment setup failed. Please try again.');
+          this.setBtn(true, 'Enter your email to continue');
+          this.building = false;
+          return;
+        }
+        this.data = data;
+
+        if (typeof window.Stripe === 'undefined') {
+          this.err('Payment provider failed to load. Please refresh.');
+          this.building = false;
+          return;
+        }
+
+        this.stripe = window.Stripe(CFG.stripePk);
+        this.elements = this.stripe.elements({ clientSecret: data.clientSecret });
+        const pe = this.elements.create('payment');
+        mount.innerHTML = '';
+        pe.mount('#pay-mount');
+        pe.on('ready', () => this.setBtn(false, 'Complete Payment'));
+        this.mountedKey = `${tierId}|${email}`;
+      } catch (_) {
+        this.err('An unexpected error occurred. Please refresh and try again.');
+      } finally {
+        this.building = false;
+      }
+    },
+
+    async pay() {
+      const email = el('email').value.trim();
+      if (!EMAIL_RE.test(email)) {
+        el('email-error').textContent = 'Please enter a valid email address.';
+        el('email').focus();
+        return;
+      }
+      const currency = Currency.detect();
+
+      if (isDev()) {
+        Pixel.purchase(selectedTier, currency, null);
+        location.href = CFG.webappUrl;
+        return;
+      }
+
+      if (this.building) return;
+      if (!this.stripe || !this.elements) { this.build(email); return; }
+
+      this.setBtn(true, 'Processing…');
+      this.err('');
+
+      const { error } = await this.stripe.confirmPayment({
+        elements: this.elements,
+        confirmParams: { return_url: location.href },
+        redirect: 'if_required',
+      });
+
+      if (error) {
+        this.err(error.message || 'Payment failed. Please try again.');
+        this.setBtn(false, 'Complete Payment');
+        return;
+      }
+
+      Pixel.purchase(selectedTier, currency, this.data?.subscriptionId);
+
+      // Forward the micro-quiz answers so the webapp personalizes on day one
+      // using the same vocabulary the full funnel produces.
+      let tokens = null;
+      try {
+        const payload = {
+          email,
+          selectedPlan: selectedTier,
+          funnelVersion: CFG.funnelVersion,
+        };
+        if (quizResult) {
+          payload.mainChallenge = quizResult.challenge;
+          payload.goal = quizResult.goal;
+          payload.quizAnswers = quizResult.answers;
+        }
+        const res = await fetch('/api/provision-account', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        const d = await res.json();
+        if (d.provisioned) tokens = { access_token: d.access_token, refresh_token: d.refresh_token };
+      } catch (_) { /* non-fatal — the account exists, the buyer can log in */ }
+
+      const hash = tokens
+        ? '#access_token=' + encodeURIComponent(tokens.access_token) +
+          '&refresh_token=' + encodeURIComponent(tokens.refresh_token)
+        : '';
+      location.href = CFG.webappUrl + hash;
+    },
+  };
+
+  // ==========================================================================
+  // Wiring
+  // ==========================================================================
+  function scrollToPricing() {
+    el('pricing').scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  function refreshCtaLabels() {
+    const label = primaryCtaLabel();
+    document.querySelectorAll('[data-cta]').forEach((b) => {
+      const arrow = b.querySelector('svg');
+      b.textContent = label;
+      if (arrow) b.appendChild(arrow);
+    });
+  }
+
+  function onPrimaryCta() {
+    if (CFG.flow === 'quiz' && !quizResult) Quiz.open();
+    else scrollToPricing();
+  }
+
+  function wireInteractions() {
+    document.addEventListener('click', (e) => {
+      if (e.target.closest('[data-cta]')) { onPrimaryCta(); return; }
+      if (e.target.closest('[data-quiz="open"]')) { Quiz.open(); return; }
+      if (e.target.closest('[data-quiz="back"]')) { Quiz.back(); return; }
+      if (e.target.closest('[data-quiz="close"]')) { Quiz.close(); return; }
+
+      const opt = e.target.closest('[data-opt]');
+      if (opt) {
+        opt.classList.add('quiz__opt--on');
+        setTimeout(() => Quiz.pick(Number(opt.getAttribute('data-opt'))), 130);
+        return;
+      }
+
+      if (e.target.closest('[data-action="checkout"]')) { Checkout.open(); return; }
+      if (e.target.closest('[data-close-modal]')) { Checkout.close(); return; }
+
+      const tier = e.target.closest('.tier');
+      if (tier) { selectTier(tier.getAttribute('data-tier')); return; }
+
+      const sciBtn = e.target.closest('#sci-toggle');
+      if (sciBtn) {
+        const box = el('sci');
+        const body = el('sci-body');
+        const open = box.classList.toggle('sci--open');
+        sciBtn.setAttribute('aria-expanded', String(open));
+        body.style.maxHeight = open ? `${body.scrollHeight}px` : '0';
+        return;
+      }
+
+      const q = e.target.closest('.faq__q');
+      if (q) {
+        const item = q.closest('.faq__item');
+        const a = item.querySelector('.faq__a');
+        const open = item.classList.toggle('faq__item--open');
+        q.setAttribute('aria-expanded', String(open));
+        a.style.maxHeight = open ? `${a.scrollHeight}px` : '0';
+      }
+    });
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') { Checkout.close(); Quiz.close(); }
+      if ((e.key === 'Enter' || e.key === ' ') && document.activeElement?.classList.contains('tier')) {
+        e.preventDefault();
+        selectTier(document.activeElement.getAttribute('data-tier'));
+      }
+    });
+
+    el('email').addEventListener('input', () => Checkout.onEmailInput());
+    el('pay-form').addEventListener('submit', (e) => { e.preventDefault(); Checkout.pay(); });
+  }
+
+  function wireSticky() {
+    const bar = el('sticky');
+    const hero = el('hero');
+    const ftr = el('ftr');
+    const onScroll = () => {
+      const past = window.scrollY > (hero?.offsetHeight || 400);
+      const near = ftr.getBoundingClientRect().top < window.innerHeight + 80;
+      const modal = el('checkout').classList.contains('modal--open') || el('quiz').classList.contains('quiz--open');
+      bar.classList.toggle('sticky--on', past && !near && !modal);
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    onScroll();
+  }
+
+  function wireReveal() {
+    const nodes = document.querySelectorAll('.rv:not(.rv--in)');
+    if (!('IntersectionObserver' in window)) {
+      nodes.forEach((n) => n.classList.add('rv--in'));
+      return;
+    }
+    const obs = new IntersectionObserver((entries) => {
+      entries.forEach((en) => {
+        if (!en.isIntersecting) return;
+        en.target.classList.add('rv--in');
+        obs.unobserve(en.target);
+      });
+    }, { threshold: 0.12, rootMargin: '0px 0px -40px' });
+    nodes.forEach((n) => obs.observe(n));
+  }
+
+  // Live theme comparison. Off unless ?themepicker=1 so real traffic never
+  // sees it, but the whole point of shipping three themes is being able to
+  // flip between them on the real page instead of guessing from a mockup.
+  function wireThemePicker() {
+    const params = new URLSearchParams(location.search);
+    if (params.get('themepicker') !== '1') return;
+    const box = el('themepicker');
+    const active = document.documentElement.getAttribute('data-theme');
+    box.classList.add('themepicker--on');
+    box.innerHTML = ['warm', 'dark', 'clean'].map((t) =>
+      `<button data-theme-set="${t}" aria-current="${t === active}">${t}</button>`).join('');
+    box.addEventListener('click', (e) => {
+      const b = e.target.closest('[data-theme-set]');
+      if (!b) return;
+      params.set('theme', b.getAttribute('data-theme-set'));
+      location.search = params.toString();
+    });
+  }
+
+  // ==========================================================================
+  // Boot
+  // ==========================================================================
+  async function init() {
+    try {
+      CONTENT = await (await fetch(CFG.contentUrl)).json();
+    } catch (err) {
+      console.error('[landing] content.json failed to load', err);
+      return;
+    }
+
+    document.title = CONTENT.meta?.title || document.title;
+    if (CFG.flow === 'quiz') quizResult = loadQuiz();
+
+    // Each section renders in isolation: a stale cached script paired with a
+    // newer content.json must never blank the whole page (it did, twice, on v1).
+    const guard = (label, fn) => { try { fn(); } catch (err) { console.error('[landing]', label, err); } };
+
+    guard('header', () => renderHeader(CONTENT));
+    guard('hero', () => renderHero(CONTENT));
+    guard('proof', () => renderProof(CONTENT));
+    guard('problem', () => renderProblem(CONTENT));
+    guard('personas', () => renderPersonas(CONTENT));
+    guard('how', () => renderHow(CONTENT));
+    guard('testimonials', () => renderTestimonials(CONTENT));
+    guard('pricing', () => renderPricing(CONTENT));
+    guard('trust', () => renderTrust(CONTENT));
+    guard('faq', () => renderFaq(CONTENT));
+    guard('final', () => renderFinal(CONTENT));
+    guard('footer', () => renderFooter(CONTENT));
+
+    // The sticky bar's label lives in the HTML, so it needs the same pass the
+    // JS-rendered CTAs get — otherwise it says "Start today" while opening a quiz.
+    guard('ctaLabels', refreshCtaLabels);
+    guard('interactions', wireInteractions);
+    guard('sticky', wireSticky);
+    guard('reveal', wireReveal);
+    guard('themepicker', wireThemePicker);
+    guard('stickyPrice', updateSticky);
+
+    Currency.fetch().then(updatePrices);
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+  else init();
+})();

--- a/funnel/landing-shared/theme-clean.css
+++ b/funnel/landing-shared/theme-clean.css
@@ -1,0 +1,67 @@
+/* ============================================================================
+   Theme: CLEAN PREMIUM
+   Light, close to the existing brand, but with a real secondary colour and a
+   high-contrast serif display so it stops reading as a one-hue template.
+   ============================================================================ */
+@import url("https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&display=swap");
+
+:root {
+  --c-bg: #ffffff;
+  --c-bg-alt: #f5f6fa;
+  --c-surface: #ffffff;
+  --c-ink: #0f1222;
+  --c-ink-2: #545a72;
+  --c-ink-3: #8c92a8;
+  --c-line: #e7e9f0;
+  --c-line-strong: #ccd0dd;
+
+  --c-brand: #4f46e5;
+  --c-brand-soft: #eeecfe;
+  --c-accent: #f97316;
+  --c-accent-soft: #fff3e9;
+  --c-cta: #16a34a;
+  --c-cta-hover: #12833c;
+  --c-cta-ink: #ffffff;
+
+  --c-invert-bg: #0f1222;
+  --c-invert-ink: #ffffff;
+  --c-invert-ink-2: rgba(255, 255, 255, 0.68);
+  --c-invert-line: rgba(255, 255, 255, 0.15);
+
+  --c-star: #f5a524;
+  --c-danger: #e5484d;
+
+  --font-display: "Instrument Serif", Georgia, serif;
+  --display-weight: 400;
+  --display-tracking: -0.005em;
+  --display-case: none;
+  --eyebrow-tracking: 0.11em;
+
+  --radius: 12px;
+  --radius-lg: 18px;
+  --shadow-1: 0 1px 2px rgba(15, 18, 34, 0.05);
+  --shadow-2: 0 12px 34px rgba(15, 18, 34, 0.10);
+}
+
+/* A 400-weight serif needs more size and tighter leading to hold a headline. */
+.hero__title { font-size: clamp(42px, 12vw, 60px); line-height: 1.0; }
+.h2 { font-size: 30px; line-height: 1.08; }
+.final__title { line-height: 1.02; }
+@media (min-width: 700px) {
+  .h2 { font-size: 38px; }
+  .hero__title { font-size: 62px; }
+}
+@media (min-width: 1000px) { .hero__title { font-size: 68px; } }
+
+/* One italic accent word is the whole trick — serif italic reads as authored. */
+.mark { font-style: italic; }
+.mark::after { opacity: 0.22; }
+
+/* Prices and stats want a sans — a light serif numeral looks accidental. */
+.tier__now, .proof__value, .modal__summary-price {
+  font-family: var(--font-body);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+.how__num { font-family: var(--font-body); font-weight: 800; }
+.persona__idx { font-family: var(--font-body); font-weight: 800; }

--- a/funnel/landing-shared/theme-dark.css
+++ b/funnel/landing-shared/theme-dark.css
@@ -1,0 +1,69 @@
+/* ============================================================================
+   Theme: DARK & BOLD
+   Near-black surface, acid accent, tight uppercase display.
+   Premium performance-product register (Whoop / Oura), high contrast.
+   ============================================================================ */
+@import url("https://fonts.googleapis.com/css2?family=Archivo:wght@600;700;800&display=swap");
+
+:root {
+  --c-bg: #0c0c11;
+  --c-bg-alt: #13131b;
+  --c-surface: #16161f;
+  --c-ink: #f4f4f7;
+  --c-ink-2: #a2a2b0;
+  --c-ink-3: #6f6f80;
+  --c-line: #24242e;
+  --c-line-strong: #3a3a48;
+
+  --c-brand: #8b7bff;
+  --c-brand-soft: rgba(139, 123, 255, 0.16);
+  --c-accent: #c9ff3d;
+  --c-accent-soft: rgba(201, 255, 61, 0.14);
+  --c-cta: #c9ff3d;
+  --c-cta-hover: #b4e830;
+  --c-cta-ink: #0c0c11;
+
+  /* Inverted bands must go *lighter* here, otherwise they vanish. */
+  --c-invert-bg: #1a1a24;
+  --c-invert-ink: #f4f4f7;
+  --c-invert-ink-2: rgba(244, 244, 247, 0.62);
+  --c-invert-line: rgba(244, 244, 247, 0.14);
+
+  --c-star: #ffc933;
+  --c-danger: #ff6b5e;
+
+  --font-display: "Archivo", -apple-system, BlinkMacSystemFont, sans-serif;
+  --display-weight: 800;
+  --display-tracking: -0.035em;
+  --display-case: uppercase;
+  --eyebrow-tracking: 0.16em;
+
+  --radius: 8px;
+  --radius-lg: 12px;
+  --shadow-1: none;
+  --shadow-2: 0 14px 36px rgba(0, 0, 0, 0.55);
+}
+
+/* Uppercase display needs looser leading and no orphan-tight tracking. */
+.hero__title, .final__title, .h2 { line-height: 1.02; }
+.hero__title { letter-spacing: -0.03em; }
+
+/* The lime CTA carries the page — nothing else may compete with it. */
+.btn--cta { box-shadow: 0 8px 26px rgba(201, 255, 61, 0.22); }
+.tier__badge { color: #0c0c11; }
+.tw__badge { color: var(--c-cta); }
+.tier__savings { color: var(--c-cta); }
+.pricing__guarantee svg { color: var(--c-cta); }
+
+/* Photography needs handling on dark: cool it down so it doesn't glow. */
+.hero__media img { filter: saturate(0.8) brightness(0.86) contrast(1.06); }
+.hero__blob { opacity: 0.2; }
+
+/* Hairlines read heavier on black — thin them out. */
+.problem__item, .persona, .faq__item, .sci__point { border-color: var(--c-line); }
+.how__step { border-top-color: var(--c-line-strong); }
+.mark::after { opacity: 0.85; height: 0.16em; bottom: 0.02em; border-radius: 2px; }
+
+/* Numerals are the bold part of "dark & bold". */
+.how__num { color: var(--c-accent); opacity: 0.55; }
+.proof__value { letter-spacing: -0.04em; }

--- a/funnel/landing-shared/theme-warm.css
+++ b/funnel/landing-shared/theme-warm.css
@@ -1,0 +1,71 @@
+/* ============================================================================
+   Theme: WARM EDITORIAL
+   Sand paper, ink, coral. Serif display against a system sans body.
+   Reads like a magazine feature rather than a SaaS template.
+   ============================================================================ */
+@import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap");
+
+:root {
+  --c-bg: #fbf7f2;
+  --c-bg-alt: #f3ebe0;
+  --c-surface: #ffffff;
+  --c-ink: #1f1b16;
+  --c-ink-2: #62594f;
+  --c-ink-3: #9a9082;
+  --c-line: #e8ded1;
+  --c-line-strong: #d3c5b3;
+
+  --c-brand: #2f5d62;
+  --c-brand-soft: #e2eded;
+  --c-accent: #e2603c;
+  --c-accent-soft: #fdeee9;
+  --c-cta: #1f7a4c;
+  --c-cta-hover: #186139;
+  --c-cta-ink: #ffffff;
+
+  --c-invert-bg: #24201a;
+  --c-invert-ink: #f8f3ec;
+  --c-invert-ink-2: rgba(248, 243, 236, 0.66);
+  --c-invert-line: rgba(248, 243, 236, 0.16);
+
+  --c-star: #d9962b;
+  --c-danger: #c0432c;
+
+  --font-display: "Fraunces", Georgia, "Times New Roman", serif;
+  --display-weight: 700;
+  --display-tracking: -0.015em;
+  --display-case: none;
+  --eyebrow-tracking: 0.13em;
+
+  --radius: 10px;
+  --radius-lg: 14px;
+  --shadow-1: 0 1px 2px rgba(60, 45, 30, 0.05);
+  --shadow-2: 0 12px 28px rgba(60, 45, 30, 0.10);
+}
+
+/* Fraunces has a lot of presence — let the headline breathe. */
+.hero__title, .final__title { line-height: 1.02; }
+.h2 { line-height: 1.1; }
+
+/* Editorial detail: the eyebrow gets a rule instead of shouting in caps only. */
+.eyebrow::after {
+  content: "";
+  display: inline-block;
+  width: 26px;
+  height: 1px;
+  background: currentColor;
+  vertical-align: middle;
+  margin-left: 10px;
+  opacity: 0.5;
+}
+
+/* Paper, not plastic: flatter cards, hairline borders, no glossy shadow. */
+.tw__card { box-shadow: none; border-color: var(--c-line-strong); }
+/* A degree of hand-pinned imperfection on the review wall. */
+.tw__card:nth-child(3n+1) { transform: rotate(-0.45deg); }
+.tw__card:nth-child(3n+2) { transform: rotate(0.3deg); }
+.tw__card:nth-child(3n)   { transform: rotate(0.6deg); }
+@media (max-width: 767px) { .tw__card { transform: none !important; } }
+
+.hero__media img { filter: saturate(0.92) contrast(1.03); }
+.mark::after { opacity: 0.28; height: 0.4em; }

--- a/funnel/vercel.json
+++ b/funnel/vercel.json
@@ -39,6 +39,16 @@
       "source": "/funnel-v2/cookie-policy.html",
       "destination": "/legal/cookie-policy.html",
       "permanent": true
+    },
+    {
+      "source": "/landing-quiz",
+      "destination": "/landing-quiz/",
+      "permanent": false
+    },
+    {
+      "source": "/landing-direct",
+      "destination": "/landing-direct/",
+      "permanent": false
     }
   ],
   "rewrites": [
@@ -68,6 +78,33 @@
     },
     {
       "source": "/landing-page/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/landing-quiz/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/landing-direct/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/landing-shared/(.*)",
       "headers": [
         {
           "key": "Cache-Control",


### PR DESCRIPTION
Closes #89.

Adds two parallel landing variants next to the untouched `/landing-page/` control, both driven by one shared engine in `funnel/landing-shared/`.

| Route | Flow | funnelVersion | Pixel content_name |
|---|---|---|---|
| `/landing-page/` | control, unchanged | `landing-page` | `LandingPage` |
| `/landing-quiz/` | 3-question inline quiz, then pricing | `landing-quiz` | `LandingQuiz` |
| `/landing-direct/` | direct sale | `landing-direct` | `LandingDirect` |

### Content: 1728 words / 14 sections -> 690 / 8

The page repeated "this will take a long time" six times (`~66 days`, `Weeks 6+`, `within 6 weeks`, `no magic 21-day fix`, `realistic expectations`, `willpower marathons`). That framing is inverted to "two minutes to set up" / "start tonight".

Nothing evidence-based was deleted — the science moved below pricing into a `See the research` accordion, so it still substantiates for skeptics and for Meta review without taxing every scroll.

Copy also names the problem directly. `porn` appeared zero times in the first pass; it now appears in 10 places (hero, proof, problem, personas, pricing, FAQ, final CTA, `<title>`). Privacy copy stays deliberately soft — the page says it out loud, the phone doesn't.

### Reviews: the marquee is gone

The old carousel animated a 6320px-wide flex track with `will-change: transform`. iOS Safari promotes that to an oversized composited layer that intermittently never paints, which is why b1a7c78 / ec4a978 / 615a8aa / 7e97c76 all failed — every one stayed inside the same paradigm.

Replaced with a CSS multi-column wall on desktop and a native `scroll-snap` strip on mobile. No transform, no rAF, no element wider than its own column, so there is nothing left to fail.

### Design

A CSS custom-property token contract plus three swappable themes via `?theme=warm|dark|clean`, an inline SVG icon set replacing all emoji, and per-section layouts (hanging numerals, hairline lists, inverted bands, pull-quote) instead of a stack of identical card grids.

The theme picker stays gated behind `?themepicker=1` so real traffic never sees it. Final direction to be chosen later from the live pages.

### Quiz variant

Three questions inline, no redirect out of the page. Answers map to the funnel's own `Scoring` vocabulary (`mainChallenge` / `goal`) and forward to `/api/provision-account`, so personalization is real rather than decorative.

### Also fixed

The renewal disclaimer fell back to a single fixed string when `/api/prices` failed, showing 1-month terms regardless of the selected tier. It now falls back to the static per-tier figures — the terms shown must match what is charged.

### Verification

jsdom harness over both variants: all 12 sections render, 0 console errors, 0 emoji, 80+ SVG icons. Full quiz walkthrough (answer mapping, persistence, CTA relabel, pricing headline), both accordions, review-wall expand, tier switching, checkout modal, all 3 themes — 34/34 pass. All four stylesheets parse clean under css-tree.

`/landing-page/` is byte-identical; the only shared file touched is `funnel/vercel.json` (two redirects + three cache-header rules).

Cache headers for `/landing-quiz/`, `/landing-direct/` and `/landing-shared/` are `max-age=0, must-revalidate`, matching `/landing-page/` — the html/js/json contract is versioned together and a stale script against fresh JSON blanks the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
