### PR TITLE
fix: checkout charges a truncated email — build() fires on a half-typed address (#94)

### DIFF
--- a/funnel/landing-direct/index.html
+++ b/funnel/landing-direct/index.html
@@ -177,6 +177,6 @@
       };
     </script>
     <script src="https://js.stripe.com/v3/"></script>
-    <script src="../landing-shared/landing.js?v=20260819"></script>
+    <script src="../landing-shared/landing.js?v=20260821"></script>
 </body>
 </html>

--- a/funnel/landing-quiz/index.html
+++ b/funnel/landing-quiz/index.html
@@ -176,6 +176,6 @@
       };
     </script>
     <script src="https://js.stripe.com/v3/"></script>
-    <script src="../landing-shared/landing.js?v=20260819"></script>
+    <script src="../landing-shared/landing.js?v=20260821"></script>
 </body>
 </html>

--- a/funnel/landing-shared/landing.js
+++ b/funnel/landing-shared/landing.js
@@ -873,8 +873,10 @@
 
       if (!this.initiated) { Pixel.initiateCheckout(selectedTier, Currency.detect()); this.initiated = true; }
 
-      const email = el('email').value.trim();
-      if (EMAIL_RE.test(email)) this.build(email);
+      // commitEmail rather than build: a remembered address whose intent is
+      // still mounted needs no second round trip, and a prefetch that cleared
+      // mountedKey is picked up here anyway.
+      this.commitEmail();
       setTimeout(() => el('email').focus(), 120);
     },
 
@@ -897,9 +899,28 @@
       if (legal) legal.textContent = Currency.disclaimer(selectedTier);
     },
 
+    // EMAIL_RE matches long before the buyer is done typing: "oleksandr@gmail.c"
+    // is already a valid address as far as the pattern is concerned. Building on
+    // that keystroke opened the PaymentIntent against a truncated address, and
+    // because build() holds `building` for the whole round trip the remaining
+    // "om" was swallowed by the guard below and never rebuilt. The buyer then
+    // paid as oleksandr@gmail.c while PostPay provisioned their account under
+    // the full address, so the webapp found no subscription for them.
+    //
+    // So: wait for a pause in typing, and treat leaving the field as "done".
+    EMAIL_SETTLE_MS: 650,
+
     onEmailInput() {
-      const email = el('email').value.trim();
       el('email-error').textContent = '';
+      clearTimeout(this._settle);
+      this._settle = setTimeout(() => this.commitEmail(), this.EMAIL_SETTLE_MS);
+    },
+
+    // Blur, change and submit mean the address is final — no reason to wait out
+    // the debounce and make the buyer watch a spinner they could have skipped.
+    commitEmail() {
+      clearTimeout(this._settle);
+      const email = el('email').value.trim();
       if (!EMAIL_RE.test(email)) return;
       Pixel.lead(email);
       rememberEmail(email);
@@ -1020,6 +1041,16 @@
         this.err('An unexpected error occurred. Please refresh and try again.');
       } finally {
         this.building = false;
+        // Everything typed while this build was in flight was dropped by the
+        // `!this.building` guard, and no further input event is coming if the
+        // buyer has stopped typing. Re-read the field: if the address moved on,
+        // this is the only chance to notice. The key comparison terminates the
+        // recursion — a rebuild for the same address cannot re-enter.
+        const live = el('email')?.value.trim() || '';
+        if (EMAIL_RE.test(live) && `${selectedTier}|${live}` !== this.mountedKey) {
+          rememberEmail(live);
+          this.build(live);
+        }
       }
     },
 
@@ -1040,6 +1071,19 @@
 
       if (this.building) return;
       if (!this.stripe || !this.elements) { this.build(email); return; }
+
+      // Last line of defence. The mounted PaymentIntent is bound to one address
+      // and one tier; confirming it while the field says something else charges
+      // a Stripe customer the buyer will never be able to log in as. Whatever
+      // race got us here — a swallowed keystroke, a prefetch that cancelled the
+      // schedule underneath us, a tier switched in another tab — rebuild rather
+      // than take the money against the wrong record.
+      if (this.mountedKey !== `${selectedTier}|${email}`) {
+        // build() clears the error box on entry, so the notice goes up after it.
+        this.build(email);
+        this.err('Your details changed — we refreshed the form. Please re-enter your card and try again.');
+        return;
+      }
 
       this.setBtn(true, 'Processing…');
       this.err('');
@@ -1451,7 +1495,15 @@
     });
 
     el('email').addEventListener('input', () => Checkout.onEmailInput());
-    el('pay-form').addEventListener('submit', (e) => { e.preventDefault(); Checkout.pay(); });
+    el('email').addEventListener('blur', () => Checkout.commitEmail());
+    el('email').addEventListener('change', () => Checkout.commitEmail());
+    el('pay-form').addEventListener('submit', (e) => {
+      e.preventDefault();
+      // A buyer who types and hits Enter straight away must not outrun the
+      // debounce and reach pay() before the intent for that address exists.
+      Checkout.commitEmail();
+      Checkout.pay();
+    });
     el('acct-form')?.addEventListener('submit', (e) => { e.preventDefault(); PostPay.submitAccount(); });
   }
 

--- a/funnel/landing-shared/landing.js
+++ b/funnel/landing-shared/landing.js
@@ -1044,10 +1044,16 @@
         // Everything typed while this build was in flight was dropped by the
         // `!this.building` guard, and no further input event is coming if the
         // buyer has stopped typing. Re-read the field: if the address moved on,
-        // this is the only chance to notice. The key comparison terminates the
-        // recursion — a rebuild for the same address cannot re-enter.
+        // this is the only chance to notice.
+        //
+        // The comparison is against the address this build was for, NOT against
+        // mountedKey. A failed create-checkout leaves mountedKey unset, so a
+        // mountedKey test would retry forever — hammering Stripe on every lap
+        // and holding the buyer on a spinner whose error message each new build
+        // wipes before they can read it. Comparing addresses retries only when
+        // the buyer actually typed something new, which cannot repeat on its own.
         const live = el('email')?.value.trim() || '';
-        if (EMAIL_RE.test(live) && `${selectedTier}|${live}` !== this.mountedKey) {
+        if (live !== email && EMAIL_RE.test(live)) {
           rememberEmail(live);
           this.build(live);
         }


### PR DESCRIPTION
Buyers were paying under a truncated email address and then locked out of the product they had just bought.

`EMAIL_RE` matches long before the buyer has finished typing — for `oleksandr@gmail.com` it already matches at `oleksandr@gmail.c`. `onEmailInput()` opened the PaymentIntent on that keystroke, and because `build()` holds `building` for the whole round trip (3–5s measured against Vercel) the remaining `om` was swallowed by the `!this.building` guard and never rebuilt.

The Stripe customer, the subscription, the Supabase row and the CAPI Purchase all carried the truncated address while `PostPay` provisioned the account under the full one, so the webapp found no subscription for a buyer who had just paid. The form also sat on "Preparing secure checkout…" for ~6.5s with no progress signal.

Closes #94.

### Changes

- `d86416a` fix: checkout no longer charges a truncated email (#94)
- `e5ee4d9` fix: post-build email recheck no longer retries a failed checkout forever

Specifically:

- Debounce the input-driven build (650ms); commit immediately on `blur`, `change` and submit, so a buyer who moves to the card field waits for nothing.
- Re-read the field when a build settles and rebuild if the address moved on — the only chance to catch keystrokes the in-flight guard dropped. Compared against the address the build was for, **not** `mountedKey`: a failed `create-checkout` never sets `mountedKey`, and the first version of this recheck therefore retried forever (9 calls in 15s and climbing, error message wiped on each lap).
- Guard `pay()` on `mountedKey`: never confirm an intent bound to an address or tier the form no longer holds, whatever race produced the mismatch.
- `open()` goes through `commitEmail()`, so a remembered address whose intent is still mounted skips a redundant round trip.

### Why #91 did not catch this

funnel-v2 captures the email on its own screen and commits it with Continue, so the engine never sees a half-typed address. The landing merged capture and payment into one modal and drives the build from `input`. Every #91 test assigned `input.value` in one shot and fired a single event, so the intermediate states never existed.

### Tests

Regression tests in the jsdom harness type character by character at both fast and hunt-and-peck speeds, assert `pay()` refuses a mismatched intent, and assert a failing `create-checkout` is attempted once with a surviving error message. All fail without this change (verified by reverting).

| suite | result |
|---|---|
| pay.js | 109 ✓ / 0 ✗ |
| flow.js | 69 ✓ / 0 ✗ |
| prod.js | PASS |
| check.js | flaky ~1 in 3 — pre-existing teardown race against the real `connect.facebook.net` load; fails the same way on unpatched main |

Smoke test runs automatically on push via Claude Code hook.

### Follow-ups, not in this PR

- Existing Stripe customers may carry truncated addresses from before this fix and need their email corrected by hand, or the webapp will not let them in.
- `create-checkout` answers in 3–5s (seven sequential Stripe round trips in one handler). This PR removes the wasted calls but not the latency.
