### PR TITLE
perf: stop charging first-time buyers for round trips we can predict (#98)

### DIFF
--- a/funnel/api/create-checkout.js
+++ b/funnel/api/create-checkout.js
@@ -77,25 +77,40 @@ export default async function handler(req, res) {
         //    create a new one only if none exists. This prevents orphaned
         //    customers + invoices when the user navigates back and re-submits.
         const existing = await stripe.customers.list({ email, limit: 1 });
-        const customer = existing.data.length > 0
+        const returning = existing.data.length > 0;
+        const customer = returning
             ? existing.data[0]
             : await stripe.customers.create({ email, metadata: pixelMeta });
-
-        // A returning customer keeps whatever identifiers this session supplies —
-        // the newest click is the one that earned the purchase.
-        if (existing.data.length > 0 && hasPixelMeta) {
-            await stripe.customers.update(customer.id, { metadata: pixelMeta });
-        }
 
         // 1b. Cancel any open subscription schedules for this customer so that
         //     prefetch calls (which fire on paywall load and on tier change) do not
         //     accumulate dangling schedules in Stripe. Only active/not_started
         //     schedules are cancelled; completed/released ones are left alone.
-        const openSchedules = await stripe.subscriptionSchedules.list({ customer: customer.id, limit: 10 });
-        for (const s of openSchedules.data) {
-            if (s.status === 'active' || s.status === 'not_started') {
-                await stripe.subscriptionSchedules.cancel(s.id);
-            }
+        //
+        //     A customer created on the line above cannot have any, so asking is a
+        //     round trip whose answer is known in advance — and it is first-time
+        //     buyers, the ones we have not converted yet, who wait for it.
+        //
+        //     The metadata refresh below is a returning customer keeping whatever
+        //     identifiers this session supplies, since the newest click is the one
+        //     that earned the purchase. It touches a different resource than the
+        //     schedule scan and neither gates the other, so they overlap.
+        if (returning) {
+            const [openSchedules] = await Promise.all([
+                stripe.subscriptionSchedules.list({ customer: customer.id, limit: 10 }),
+                hasPixelMeta
+                    ? stripe.customers.update(customer.id, { metadata: pixelMeta })
+                    : Promise.resolve(null),
+            ]);
+
+            // The cancels are independent of one another. Awaiting them in
+            // sequence charged N round trips for work that costs one, and a buyer
+            // who had compared a few tiers paid for every comparison.
+            await Promise.all(
+                openSchedules.data
+                    .filter((s) => s.status === 'active' || s.status === 'not_started')
+                    .map((s) => stripe.subscriptionSchedules.cancel(s.id))
+            );
         }
 
         // 2. Create a 2-phase Subscription Schedule:

--- a/funnel/package.json
+++ b/funnel/package.json
@@ -3,5 +3,8 @@
   "dependencies": {
     "@supabase/supabase-js": "^2",
     "stripe": "^14"
+  },
+  "scripts": {
+    "test": "node --experimental-test-module-mocks --no-warnings tests/create-checkout.test.mjs"
   }
 }

--- a/funnel/tests/create-checkout.test.mjs
+++ b/funnel/tests/create-checkout.test.mjs
@@ -1,0 +1,143 @@
+/* Issue #98 — create-checkout's avoidable round trips.
+   No Stripe key here, so the SDK is mocked and the call sequence itself is
+   what gets asserted: what is called, in what order, and what overlaps. */
+import { mock } from 'node:test';
+
+const LAG = 40;                 // stand-in for a Stripe round trip
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let calls;
+function rec(name, ret) {
+  return async (...args) => {
+    const at = calls.length;
+    calls.push({ name, args, start: Date.now(), end: null });
+    await wait(LAG);
+    calls[at].end = Date.now();
+    return typeof ret === 'function' ? ret(...args) : ret;
+  };
+}
+
+function makeStripe({ customerExists, schedules }) {
+  return {
+    customers: {
+      list:   rec('customers.list',   () => ({ data: customerExists ? [{ id: 'cus_1' }] : [] })),
+      create: rec('customers.create', () => ({ id: 'cus_new' })),
+      update: rec('customers.update', () => ({})),
+    },
+    subscriptionSchedules: {
+      list:   rec('schedules.list',   () => ({ data: schedules })),
+      cancel: rec('schedules.cancel', () => ({})),
+      create: rec('schedules.create', () => ({
+        id: 'sched_1',
+        subscription: { id: 'sub_1', latest_invoice: { id: 'in_1' } },
+      })),
+    },
+    invoices: {
+      finalizeInvoice: rec('invoices.finalize', () => ({
+        status: 'open',
+        payment_intent: { id: 'pi_1', client_secret: 'cs_test_1' },
+      })),
+    },
+    paymentIntents: { update: rec('pi.update', () => ({})) },
+  };
+}
+
+let stripeCfg = { customerExists: false, schedules: [] };
+mock.module('stripe', {
+  defaultExport: class { constructor() { return makeStripe(stripeCfg); } },
+});
+
+Object.assign(process.env, {
+  STRIPE_SECRET_KEY: 'sk_test', STRIPE_PRICE_INTRO_1MONTH: 'price_i',
+  STRIPE_PRICE_REGULAR_MONTHLY: 'price_r',
+});
+
+const { default: handler } = await import('../api/create-checkout.js');
+
+function res() {
+  const o = { code: null, body: null, headers: {} };
+  o.setHeader = (k, v) => { o.headers[k] = v; };
+  o.status = (c) => { o.code = c; return o; };
+  o.json = (b) => { o.body = b; return o; };
+  o.end = () => o;
+  return o;
+}
+
+async function run(cfg, body) {
+  stripeCfg = cfg;
+  calls = [];
+  const r = res();
+  await handler({ method: 'POST', headers: {}, body }, r);
+  return r;
+}
+
+let bad = 0;
+const ok = (c, m) => { console.log((c ? '  ✓ ' : '  ✗ ') + m); if (!c) bad++; };
+const names = () => calls.map((c) => c.name);
+const overlap = (a, b) => {
+  const x = calls.find((c) => c.name === a), y = calls.find((c) => c.name === b);
+  return x && y && x.start < y.end && y.start < x.end;
+};
+
+const PAYLOAD = { tierId: '1_month', email: 'test@testtest1.com', currency: 'eur' };
+const OPEN = [
+  { id: 'ss_1', status: 'active' },
+  { id: 'ss_2', status: 'not_started' },
+  { id: 'ss_3', status: 'active' },
+  { id: 'ss_4', status: 'released' },   // must be left alone
+];
+
+console.log('\n[a first-time buyer is not billed a round trip for an answer we know]');
+{
+  const r = await run({ customerExists: false, schedules: [] }, { ...PAYLOAD, fbp: 'fb.1.2.3' });
+  ok(!names().includes('schedules.list'),
+    `no schedule scan for a customer created one line earlier (saw: ${names().join(' → ')})`);
+  ok(!names().includes('customers.update'),
+    'no metadata update — create already carried it');
+  ok(r.code === 200 && r.body.clientSecret === 'cs_test_1', 'still returns a usable clientSecret');
+}
+
+console.log('\n[a returning buyer still gets their stale schedules cancelled]');
+{
+  await run({ customerExists: true, schedules: OPEN }, { ...PAYLOAD, fbp: 'fb.1.2.3' });
+  const cancelled = calls.filter((c) => c.name === 'schedules.cancel').map((c) => c.args[0]);
+  ok(cancelled.length === 3, `three open schedules cancelled (got ${cancelled.length})`);
+  ok(!cancelled.includes('ss_4'), 'a released schedule is left alone');
+  ok(names().indexOf('schedules.cancel') < names().indexOf('schedules.create'),
+    'cancels finish before the new schedule opens');
+}
+
+console.log('\n[independent work overlaps instead of queueing]');
+{
+  await run({ customerExists: true, schedules: OPEN }, { ...PAYLOAD, fbp: 'fb.1.2.3' });
+  ok(overlap('customers.update', 'schedules.list'),
+    'the metadata refresh runs alongside the schedule scan, not after it');
+
+  const c = calls.filter((x) => x.name === 'schedules.cancel');
+  const span = Math.max(...c.map((x) => x.end)) - Math.min(...c.map((x) => x.start));
+  ok(span < LAG * 2, `three cancels cost one round trip, not three (span ${span}ms, one trip ${LAG}ms)`);
+}
+
+console.log('\n[the shape of the response is untouched]');
+{
+  const r = await run({ customerExists: true, schedules: [] }, PAYLOAD);
+  const b = r.body;
+  ok(b.customerId === 'cus_1' && b.subscriptionId === 'sub_1' && b.scheduleId === 'sched_1'
+     && b.planLabel === '1-Month Plan' && b.currency === 'eur',
+     'customerId, subscriptionId, scheduleId, planLabel and currency all still returned');
+  ok(names().includes('pi.update'),
+    'setup_future_usage is still applied — the upsell depends on the saved card');
+}
+
+console.log('\n[the guards in front of it all still hold]');
+{
+  const r1 = await run({ customerExists: false, schedules: [] }, { tierId: '1_month' });
+  ok(r1.code === 400, 'a missing email is rejected before Stripe is touched');
+  const r2 = await run({ customerExists: false, schedules: [] }, { ...PAYLOAD, tierId: 'nope' });
+  ok(r2.code === 400, 'an unknown plan is rejected');
+  const r3 = await run({ customerExists: false, schedules: [] }, { ...PAYLOAD, currency: 'zzz' });
+  ok(r3.body.currency === 'eur', 'an unsupported currency still falls back to eur');
+}
+
+console.log(bad === 0 ? '\nPASS' : `\nFAIL (${bad})`);
+process.exit(bad === 0 ? 0 : 1);

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -256,6 +256,28 @@ fi
 echo ""
 
 # ---------------------------------------------------------------------------
+# 6. create-checkout call sequence
+#
+# There is no Stripe key in most environments, so the handler's Stripe calls
+# are asserted against a mocked SDK instead: what is called, in what order,
+# and what overlaps. Catches a re-serialised cancel loop or a schedule scan
+# creeping back in front of first-time buyers (Issue #98).
+# ---------------------------------------------------------------------------
+echo "── 6. create-checkout Call Sequence ────────"
+
+UNIT_DIR="$(dirname "$0")/../funnel"
+if [ ! -d "$UNIT_DIR/node_modules" ]; then
+  info "funnel/node_modules missing — run 'npm install' in funnel/ to enable this check"
+elif (cd "$UNIT_DIR" && npm test --silent >/tmp/smoke-unit.log 2>&1); then
+  pass "create-checkout issues the expected Stripe calls, concurrently where they are independent"
+else
+  fail_critical "create-checkout call-sequence test failed — see /tmp/smoke-unit.log"
+  tail -20 /tmp/smoke-unit.log
+fi
+
+echo ""
+
+# ---------------------------------------------------------------------------
 # SUMMARY
 # ---------------------------------------------------------------------------
 echo "============================================"


### PR DESCRIPTION
Measured against production:

```
brand-new customer:   3.54s  3.21s  2.75s
returning customer:   2.78s  3.40s  3.69s  3.63s
```

A first-time buyer has no remembered address, so `Checkout.prefetch()` cannot warm anything for them — they type their email and watch "Loading secure payment form…" for the whole of it. The three seconds land on exactly the people we have not converted yet.

Three of those round trips were avoidable:

- **A customer created one line earlier cannot have subscription schedules.** Scanning for them asks Stripe a question whose answer is already known. Now skipped entirely for new customers.
- **The cancel loop awaited each cancellation before starting the next.** The cancels are independent; N schedules cost N round trips where they cost one. A buyer who had compared a few tiers paid for every comparison.
- **The metadata refresh and the schedule scan touch different resources** and neither gates the other, so they overlap rather than queue.

Expected saving ~0.4–0.6s of ~3.2s. Steps 5–7 (`schedules.create` → `finalizeInvoice` → `paymentIntents.update`) are strictly sequential by construction and are the ~2.7s floor the measurements show.

**Deliberately left alone:** `paymentIntents.update({ setup_future_usage })`. Folding it elsewhere risks both subscription renewals and the off-session upsell charge, and neither can be verified without a live Stripe key.

### Verification

No Stripe key here, so the handler is pinned against a mocked SDK — `funnel/tests/create-checkout.test.mjs` asserts the calls made, their order, and which of them overlap. 13 assertions:

- No schedule scan and no metadata update for a new customer; still returns a usable `clientSecret`
- A returning buyer's three open schedules are still cancelled, a `released` one is still left alone, and the cancels still finish before the new schedule opens
- The metadata refresh overlaps the scan; three cancels span one round trip rather than three
- `customerId` / `subscriptionId` / `scheduleId` / `planLabel` / `currency` all still returned, and `setup_future_usage` is still applied
- Missing email → 400, unknown plan → 400, unsupported currency → falls back to `eur`

**3 of these fail against the previous handler** (verified by stashing): the schedule scan, the overlap, and the cancel span (123ms vs 41ms).

Wired into `scripts/smoke-test.sh` as check 6, which skips cleanly with an `info` line when `funnel/node_modules` is absent. Local run: check 6 green; checks 3 and 4 still fail on the pre-existing missing `funnel/.env.local`.

Closes #98.
